### PR TITLE
fix(ci): remove registry-url for trusted publishers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,6 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Remove `registry-url` from setup-node in the release job
- OIDC-based Trusted Publishers don't need registry-url
- The original release.yml didn't have it

The refactor in #28 incorrectly added both `registry-url` and `NODE_AUTH_TOKEN`. This PR removes `registry-url` to match the original working configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)