### PR TITLE
feat: support YAML comments and empty files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,13 @@ Raw YAML → Parse → Validate → Expand git arrays → Deep merge per file �
 
 **Create-Only Mode**: Set `files[fileName].createOnly: true` to only create a file if it doesn't exist. Per-repo can override with `repos[].files[fileName].createOnly: false`.
 
+**Empty Files**: Omit `content` to create an empty file. Useful for files like `.prettierignore` that just need to exist.
+
+**YAML Comments**: For YAML output files, use `header` and/or `schemaUrl` to add comments at the top of the file:
+
+- `schemaUrl`: Adds `# yaml-language-server: $schema=<url>` directive for IDE support
+- `header`: Adds custom comment lines (string or array of strings)
+
 ### Deep Merge (merge.ts)
 
 Recursive object merging with configurable array handling:
@@ -145,10 +152,23 @@ files:
     content:
       singleQuote: true
 
+  trivy.yaml:
+    schemaUrl: https://trivy.dev/latest/docs/references/configuration/config-file/
+    header: "Trivy security scanner configuration"
+    content:
+      exit-code: 1
+      scan:
+        scanners:
+          - vuln
+
   .trivyignore.yaml:
     createOnly: true # Only create if file doesn't exist
     content:
       vulnerabilities: []
+
+  .prettierignore:
+    createOnly: true
+    # content omitted = empty file
 
 repos:
   - git: # Can be string or array of strings

--- a/config-schema.json
+++ b/config-schema.json
@@ -27,11 +27,10 @@
     "fileConfig": {
       "type": "object",
       "description": "Configuration for a single file to sync",
-      "required": ["content"],
       "properties": {
         "content": {
           "type": "object",
-          "description": "Base configuration content. Supports environment variables: ${VAR}, ${VAR:-default}, ${VAR:?message}",
+          "description": "Base configuration content. Supports environment variables: ${VAR}, ${VAR:-default}, ${VAR:?message}. Omit for empty file.",
           "additionalProperties": true
         },
         "mergeStrategy": {
@@ -44,6 +43,26 @@
           "type": "boolean",
           "default": false,
           "description": "If true, only create this file if it doesn't already exist in the target repo. Useful for files like .trivyignore or .prettierignore where you want to provide defaults but let repos customize. Default: false"
+        },
+        "header": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Single comment line"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multiple comment lines"
+            }
+          ],
+          "description": "Comment line(s) added at the top of YAML output files. Each line gets a '# ' prefix. Ignored for JSON files."
+        },
+        "schemaUrl": {
+          "type": "string",
+          "description": "URL for yaml-language-server schema directive. Adds '# yaml-language-server: $schema=<url>' at the top of YAML files. Ignored for JSON files."
         }
       }
     },
@@ -99,11 +118,31 @@
         "override": {
           "type": "boolean",
           "default": false,
-          "description": "If true, use only this content and skip merging with base. Requires 'content' to be specified. Default: false"
+          "description": "If true, use only this content and skip merging with base. Default: false"
         },
         "createOnly": {
           "type": "boolean",
           "description": "Override the root-level createOnly setting for this specific repo"
+        },
+        "header": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Single comment line"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Multiple comment lines"
+            }
+          ],
+          "description": "Override the root-level header for this specific repo"
+        },
+        "schemaUrl": {
+          "type": "string",
+          "description": "Override the root-level schemaUrl for this specific repo"
         }
       }
     }

--- a/src/config-normalizer.ts
+++ b/src/config-normalizer.ts
@@ -7,6 +7,17 @@ import { interpolateEnvVars } from "./env.js";
 import type { RawConfig, Config, RepoConfig, FileContent } from "./config.js";
 
 /**
+ * Normalizes header to array format.
+ */
+function normalizeHeader(
+  header: string | string[] | undefined,
+): string[] | undefined {
+  if (header === undefined) return undefined;
+  if (typeof header === "string") return [header];
+  return header;
+}
+
+/**
  * Normalizes raw config into expanded, merged config.
  * Pipeline: expand git arrays -> merge content -> interpolate env vars
  */
@@ -31,41 +42,61 @@ export function normalizeConfig(raw: RawConfig): Config {
         }
 
         const fileConfig = raw.files[fileName];
-        const baseContent = fileConfig.content ?? {};
         const fileStrategy = fileConfig.mergeStrategy ?? "replace";
 
         // Step 3: Compute merged content for this file
-        let mergedContent: Record<string, unknown>;
+        let mergedContent: Record<string, unknown> | null;
 
         if (repoOverride?.override) {
-          // Override mode: use only repo file content
-          mergedContent = stripMergeDirectives(
-            structuredClone(repoOverride.content as Record<string, unknown>),
-          );
+          // Override mode: use only repo file content (may be undefined for empty file)
+          if (repoOverride.content === undefined) {
+            mergedContent = null;
+          } else {
+            mergedContent = stripMergeDirectives(
+              structuredClone(repoOverride.content),
+            );
+          }
+        } else if (fileConfig.content === undefined) {
+          // Root file has no content = empty file (unless repo provides content)
+          if (repoOverride?.content) {
+            mergedContent = stripMergeDirectives(
+              structuredClone(repoOverride.content),
+            );
+          } else {
+            mergedContent = null;
+          }
         } else if (!repoOverride?.content) {
           // No repo override: use file base content as-is
-          mergedContent = structuredClone(baseContent);
+          mergedContent = structuredClone(fileConfig.content);
         } else {
           // Merge mode: deep merge file base + repo overlay
           const ctx = createMergeContext(fileStrategy);
           mergedContent = deepMerge(
-            structuredClone(baseContent),
+            structuredClone(fileConfig.content),
             repoOverride.content,
             ctx,
           );
           mergedContent = stripMergeDirectives(mergedContent);
         }
 
-        // Step 4: Interpolate env vars
-        mergedContent = interpolateEnvVars(mergedContent, { strict: true });
+        // Step 4: Interpolate env vars (only if content exists)
+        if (mergedContent !== null) {
+          mergedContent = interpolateEnvVars(mergedContent, { strict: true });
+        }
 
-        // Resolve createOnly: per-repo overrides root level
+        // Resolve fields: per-repo overrides root level
         const createOnly = repoOverride?.createOnly ?? fileConfig.createOnly;
+        const header = normalizeHeader(
+          repoOverride?.header ?? fileConfig.header,
+        );
+        const schemaUrl = repoOverride?.schemaUrl ?? fileConfig.schemaUrl;
 
         files.push({
           fileName,
           content: mergedContent,
           createOnly,
+          header,
+          schemaUrl,
         });
       }
 

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -50,6 +50,25 @@ export function validateRawConfig(config: RawConfig): void {
     ) {
       throw new Error(`File '${fileName}' createOnly must be a boolean`);
     }
+
+    if (fileConfig.header !== undefined) {
+      if (
+        typeof fileConfig.header !== "string" &&
+        (!Array.isArray(fileConfig.header) ||
+          !fileConfig.header.every((h) => typeof h === "string"))
+      ) {
+        throw new Error(
+          `File '${fileName}' header must be a string or array of strings`,
+        );
+      }
+    }
+
+    if (
+      fileConfig.schemaUrl !== undefined &&
+      typeof fileConfig.schemaUrl !== "string"
+    ) {
+      throw new Error(`File '${fileName}' schemaUrl must be a string`);
+    }
   }
 
   if (!config.repos || !Array.isArray(config.repos)) {
@@ -110,6 +129,27 @@ export function validateRawConfig(config: RawConfig): void {
         ) {
           throw new Error(
             `Repo ${getGitDisplayName(repo.git)}: file '${fileName}' createOnly must be a boolean`,
+          );
+        }
+
+        if (fileOverride.header !== undefined) {
+          if (
+            typeof fileOverride.header !== "string" &&
+            (!Array.isArray(fileOverride.header) ||
+              !fileOverride.header.every((h) => typeof h === "string"))
+          ) {
+            throw new Error(
+              `Repo ${getGitDisplayName(repo.git)}: file '${fileName}' header must be a string or array of strings`,
+            );
+          }
+        }
+
+        if (
+          fileOverride.schemaUrl !== undefined &&
+          typeof fileOverride.schemaUrl !== "string"
+        ) {
+          throw new Error(
+            `Repo ${getGitDisplayName(repo.git)}: file '${fileName}' schemaUrl must be a string`,
           );
         }
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,9 +13,11 @@ export { convertContentToString } from "./config-formatter.js";
 
 // Per-file configuration at root level
 export interface RawFileConfig {
-  content: Record<string, unknown>;
+  content?: Record<string, unknown>;
   mergeStrategy?: ArrayMergeStrategy;
   createOnly?: boolean;
+  header?: string | string[];
+  schemaUrl?: string;
 }
 
 // Per-repo file override
@@ -23,6 +25,8 @@ export interface RawRepoFileOverride {
   content?: Record<string, unknown>;
   override?: boolean;
   createOnly?: boolean;
+  header?: string | string[];
+  schemaUrl?: string;
 }
 
 // Repo configuration
@@ -45,8 +49,10 @@ export interface RawConfig {
 // File content for a single file in a repo
 export interface FileContent {
   fileName: string;
-  content: Record<string, unknown>;
+  content: Record<string, unknown> | null;
   createOnly?: boolean;
+  header?: string[];
+  schemaUrl?: string;
 }
 
 // Normalized repo config with all files to sync

--- a/src/repository-processor.ts
+++ b/src/repository-processor.ts
@@ -90,7 +90,14 @@ export class RepositoryProcessor {
         }
 
         this.log.info(`Writing ${file.fileName}...`);
-        const fileContent = convertContentToString(file.content, file.fileName);
+        const fileContent = convertContentToString(
+          file.content,
+          file.fileName,
+          {
+            header: file.header,
+            schemaUrl: file.schemaUrl,
+          },
+        );
 
         // Determine action type (create vs update)
         const action: "create" | "update" = fileExists ? "update" : "create";


### PR DESCRIPTION
## Summary

- Add `header` field for custom comment lines at top of YAML files
- Add `schemaUrl` field for `# yaml-language-server: $schema=<url>` directive
- Make `content` optional - omit it to create empty files

## New Configuration Options

### YAML Comments
```yaml
files:
  trivy.yaml:
    schemaUrl: https://trivy.dev/schema.json
    header: "Trivy security scanner configuration"
    content:
      exit-code: 1
```

**Output:**
```yaml
# yaml-language-server: $schema=https://trivy.dev/schema.json
# Trivy security scanner configuration
exit-code: 1
```

### Empty Files
```yaml
files:
  .prettierignore:
    createOnly: true
    # No content = empty file
```

## Changes

- `src/config.ts` - Updated type interfaces
- `src/config-validator.ts` - Added validation for new fields
- `src/config-normalizer.ts` - Handle empty content and new fields
- `src/config-formatter.ts` - YAML comment generation
- `src/repository-processor.ts` - Pass options to formatter
- `config-schema.json` - Updated JSON Schema
- `CLAUDE.md`, `README.md` - Documentation

## Test plan

- [x] 38 new unit tests added (479 total, all passing)
- [x] Build passes
- [ ] Integration test with real repo

🤖 Generated with [Claude Code](https://claude.ai/code)