### PR TITLE
fix(ci): use Node.js 24 for release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Use Node.js 24 in release job, matching original release.yml configuration.

## Reference
`git show 5a8f153^:.github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.ai/code)