### PR TITLE
feat: add transient error handling with p-retry and improve test coverage

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Prevent concurrent runs - they race on the shared test repo branch
+concurrency:
+  group: integration-test
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ json-config-sync --config ./config.yaml
 - **GitHub & Azure DevOps** - Works with both platforms
 - **Dry-Run Mode** - Preview changes without creating PRs
 - **Error Resilience** - Continues processing if individual repos fail
+- **Automatic Retries** - Retries transient network errors with exponential backoff
 
 ## Installation
 
@@ -126,11 +127,12 @@ json-config-sync --config ./config.yaml --work-dir ./my-temp
 
 ### Options
 
-| Option       | Alias | Description                                        | Required |
-| ------------ | ----- | -------------------------------------------------- | -------- |
-| `--config`   | `-c`  | Path to YAML config file                           | Yes      |
-| `--dry-run`  | `-d`  | Show what would be done without making changes     | No       |
-| `--work-dir` | `-w`  | Temporary directory for cloning (default: `./tmp`) | No       |
+| Option       | Alias | Description                                           | Required |
+| ------------ | ----- | ----------------------------------------------------- | -------- |
+| `--config`   | `-c`  | Path to YAML config file                              | Yes      |
+| `--dry-run`  | `-d`  | Show what would be done without making changes        | No       |
+| `--work-dir` | `-w`  | Temporary directory for cloning (default: `./tmp`)    | No       |
+| `--retries`  | `-r`  | Number of retries for network operations (default: 3) | No       |
 
 ## Configuration Format
 
@@ -504,6 +506,20 @@ If cloning fails behind a corporate proxy:
 git config --global http.proxy http://proxy.example.com:8080
 git config --global https.proxy http://proxy.example.com:8080
 ```
+
+### Transient Network Errors
+
+The tool automatically retries transient errors (timeouts, connection resets, rate limits) with exponential backoff. By default, it retries 3 times before failing.
+
+```bash
+# Increase retries for unreliable networks
+json-config-sync --config ./config.yaml --retries 5
+
+# Disable retries
+json-config-sync --config ./config.yaml --retries 0
+```
+
+Permanent errors (authentication failures, permission denied, repository not found) are not retried.
 
 ## IDE Integration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^14.0.2",
+        "p-retry": "^7.1.1",
         "yaml": "^2.4.5"
       },
       "bin": {
@@ -566,6 +567,33 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
+      "integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
-    "test": "node --import tsx --test src/config.test.ts src/merge.test.ts src/env.test.ts src/repo-detector.test.ts src/pr-creator.test.ts src/git-ops.test.ts src/logger.test.ts src/workspace-utils.test.ts src/strategies/pr-strategy.test.ts src/repository-processor.test.ts",
+    "test": "node --import tsx --test src/config.test.ts src/merge.test.ts src/env.test.ts src/repo-detector.test.ts src/pr-creator.test.ts src/git-ops.test.ts src/logger.test.ts src/workspace-utils.test.ts src/strategies/pr-strategy.test.ts src/strategies/github-pr-strategy.test.ts src/strategies/azure-pr-strategy.test.ts src/repository-processor.test.ts src/retry-utils.test.ts src/index.test.ts",
     "test:integration": "npm run build && node --import tsx --test src/integration.test.ts",
     "prepublishOnly": "npm run build"
   },
@@ -46,6 +46,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^14.0.2",
+    "p-retry": "^7.1.1",
     "yaml": "^2.4.5"
   },
   "devDependencies": {

--- a/src/command-executor.ts
+++ b/src/command-executor.ts
@@ -9,10 +9,10 @@ export interface CommandExecutor {
    * Execute a shell command and return the output.
    * @param command The command to execute
    * @param cwd The working directory for the command
-   * @returns The trimmed stdout output
+   * @returns Promise resolving to the trimmed stdout output
    * @throws Error if the command fails
    */
-  exec(command: string, cwd: string): string;
+  exec(command: string, cwd: string): Promise<string>;
 }
 
 /**
@@ -20,7 +20,7 @@ export interface CommandExecutor {
  * Note: Commands are escaped using escapeShellArg before being passed here.
  */
 export class ShellCommandExecutor implements CommandExecutor {
-  exec(command: string, cwd: string): string {
+  async exec(command: string, cwd: string): Promise<string> {
     return execSync(command, {
       cwd,
       encoding: "utf-8",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,297 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { execFileSync } from "node:child_process";
+import { writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const testDir = join(process.cwd(), "test-cli-tmp");
+const testConfigPath = join(testDir, "test-config.yaml");
+
+// Helper to run CLI and capture output
+function runCLI(
+  args: string[],
+  options?: { timeout?: number },
+): { stdout: string; stderr: string; success: boolean } {
+  try {
+    const stdout = execFileSync(
+      "node",
+      ["--import", "tsx", "src/index.ts", ...args],
+      {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: options?.timeout ?? 10000,
+      },
+    );
+    return { stdout, stderr: "", success: true };
+  } catch (error) {
+    const err = error as {
+      stdout?: string;
+      stderr?: string;
+      status?: number;
+    };
+    return {
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+      success: false,
+    };
+  }
+}
+
+describe("CLI", () => {
+  beforeEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("argument parsing", () => {
+    test("shows help with --help", () => {
+      const result = runCLI(["--help"]);
+      assert.ok(result.stdout.includes("json-config-sync"));
+      assert.ok(result.stdout.includes("-c, --config"));
+      assert.ok(result.stdout.includes("-d, --dry-run"));
+      assert.ok(result.stdout.includes("-w, --work-dir"));
+      assert.ok(result.stdout.includes("-r, --retries"));
+    });
+
+    test("requires --config option", () => {
+      const result = runCLI([]);
+      assert.equal(result.success, false);
+      assert.ok(
+        result.stderr.includes("required") ||
+          result.stderr.includes("--config"),
+      );
+    });
+
+    test("fails with non-existent config file", () => {
+      const result = runCLI(["-c", "/nonexistent/config.yaml"]);
+      assert.equal(result.success, false);
+      const output = result.stdout + result.stderr;
+      assert.ok(output.includes("Config file not found"));
+    });
+
+    test("accepts --dry-run flag", () => {
+      // Create a minimal valid config
+      writeFileSync(
+        testConfigPath,
+        `
+fileName: test.json
+repos:
+  - git: git@github.com:test/invalid-repo-for-test.git
+    content:
+      key: value
+`,
+      );
+
+      // Should fail on clone (invalid repo) but should show dry run message
+      const result = runCLI([
+        "-c",
+        testConfigPath,
+        "--dry-run",
+        "-w",
+        `${testDir}/work`,
+      ]);
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes("DRY RUN mode") || output.includes("Processing"),
+        "Should show dry run mode or start processing",
+      );
+    });
+
+    test("accepts --retries option with number", () => {
+      writeFileSync(
+        testConfigPath,
+        `
+fileName: test.json
+repos:
+  - git: git@github.com:test/invalid-repo-for-test.git
+    content:
+      key: value
+`,
+      );
+
+      // Should parse --retries without error
+      const result = runCLI([
+        "-c",
+        testConfigPath,
+        "--dry-run",
+        "--retries",
+        "5",
+        "-w",
+        `${testDir}/work`,
+      ]);
+      // If it gets past argument parsing, the flag worked
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes("Loading config") || output.includes("Processing"),
+      );
+    });
+
+    test("--retries 0 disables retry", () => {
+      writeFileSync(
+        testConfigPath,
+        `
+fileName: test.json
+repos:
+  - git: git@github.com:test/invalid-repo-for-test.git
+    content:
+      key: value
+`,
+      );
+
+      // Should parse --retries 0 without error
+      const result = runCLI([
+        "-c",
+        testConfigPath,
+        "--dry-run",
+        "--retries",
+        "0",
+        "-w",
+        `${testDir}/work`,
+      ]);
+      // If it gets past argument parsing, the flag worked
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes("Loading config") || output.includes("Processing"),
+      );
+    });
+  });
+
+  describe("config validation", () => {
+    test("fails with invalid YAML", () => {
+      writeFileSync(testConfigPath, "invalid: yaml: content: [");
+
+      const result = runCLI(["-c", testConfigPath, "--dry-run"]);
+      assert.equal(result.success, false);
+    });
+
+    test("fails with missing fileName", () => {
+      writeFileSync(
+        testConfigPath,
+        `
+repos:
+  - git: git@github.com:test/repo.git
+    content:
+      key: value
+`,
+      );
+
+      const result = runCLI(["-c", testConfigPath, "--dry-run"]);
+      assert.equal(result.success, false);
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes("fileName") || output.includes("required"),
+        "Should mention missing fileName",
+      );
+    });
+
+    test("fails with missing repos", () => {
+      writeFileSync(
+        testConfigPath,
+        `
+fileName: test.json
+content:
+  key: value
+`,
+      );
+
+      const result = runCLI(["-c", testConfigPath, "--dry-run"]);
+      assert.equal(result.success, false);
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes("repos") || output.includes("required"),
+        "Should mention missing repos",
+      );
+    });
+  });
+
+  describe("output formatting", () => {
+    test("displays repository count", () => {
+      writeFileSync(
+        testConfigPath,
+        `
+fileName: test.json
+repos:
+  - git: git@github.com:test/repo1.git
+    content:
+      key: value
+  - git: git@github.com:test/repo2.git
+    content:
+      key: value
+`,
+      );
+
+      const result = runCLI([
+        "-c",
+        testConfigPath,
+        "--dry-run",
+        "-w",
+        `${testDir}/work`,
+      ]);
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes("2 repositories") || output.includes("Found 2"),
+        "Should display repository count",
+      );
+    });
+
+    test("displays target file name", () => {
+      writeFileSync(
+        testConfigPath,
+        `
+fileName: my-config.json
+repos:
+  - git: git@github.com:test/repo.git
+    content:
+      key: value
+`,
+      );
+
+      const result = runCLI([
+        "-c",
+        testConfigPath,
+        "--dry-run",
+        "-w",
+        `${testDir}/work`,
+      ]);
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes("my-config.json"),
+        "Should display target file name",
+      );
+    });
+
+    test("displays branch name based on fileName", () => {
+      writeFileSync(
+        testConfigPath,
+        `
+fileName: my-config.json
+repos:
+  - git: git@github.com:test/repo.git
+    content:
+      key: value
+`,
+      );
+
+      const result = runCLI([
+        "-c",
+        testConfigPath,
+        "--dry-run",
+        "-w",
+        `${testDir}/work`,
+      ]);
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes("chore/sync-my-config"),
+        "Should display sanitized branch name",
+      );
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ interface CLIOptions {
   config: string;
   dryRun?: boolean;
   workDir?: string;
+  retries?: number;
 }
 
 program
@@ -23,6 +24,12 @@ program
   .requiredOption("-c, --config <path>", "Path to YAML config file")
   .option("-d, --dry-run", "Show what would be done without making changes")
   .option("-w, --work-dir <path>", "Temporary directory for cloning", "./tmp")
+  .option(
+    "-r, --retries <number>",
+    "Number of retries for network operations (0 to disable)",
+    (v) => parseInt(v, 10),
+    3,
+  )
   .parse();
 
 const options = program.opts<CLIOptions>();
@@ -76,6 +83,7 @@ async function main(): Promise<void> {
         branchName,
         workDir,
         dryRun: options.dryRun,
+        retries: options.retries,
       });
 
       if (result.skipped) {

--- a/src/pr-creator.ts
+++ b/src/pr-creator.ts
@@ -15,6 +15,8 @@ export interface PROptions {
   action: "create" | "update";
   workDir: string;
   dryRun?: boolean;
+  /** Number of retries for API operations (default: 3) */
+  retries?: number;
 }
 
 export interface PRResult {
@@ -65,6 +67,7 @@ export async function createPR(options: PROptions): Promise<PRResult> {
     action,
     workDir,
     dryRun,
+    retries,
   } = options;
 
   const title = `chore: sync ${fileName}`;
@@ -86,5 +89,6 @@ export async function createPR(options: PROptions): Promise<PRResult> {
     branchName,
     baseBranch,
     workDir,
+    retries,
   });
 }

--- a/src/retry-utils.test.ts
+++ b/src/retry-utils.test.ts
@@ -1,0 +1,294 @@
+import { test, describe } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  isPermanentError,
+  isTransientError,
+  withRetry,
+  promisify,
+} from "./retry-utils.js";
+
+describe("isPermanentError", () => {
+  test("returns true for permission denied", () => {
+    const error = new Error("Permission denied (publickey)");
+    assert.equal(isPermanentError(error), true);
+  });
+
+  test("returns true for authentication failed", () => {
+    const error = new Error("Authentication failed for repository");
+    assert.equal(isPermanentError(error), true);
+  });
+
+  test("returns true for bad credentials", () => {
+    const error = new Error("Bad credentials");
+    assert.equal(isPermanentError(error), true);
+  });
+
+  test("returns true for 401 status", () => {
+    const error = new Error("HTTP 401 Unauthorized");
+    assert.equal(isPermanentError(error), true);
+  });
+
+  test("returns true for 404 status", () => {
+    const error = new Error("HTTP 404 Not Found");
+    assert.equal(isPermanentError(error), true);
+  });
+
+  test("returns true for repository not found", () => {
+    const error = new Error("Repository not found");
+    assert.equal(isPermanentError(error), true);
+  });
+
+  test("returns true for not a git repository", () => {
+    const error = new Error("fatal: not a git repository");
+    assert.equal(isPermanentError(error), true);
+  });
+
+  test("returns true for non-fast-forward", () => {
+    const error = new Error("error: non-fast-forward updates were rejected");
+    assert.equal(isPermanentError(error), true);
+  });
+
+  test("returns false for timeout", () => {
+    const error = new Error("Connection timed out");
+    assert.equal(isPermanentError(error), false);
+  });
+
+  test("returns false for network error", () => {
+    const error = new Error("ECONNRESET");
+    assert.equal(isPermanentError(error), false);
+  });
+
+  test("checks stderr if present", () => {
+    const error = new Error("Command failed") as Error & { stderr: string };
+    error.stderr = "fatal: Authentication failed";
+    assert.equal(isPermanentError(error), true);
+  });
+});
+
+describe("isTransientError", () => {
+  test("returns true for timeout", () => {
+    const error = new Error("Connection timed out");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns true for ETIMEDOUT", () => {
+    const error = new Error("ETIMEDOUT");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns true for ECONNRESET", () => {
+    const error = new Error("ECONNRESET");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns true for ECONNREFUSED", () => {
+    const error = new Error("connect ECONNREFUSED 127.0.0.1:443");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns true for rate limit", () => {
+    const error = new Error("API rate limit exceeded");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns true for 429 status", () => {
+    const error = new Error("HTTP 429 Too Many Requests");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns true for 503 status", () => {
+    const error = new Error("HTTP 503 Service Unavailable");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns true for connection reset", () => {
+    const error = new Error("connection reset by peer");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns true for could not resolve host", () => {
+    const error = new Error("Could not resolve host: github.com");
+    assert.equal(isTransientError(error), true);
+  });
+
+  test("returns false for permanent error", () => {
+    const error = new Error("Permission denied");
+    assert.equal(isTransientError(error), false);
+  });
+
+  test("returns false for unknown error", () => {
+    const error = new Error("Some random error");
+    assert.equal(isTransientError(error), false);
+  });
+});
+
+describe("withRetry", () => {
+  test("returns result on first success", async () => {
+    let attempts = 0;
+    const result = await withRetry(async () => {
+      attempts++;
+      return "success";
+    });
+    assert.equal(result, "success");
+    assert.equal(attempts, 1);
+  });
+
+  test("retries on transient error and succeeds", async () => {
+    let attempts = 0;
+    const result = await withRetry(
+      async () => {
+        attempts++;
+        if (attempts < 3) {
+          throw new Error("Connection timed out");
+        }
+        return "success";
+      },
+      { retries: 3 },
+    );
+    assert.equal(result, "success");
+    assert.equal(attempts, 3);
+  });
+
+  test("stops immediately on permanent error", async () => {
+    let attempts = 0;
+    await assert.rejects(async () => {
+      await withRetry(
+        async () => {
+          attempts++;
+          throw new Error("Permission denied");
+        },
+        { retries: 3 },
+      );
+    }, /Permission denied/);
+    // Key assertion: only 1 attempt, no retries for permanent errors
+    assert.equal(attempts, 1);
+  });
+
+  test("throws last error after exhausting retries", async () => {
+    let attempts = 0;
+    await assert.rejects(async () => {
+      await withRetry(
+        async () => {
+          attempts++;
+          throw new Error("Connection timed out");
+        },
+        { retries: 2 },
+      );
+    }, /Connection timed out/);
+    // 1 initial attempt + 2 retries = 3 total
+    assert.equal(attempts, 3);
+  });
+
+  test("calls onRetry callback on failed attempts", async () => {
+    const retryAttempts: number[] = [];
+    await assert.rejects(async () => {
+      await withRetry(
+        async () => {
+          throw new Error("Connection timed out");
+        },
+        {
+          retries: 2,
+          onRetry: (_error, attempt) => {
+            retryAttempts.push(attempt);
+          },
+        },
+      );
+    });
+    // onRetry is called on attempts 1 and 2 (before the final failure)
+    assert.deepEqual(retryAttempts, [1, 2]);
+  });
+
+  test("uses default of 3 retries when not specified", async () => {
+    let attempts = 0;
+    await assert.rejects(async () => {
+      await withRetry(async () => {
+        attempts++;
+        throw new Error("Connection timed out");
+      });
+    });
+    // 1 initial + 3 retries = 4 total
+    assert.equal(attempts, 4);
+  });
+
+  test("does not retry when retries is 0", async () => {
+    let attempts = 0;
+    await assert.rejects(async () => {
+      await withRetry(
+        async () => {
+          attempts++;
+          throw new Error("Connection timed out");
+        },
+        { retries: 0 },
+      );
+    });
+    assert.equal(attempts, 1);
+  });
+});
+
+describe("promisify", () => {
+  test("resolves with sync return value", async () => {
+    const result = await promisify(() => "hello");
+    assert.equal(result, "hello");
+  });
+
+  test("rejects with sync thrown error", async () => {
+    await assert.rejects(async () => {
+      await promisify(() => {
+        throw new Error("sync error");
+      });
+    }, /sync error/);
+  });
+
+  test("preserves error properties", async () => {
+    const customError = new Error("custom") as Error & { code: string };
+    customError.code = "CUSTOM_CODE";
+
+    await assert.rejects(
+      async () => {
+        await promisify(() => {
+          throw customError;
+        });
+      },
+      (error: Error & { code?: string }) => {
+        assert.equal(error.message, "custom");
+        assert.equal(error.code, "CUSTOM_CODE");
+        return true;
+      },
+    );
+  });
+});
+
+describe("integration: withRetry + promisify", () => {
+  test("retries sync function wrapped in promisify", async () => {
+    let attempts = 0;
+    const result = await withRetry(
+      () =>
+        promisify(() => {
+          attempts++;
+          if (attempts < 2) {
+            throw new Error("Connection timed out");
+          }
+          return "success";
+        }),
+      { retries: 3 },
+    );
+    assert.equal(result, "success");
+    assert.equal(attempts, 2);
+  });
+
+  test("stops retrying permanent errors from sync function", async () => {
+    let attempts = 0;
+    await assert.rejects(async () => {
+      await withRetry(
+        () =>
+          promisify(() => {
+            attempts++;
+            throw new Error("Permission denied");
+          }),
+        { retries: 3 },
+      );
+    }, /Permission denied/);
+    // Key assertion: only 1 attempt, no retries for permanent errors
+    assert.equal(attempts, 1);
+  });
+});

--- a/src/retry-utils.ts
+++ b/src/retry-utils.ts
@@ -1,0 +1,163 @@
+import pRetry, { AbortError } from "p-retry";
+import { logger } from "./logger.js";
+
+/**
+ * Patterns indicating permanent errors that should NOT be retried.
+ * These typically indicate configuration issues, auth failures, or invalid resources.
+ */
+const PERMANENT_ERROR_PATTERNS = [
+  /permission\s*denied/i,
+  /authentication\s*failed/i,
+  /bad\s*credentials/i,
+  /invalid\s*(token|credentials)/i,
+  /unauthorized/i,
+  /401\b/,
+  /403\b/,
+  /404\b/,
+  /not\s*found/i,
+  /does\s*not\s*exist/i,
+  /repository\s*not\s*found/i,
+  /no\s*such\s*(file|directory|remote|ref)/i,
+  /invalid\s*remote/i,
+  /not\s*a\s*git\s*repository/i,
+  /non-fast-forward/i,
+  /remote\s*rejected/i,
+];
+
+/**
+ * Patterns indicating transient errors that SHOULD be retried.
+ * These typically indicate temporary network or service issues.
+ */
+const TRANSIENT_ERROR_PATTERNS = [
+  /timed?\s*out/i,
+  /ETIMEDOUT/,
+  /ECONNRESET/,
+  /ECONNREFUSED/,
+  /ENOTFOUND/,
+  /connection\s*(reset|refused|closed)/i,
+  /network\s*(error|unreachable)/i,
+  /rate\s*limit/i,
+  /too\s*many\s*requests/i,
+  /429\b/,
+  /500\b/,
+  /502\b/,
+  /503\b/,
+  /504\b/,
+  /service\s*unavailable/i,
+  /temporarily\s*unavailable/i,
+  /internal\s*server\s*error/i,
+  /temporary\s*(failure|error)/i,
+  /try\s*again/i,
+  /ssh_exchange_identification/i,
+  /could\s*not\s*resolve\s*host/i,
+  /unable\s*to\s*access/i,
+];
+
+export interface RetryOptions {
+  /** Maximum number of retries (default: 3) */
+  retries?: number;
+  /** Callback when a retry attempt fails */
+  onRetry?: (error: Error, attempt: number) => void;
+}
+
+/**
+ * Classifies an error as permanent (should not retry) or transient (should retry).
+ * @param error The error to classify
+ * @returns true if the error is permanent, false if it might be transient
+ */
+export function isPermanentError(error: Error): boolean {
+  const message = error.message;
+  const stderr =
+    (error as { stderr?: string | Buffer }).stderr?.toString() ?? "";
+  const combined = `${message} ${stderr}`;
+
+  // Check permanent patterns first - these always stop retries
+  for (const pattern of PERMANENT_ERROR_PATTERNS) {
+    if (pattern.test(combined)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Checks if an error matches known transient patterns.
+ * @param error The error to check
+ * @returns true if the error appears to be transient
+ */
+export function isTransientError(error: Error): boolean {
+  const message = error.message;
+  const stderr =
+    (error as { stderr?: string | Buffer }).stderr?.toString() ?? "";
+  const combined = `${message} ${stderr}`;
+
+  for (const pattern of TRANSIENT_ERROR_PATTERNS) {
+    if (pattern.test(combined)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Wraps an async operation with retry logic using exponential backoff.
+ * Automatically classifies errors and aborts retries for permanent failures.
+ *
+ * @param fn The async function to run with retry
+ * @param options Retry configuration options
+ * @returns The result of the function if successful
+ * @throws AbortError for permanent failures, or the last error after all retries exhausted
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options?: RetryOptions,
+): Promise<T> {
+  const retries = options?.retries ?? 3;
+
+  return pRetry(
+    async () => {
+      try {
+        return await fn();
+      } catch (error) {
+        if (error instanceof Error && isPermanentError(error)) {
+          // Wrap in AbortError to stop retrying immediately
+          throw new AbortError(error.message);
+        }
+        throw error;
+      }
+    },
+    {
+      retries,
+      onFailedAttempt: (context) => {
+        // Only log if this isn't the last attempt
+        if (context.retriesLeft > 0) {
+          const msg = context.error.message || "Unknown error";
+          logger.info(
+            `Attempt ${context.attemptNumber}/${retries + 1} failed: ${msg}. Retrying...`,
+          );
+          options?.onRetry?.(context.error, context.attemptNumber);
+        }
+      },
+    },
+  );
+}
+
+/**
+ * Wraps a synchronous operation in a Promise for use with retry logic.
+ * @param fn The sync function to run
+ * @returns A Promise that resolves/rejects with the sync result
+ */
+export function promisify<T>(fn: () => T): Promise<T> {
+  return new Promise((resolve, reject) => {
+    try {
+      resolve(fn());
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+// Re-export AbortError for use in custom error handling
+export { AbortError } from "p-retry";

--- a/src/strategies/azure-pr-strategy.test.ts
+++ b/src/strategies/azure-pr-strategy.test.ts
@@ -1,0 +1,298 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { AzurePRStrategy } from "./azure-pr-strategy.js";
+import { AzureDevOpsRepoInfo } from "../repo-detector.js";
+import { PRStrategyOptions } from "./pr-strategy.js";
+import { CommandExecutor } from "../command-executor.js";
+
+const testDir = join(process.cwd(), "test-azure-strategy-tmp");
+
+// Mock executor factory - creates CommandExecutor for testing
+function createMockExecutor(): CommandExecutor & {
+  calls: Array<{ command: string; cwd: string }>;
+  responses: Map<string, string | Error>;
+} {
+  const state = {
+    calls: [] as Array<{ command: string; cwd: string }>,
+    responses: new Map<string, string | Error>(),
+  };
+
+  const executor: CommandExecutor = {
+    exec: async (command: string, cwd: string): Promise<string> => {
+      state.calls.push({ command, cwd });
+
+      for (const [pattern, response] of state.responses) {
+        if (command.includes(pattern)) {
+          if (response instanceof Error) throw response;
+          return response;
+        }
+      }
+      return "";
+    },
+  };
+
+  return Object.assign(executor, state);
+}
+
+describe("AzurePRStrategy with mock executor", () => {
+  const azureRepoInfo: AzureDevOpsRepoInfo = {
+    type: "azure-devops",
+    gitUrl: "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo",
+    owner: "myorg",
+    repo: "myrepo",
+    organization: "myorg",
+    project: "myproject",
+  };
+
+  let mockExecutor: ReturnType<typeof createMockExecutor>;
+
+  beforeEach(() => {
+    mockExecutor = createMockExecutor();
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("checkExistingPR", () => {
+    test("returns PR URL when PR exists", async () => {
+      mockExecutor.responses.set("az repos pr list", "456");
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.checkExistingPR(options);
+
+      assert.ok(result?.includes("dev.azure.com"));
+      assert.ok(result?.includes("pullrequest/456"));
+      assert.equal(mockExecutor.calls.length, 1);
+      assert.ok(mockExecutor.calls[0].command.includes("az repos pr list"));
+    });
+
+    test("returns null when no PR exists", async () => {
+      mockExecutor.responses.set("az repos pr list", "");
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.checkExistingPR(options);
+
+      assert.equal(result, null);
+    });
+
+    test("throws on permanent error (auth failure)", async () => {
+      const authError = new Error("401 Unauthorized");
+      mockExecutor.responses.set("az repos pr list", authError);
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      await assert.rejects(() => strategy.checkExistingPR(options), /401/);
+    });
+
+    test("returns null on transient error", async () => {
+      const networkError = new Error("Connection timed out");
+      mockExecutor.responses.set("az repos pr list", networkError);
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.checkExistingPR(options);
+      assert.equal(result, null);
+    });
+  });
+
+  describe("create", () => {
+    test("creates PR and returns URL", async () => {
+      mockExecutor.responses.set("az repos pr create", "789");
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.create(options);
+
+      assert.equal(result.success, true);
+      assert.ok(result.url?.includes("dev.azure.com"));
+      assert.ok(result.url?.includes("pullrequest/789"));
+      assert.equal(mockExecutor.calls.length, 1);
+      assert.ok(mockExecutor.calls[0].command.includes("az repos pr create"));
+    });
+
+    test("cleans up description file after success", async () => {
+      mockExecutor.responses.set("az repos pr create", "123");
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      await strategy.create(options);
+
+      const descFile = join(testDir, ".pr-description.md");
+      assert.equal(existsSync(descFile), false);
+    });
+
+    test("cleans up description file after error", async () => {
+      mockExecutor.responses.set("az repos pr create", new Error("Failed"));
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      await assert.rejects(() => strategy.create(options));
+
+      const descFile = join(testDir, ".pr-description.md");
+      assert.equal(existsSync(descFile), false);
+    });
+  });
+
+  describe("execute (full workflow)", () => {
+    test("returns existing PR if found", async () => {
+      mockExecutor.responses.set("az repos pr list", "existing-pr-id");
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.execute(options);
+
+      assert.equal(result.success, true);
+      assert.ok(result.message.includes("already exists"));
+      assert.equal(mockExecutor.calls.length, 1);
+    });
+
+    test("creates new PR if none exists", async () => {
+      mockExecutor.responses.set("az repos pr list", "");
+      mockExecutor.responses.set("az repos pr create", "new-pr-id");
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.execute(options);
+
+      assert.equal(result.success, true);
+      assert.equal(mockExecutor.calls.length, 2);
+    });
+
+    test("returns failure on error", async () => {
+      mockExecutor.responses.set("az repos pr list", "");
+      mockExecutor.responses.set("az repos pr create", new Error("Failed"));
+
+      const strategy = new AzurePRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: azureRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.execute(options);
+
+      assert.equal(result.success, false);
+      assert.ok(result.message.includes("Failed to create PR"));
+    });
+  });
+});
+
+describe("AzurePRStrategy URL building", () => {
+  test("builds correct PR URL with special characters", () => {
+    const org = "my-org";
+    const project = "my project"; // Has space
+    const repo = "my-repo";
+    const prId = "123";
+
+    // Expected URL with encoded values
+    const expectedUrl = `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repo)}/pullrequest/${prId}`;
+
+    assert.equal(
+      expectedUrl,
+      "https://dev.azure.com/my-org/my%20project/_git/my-repo/pullrequest/123",
+    );
+  });
+
+  test("builds correct org URL", () => {
+    const org = "test-organization";
+    const expectedOrgUrl = `https://dev.azure.com/${encodeURIComponent(org)}`;
+
+    assert.equal(expectedOrgUrl, "https://dev.azure.com/test-organization");
+  });
+});

--- a/src/strategies/azure-pr-strategy.ts
+++ b/src/strategies/azure-pr-strategy.ts
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import { existsSync, writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { escapeShellArg } from "../shell-utils.js";
@@ -6,10 +5,12 @@ import { AzureDevOpsRepoInfo, isAzureDevOpsRepo } from "../repo-detector.js";
 import { PRResult } from "../pr-creator.js";
 import { BasePRStrategy, PRStrategyOptions } from "./pr-strategy.js";
 import { logger } from "../logger.js";
+import { withRetry, isPermanentError } from "../retry-utils.js";
+import { CommandExecutor } from "../command-executor.js";
 
 export class AzurePRStrategy extends BasePRStrategy {
-  constructor() {
-    super();
+  constructor(executor?: CommandExecutor) {
+    super(executor);
     this.bodyFilePath = ".pr-description.md";
   }
 
@@ -22,7 +23,7 @@ export class AzurePRStrategy extends BasePRStrategy {
   }
 
   async checkExistingPR(options: PRStrategyOptions): Promise<string | null> {
-    const { repoInfo, branchName, baseBranch, workDir } = options;
+    const { repoInfo, branchName, baseBranch, workDir, retries = 3 } = options;
 
     if (!isAzureDevOpsRepo(repoInfo)) {
       throw new Error("Expected Azure DevOps repository");
@@ -30,16 +31,20 @@ export class AzurePRStrategy extends BasePRStrategy {
     const azureRepoInfo: AzureDevOpsRepoInfo = repoInfo;
     const orgUrl = this.getOrgUrl(azureRepoInfo);
 
+    const command = `az repos pr list --repository ${escapeShellArg(azureRepoInfo.repo)} --source-branch ${escapeShellArg(branchName)} --target-branch ${escapeShellArg(baseBranch)} --org ${escapeShellArg(orgUrl)} --project ${escapeShellArg(azureRepoInfo.project)} --query "[0].pullRequestId" -o tsv`;
+
     try {
-      const existingPRId = execSync(
-        `az repos pr list --repository ${escapeShellArg(azureRepoInfo.repo)} --source-branch ${escapeShellArg(branchName)} --target-branch ${escapeShellArg(baseBranch)} --org ${escapeShellArg(orgUrl)} --project ${escapeShellArg(azureRepoInfo.project)} --query "[0].pullRequestId" -o tsv`,
-        { cwd: workDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
-      ).trim();
+      const existingPRId = await withRetry(
+        () => this.executor.exec(command, workDir),
+        { retries },
+      );
 
       return existingPRId ? this.buildPRUrl(azureRepoInfo, existingPRId) : null;
     } catch (error) {
-      // Log unexpected errors for debugging (expected: empty result means no PR)
       if (error instanceof Error) {
+        if (isPermanentError(error)) {
+          throw error;
+        }
         const stderr = (error as { stderr?: string }).stderr ?? "";
         if (stderr && !stderr.includes("does not exist")) {
           logger.info(`Debug: Azure PR check failed - ${stderr.trim()}`);
@@ -50,7 +55,15 @@ export class AzurePRStrategy extends BasePRStrategy {
   }
 
   async create(options: PRStrategyOptions): Promise<PRResult> {
-    const { repoInfo, title, body, branchName, baseBranch, workDir } = options;
+    const {
+      repoInfo,
+      title,
+      body,
+      branchName,
+      baseBranch,
+      workDir,
+      retries = 3,
+    } = options;
 
     if (!isAzureDevOpsRepo(repoInfo)) {
       throw new Error("Expected Azure DevOps repository");
@@ -62,11 +75,12 @@ export class AzurePRStrategy extends BasePRStrategy {
     const descFile = join(workDir, this.bodyFilePath);
     writeFileSync(descFile, body, "utf-8");
 
+    const command = `az repos pr create --repository ${escapeShellArg(azureRepoInfo.repo)} --source-branch ${escapeShellArg(branchName)} --target-branch ${escapeShellArg(baseBranch)} --title ${escapeShellArg(title)} --description @${escapeShellArg(descFile)} --org ${escapeShellArg(orgUrl)} --project ${escapeShellArg(azureRepoInfo.project)} --query "pullRequestId" -o tsv`;
+
     try {
-      const prId = execSync(
-        `az repos pr create --repository ${escapeShellArg(azureRepoInfo.repo)} --source-branch ${escapeShellArg(branchName)} --target-branch ${escapeShellArg(baseBranch)} --title ${escapeShellArg(title)} --description @${escapeShellArg(descFile)} --org ${escapeShellArg(orgUrl)} --project ${escapeShellArg(azureRepoInfo.project)} --query "pullRequestId" -o tsv`,
-        { cwd: workDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
-      ).trim();
+      const prId = await withRetry(() => this.executor.exec(command, workDir), {
+        retries,
+      });
 
       return {
         url: this.buildPRUrl(azureRepoInfo, prId),

--- a/src/strategies/github-pr-strategy.test.ts
+++ b/src/strategies/github-pr-strategy.test.ts
@@ -1,0 +1,347 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { GitHubPRStrategy } from "./github-pr-strategy.js";
+import { GitHubRepoInfo } from "../repo-detector.js";
+import { PRStrategyOptions } from "./pr-strategy.js";
+import { CommandExecutor } from "../command-executor.js";
+
+const testDir = join(process.cwd(), "test-github-strategy-tmp");
+
+// Mock executor for testing - implements CommandExecutor interface
+function createMockExecutor(): CommandExecutor & {
+  calls: Array<{ command: string; cwd: string }>;
+  responses: Map<string, string | Error>;
+  reset: () => void;
+} {
+  const calls: Array<{ command: string; cwd: string }> = [];
+  const responses = new Map<string, string | Error>();
+
+  return {
+    calls,
+    responses,
+    async exec(command: string, cwd: string): Promise<string> {
+      calls.push({ command, cwd });
+
+      // Check for matching response
+      for (const [pattern, response] of responses) {
+        if (command.includes(pattern)) {
+          if (response instanceof Error) {
+            throw response;
+          }
+          return response;
+        }
+      }
+
+      // Default: return empty string
+      return "";
+    },
+    reset(): void {
+      calls.length = 0;
+      responses.clear();
+    },
+  };
+}
+
+describe("GitHubPRStrategy with mock executor", () => {
+  const githubRepoInfo: GitHubRepoInfo = {
+    type: "github",
+    gitUrl: "git@github.com:owner/repo.git",
+    owner: "owner",
+    repo: "repo",
+  };
+
+  let mockExecutor: ReturnType<typeof createMockExecutor>;
+
+  beforeEach(() => {
+    mockExecutor = createMockExecutor();
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("checkExistingPR", () => {
+    test("returns PR URL when PR exists", async () => {
+      mockExecutor.responses.set(
+        "gh pr list",
+        "https://github.com/owner/repo/pull/123",
+      );
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.checkExistingPR(options);
+
+      assert.equal(result, "https://github.com/owner/repo/pull/123");
+      assert.equal(mockExecutor.calls.length, 1);
+      assert.ok(mockExecutor.calls[0].command.includes("gh pr list"));
+      assert.ok(mockExecutor.calls[0].command.includes("test-branch"));
+    });
+
+    test("returns null when no PR exists", async () => {
+      mockExecutor.responses.set("gh pr list", "");
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.checkExistingPR(options);
+
+      assert.equal(result, null);
+    });
+
+    test("throws on permanent error (auth failure)", async () => {
+      const authError = new Error("401 Unauthorized - Bad credentials");
+      mockExecutor.responses.set("gh pr list", authError);
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      await assert.rejects(() => strategy.checkExistingPR(options), /401/);
+    });
+
+    test("returns null on transient error", async () => {
+      const networkError = new Error("Connection timed out");
+      mockExecutor.responses.set("gh pr list", networkError);
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.checkExistingPR(options);
+      assert.equal(result, null);
+    });
+  });
+
+  describe("create", () => {
+    test("creates PR and returns URL", async () => {
+      mockExecutor.responses.set(
+        "gh pr create",
+        "Creating pull request...\nhttps://github.com/owner/repo/pull/456",
+      );
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.create(options);
+
+      assert.equal(result.success, true);
+      assert.equal(result.url, "https://github.com/owner/repo/pull/456");
+      assert.equal(mockExecutor.calls.length, 1);
+      assert.ok(mockExecutor.calls[0].command.includes("gh pr create"));
+      assert.ok(mockExecutor.calls[0].command.includes("Test PR"));
+    });
+
+    test("extracts URL from verbose output", async () => {
+      mockExecutor.responses.set(
+        "gh pr create",
+        "Some prefix text\nhttps://github.com/owner/repo/pull/789\nSome suffix text",
+      );
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.create(options);
+
+      assert.equal(result.url, "https://github.com/owner/repo/pull/789");
+    });
+
+    test("cleans up body file after success", async () => {
+      mockExecutor.responses.set(
+        "gh pr create",
+        "https://github.com/owner/repo/pull/123",
+      );
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      await strategy.create(options);
+
+      const bodyFile = join(testDir, ".pr-body.md");
+      assert.equal(existsSync(bodyFile), false);
+    });
+
+    test("cleans up body file after error", async () => {
+      mockExecutor.responses.set("gh pr create", new Error("Command failed"));
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      await assert.rejects(() => strategy.create(options));
+
+      const bodyFile = join(testDir, ".pr-body.md");
+      assert.equal(existsSync(bodyFile), false);
+    });
+  });
+
+  describe("execute (full workflow)", () => {
+    test("returns existing PR if found", async () => {
+      mockExecutor.responses.set(
+        "gh pr list",
+        "https://github.com/owner/repo/pull/existing",
+      );
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.execute(options);
+
+      assert.equal(result.success, true);
+      assert.equal(result.url, "https://github.com/owner/repo/pull/existing");
+      assert.ok(result.message.includes("already exists"));
+      // Should only call checkExistingPR, not create
+      assert.equal(mockExecutor.calls.length, 1);
+    });
+
+    test("creates new PR if none exists", async () => {
+      mockExecutor.responses.set("gh pr list", "");
+      mockExecutor.responses.set(
+        "gh pr create",
+        "https://github.com/owner/repo/pull/new",
+      );
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.execute(options);
+
+      assert.equal(result.success, true);
+      assert.equal(result.url, "https://github.com/owner/repo/pull/new");
+      // Should call both checkExistingPR and create
+      assert.equal(mockExecutor.calls.length, 2);
+    });
+
+    test("returns failure on error", async () => {
+      mockExecutor.responses.set("gh pr list", "");
+      mockExecutor.responses.set("gh pr create", new Error("Failed to create"));
+
+      const strategy = new GitHubPRStrategy(mockExecutor);
+      const options: PRStrategyOptions = {
+        repoInfo: githubRepoInfo,
+        title: "Test PR",
+        body: "Test body",
+        branchName: "test-branch",
+        baseBranch: "main",
+        workDir: testDir,
+        retries: 0,
+      };
+
+      const result = await strategy.execute(options);
+
+      assert.equal(result.success, false);
+      assert.ok(result.message.includes("Failed to create PR"));
+    });
+  });
+});
+
+describe("GitHubPRStrategy URL extraction", () => {
+  test("extracts URL from gh output with extra text", () => {
+    const regex = /https:\/\/github\.com\/[^\s]+/;
+
+    const outputs = [
+      "https://github.com/owner/repo/pull/123",
+      "Creating pull request for branch...\nhttps://github.com/owner/repo/pull/456",
+      "https://github.com/owner/repo/pull/789\nDone!",
+    ];
+
+    for (const output of outputs) {
+      const match = output.match(regex);
+      assert.ok(match, `Should extract URL from: ${output}`);
+      assert.ok(match[0].startsWith("https://github.com/"));
+    }
+  });
+
+  test("handles output without URL", () => {
+    const regex = /https:\/\/github\.com\/[^\s]+/;
+    const output = "Error: something went wrong";
+
+    const match = output.match(regex);
+    assert.equal(match, null);
+  });
+});

--- a/src/strategies/pr-strategy.ts
+++ b/src/strategies/pr-strategy.ts
@@ -1,5 +1,6 @@
 import { PRResult } from "../pr-creator.js";
 import { RepoInfo } from "../repo-detector.js";
+import { CommandExecutor, defaultExecutor } from "../command-executor.js";
 
 export interface PRStrategyOptions {
   repoInfo: RepoInfo;
@@ -8,6 +9,8 @@ export interface PRStrategyOptions {
   branchName: string;
   baseBranch: string;
   workDir: string;
+  /** Number of retries for API operations (default: 3) */
+  retries?: number;
 }
 
 export interface PRStrategy {
@@ -31,6 +34,11 @@ export interface PRStrategy {
 
 export abstract class BasePRStrategy implements PRStrategy {
   protected bodyFilePath: string = ".pr-body.md";
+  protected executor: CommandExecutor;
+
+  constructor(executor?: CommandExecutor) {
+    this.executor = executor ?? defaultExecutor;
+  }
 
   abstract checkExistingPR(options: PRStrategyOptions): Promise<string | null>;
   abstract create(options: PRStrategyOptions): Promise<PRResult>;


### PR DESCRIPTION
## Summary

- Add **p-retry** library for automatic retries with exponential backoff on transient errors
- Convert `CommandExecutor` to **async interface** for better testability
- Update PR strategies to use **injected CommandExecutor** (enables proper unit testing)
- Add `--retries` CLI flag (default: 3, use 0 to disable)

### Bug Fixes

- Fix YAML trailing newline inconsistency
- Fix path traversal check using `path.relative()`
- Improve error differentiation in PR strategies (auth errors now throw instead of returning null)
- Fix race condition in repository-processor (action detection)

### Test Coverage

- Add CLI argument parsing tests (`index.test.ts`)
- Add GitHub PR strategy tests with mock executor
- Add Azure PR strategy tests with mock executor
- Add comprehensive retry-utils tests

### CI Fix

- Add concurrency block to integration workflow to prevent race conditions when multiple CI runs target the same test branch

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (268 tests)
- [x] Integration test passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)