### PR TITLE
chore: add repository ruleset configs

### DIFF
--- a/.github/apply-rulesets.sh
+++ b/.github/apply-rulesets.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply repository rulesets from .github/rulesets/*.json
+# Requires: gh CLI authenticated with repo admin permissions
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# Validate REPO format to prevent injection
+if ! echo "$REPO" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$'; then
+  echo "Error: Invalid repository format: $REPO" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULESETS_DIR="$SCRIPT_DIR/rulesets"
+
+echo "Applying rulesets to $REPO..."
+
+for ruleset in "$RULESETS_DIR"/*.json; do
+  if [ -f "$ruleset" ]; then
+    name=$(basename "$ruleset" .json)
+    echo "  Applying ruleset: $name"
+
+    # Check if ruleset already exists (using --arg to prevent jq injection)
+    existing=$(gh api "repos/$REPO/rulesets" 2>/dev/null | jq -r --arg name "$name" '.[] | select(.name == $name) | .id' || true)
+
+    if [ -n "$existing" ]; then
+      echo "    Updating existing ruleset (ID: $existing)"
+      gh api "repos/$REPO/rulesets/$existing" -X PUT --input "$ruleset"
+    else
+      echo "    Creating new ruleset"
+      gh api "repos/$REPO/rulesets" -X POST --input "$ruleset"
+    fi
+  fi
+done
+
+echo "Done. Rulesets applied successfully."

--- a/.github/rulesets/pr-rules.json
+++ b/.github/rulesets/pr-rules.json
@@ -1,0 +1,65 @@
+{
+  "name": "pr-rules",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "build"
+          }
+        ]
+      }
+    },
+    {
+      "type": "required_signatures"
+    },
+    {
+      "type": "code_scanning",
+      "parameters": {
+        "code_scanning_tools": [
+          {
+            "tool": "CodeQL",
+            "security_alerts_threshold": "high_or_higher",
+            "alerts_threshold": "errors"
+          }
+        ]
+      }
+    },
+    {
+      "type": "code_quality",
+      "parameters": {
+        "severity": "errors"
+      }
+    }
+  ]
+}

--- a/.github/rulesets/push-protection.json
+++ b/.github/rulesets/push-protection.json
@@ -1,0 +1,25 @@
+{
+  "name": "push-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "required_linear_history"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add version-controlled ruleset definitions for standardizing repo protection
- `pr-rules.json`: PR requirements (1 approval, stale review dismissal, thread resolution, build check, signatures, CodeQL, code quality)
- `push-protection.json`: Branch protection (no force push, delete, creation, linear history)
- `apply-rulesets.sh`: Script to apply rulesets via GitHub API

## Test plan
- [x] Verified rulesets are already applied and active on this repo
- [x] Confirmed status check name matches workflow (`build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)