### PR TITLE
fix(ci): add registry-url for npm OIDC auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Add `registry-url` back to setup-node in release job
- Required for npm Trusted Publishers OIDC flow to work

Without `registry-url`, npm doesn't know which registry to authenticate against (ENEEDAUTH).
With `registry-url` but no `NODE_AUTH_TOKEN`, setup-node should configure npm to use OIDC.

🤖 Generated with [Claude Code](https://claude.ai/code)