### PR TITLE
fix(ci): match release job to original release.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,17 +118,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: dist
-          path: dist/
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
Update release job to match the working original configuration from before the consolidation.

## Changes
- Node.js 24 (required by npm for provenance)
- Build and test in release job (not from artifacts)
- No registry-url (not needed for Trusted Publishers)
- No NODE_AUTH_TOKEN (Trusted Publishers uses OIDC)

## Reference
Original release.yml: `git show 5a8f153^:.github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.ai/code)