### PR TITLE
refactor: strategy pattern and SOLID improvements

### DIFF
--- a/src/command-executor.ts
+++ b/src/command-executor.ts
@@ -1,0 +1,35 @@
+import { execSync } from "node:child_process";
+
+/**
+ * Interface for executing shell commands.
+ * Enables dependency injection for testing and alternative implementations.
+ */
+export interface CommandExecutor {
+  /**
+   * Execute a shell command and return the output.
+   * @param command The command to execute
+   * @param cwd The working directory for the command
+   * @returns The trimmed stdout output
+   * @throws Error if the command fails
+   */
+  exec(command: string, cwd: string): string;
+}
+
+/**
+ * Default implementation that uses Node.js child_process.execSync.
+ * Note: Commands are escaped using escapeShellArg before being passed here.
+ */
+export class ShellCommandExecutor implements CommandExecutor {
+  exec(command: string, cwd: string): string {
+    return execSync(command, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  }
+}
+
+/**
+ * Default executor instance for production use.
+ */
+export const defaultExecutor: CommandExecutor = new ShellCommandExecutor();

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -77,6 +77,46 @@ repos:
       );
     });
 
+    test("throws when fileName contains path traversal", () => {
+      const path = createTestConfig(`
+fileName: ../escape.json
+repos:
+  - git: git@github.com:org/repo.git
+    content:
+      key: value
+`);
+      assert.throws(
+        () => loadConfig(path),
+        /Invalid fileName: must be a relative path without '\.\.' components/,
+      );
+    });
+
+    test("throws when fileName is absolute path", () => {
+      const path = createTestConfig(`
+fileName: /etc/passwd
+repos:
+  - git: git@github.com:org/repo.git
+    content:
+      key: value
+`);
+      assert.throws(
+        () => loadConfig(path),
+        /Invalid fileName: must be a relative path without '\.\.' components/,
+      );
+    });
+
+    test("allows nested relative paths without traversal", () => {
+      const path = createTestConfig(`
+fileName: config/settings.json
+repos:
+  - git: git@github.com:org/repo.git
+    content:
+      key: value
+`);
+      const config = loadConfig(path);
+      assert.equal(config.fileName, "config/settings.json");
+    });
+
     test("allows missing repo.content when root content exists", () => {
       const path = createTestConfig(`
 fileName: config.json

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import { parse, stringify } from "yaml";
 import {
   deepMerge,
@@ -46,6 +47,13 @@ export interface Config {
 function validateRawConfig(config: RawConfig): void {
   if (!config.fileName) {
     throw new Error("Config missing required field: fileName");
+  }
+
+  // Validate fileName doesn't allow path traversal
+  if (config.fileName.includes("..") || isAbsolute(config.fileName)) {
+    throw new Error(
+      `Invalid fileName: must be a relative path without '..' components`,
+    );
   }
 
   if (!config.repos || !Array.isArray(config.repos)) {

--- a/src/pr-creator.ts
+++ b/src/pr-creator.ts
@@ -80,6 +80,7 @@ export async function createPR(options: PROptions): Promise<PRResult> {
   // Get the appropriate strategy and execute
   const strategy = getPRStrategy(repoInfo);
   return strategy.execute({
+    repoInfo,
     title,
     body,
     branchName,

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -9,7 +9,9 @@ export { GitHubPRStrategy } from "./github-pr-strategy.js";
 export { AzurePRStrategy } from "./azure-pr-strategy.js";
 
 /**
- * Factory function to get the appropriate PR strategy for a repository
+ * Factory function to get the appropriate PR strategy for a repository.
+ * Note: repoInfo is passed via PRStrategyOptions.execute() rather than constructor
+ * to ensure LSP compliance (all strategies have identical constructors).
  */
 export function getPRStrategy(repoInfo: RepoInfo): PRStrategy {
   if (isGitHubRepo(repoInfo)) {
@@ -17,7 +19,7 @@ export function getPRStrategy(repoInfo: RepoInfo): PRStrategy {
   }
 
   if (isAzureDevOpsRepo(repoInfo)) {
-    return new AzurePRStrategy(repoInfo);
+    return new AzurePRStrategy();
   }
 
   // Type exhaustiveness check - should never reach here

--- a/src/strategies/pr-strategy.ts
+++ b/src/strategies/pr-strategy.ts
@@ -1,6 +1,8 @@
 import { PRResult } from "../pr-creator.js";
+import { RepoInfo } from "../repo-detector.js";
 
 export interface PRStrategyOptions {
+  repoInfo: RepoInfo;
   title: string;
   body: string;
   branchName: string;


### PR DESCRIPTION
## Summary
- Implement strategy pattern with discriminated unions for PR creation (GitHub vs Azure)
- Add integration tests to PR workflow
- Apply SOLID principle improvements:
  - Fix silent error swallowing in `createBranch` (bug fix)
  - Add path traversal validation for `fileName` (security fix)
  - Unify strategy constructors for LSP compliance
  - Extract `CommandExecutor` interface for DIP compliance

## Changes
- **Strategy pattern**: `GitHubPRStrategy` and `AzurePRStrategy` with common `PRStrategy` interface
- **Type safety**: Discriminated unions for `RepoInfo` types
- **Security**: Path traversal protection in config validation and file operations
- **Testability**: `CommandExecutor` interface enables mocking shell commands
- **CI**: Integration tests now run on PRs

## Test plan
- [x] All 191 unit tests pass
- [ ] Integration tests pass (requires `gh` auth)
- [ ] Manual test with real repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)