### PR TITLE
feat: add subdirectory support for syncing files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ Raw YAML → Parse → Validate → Expand git arrays → Deep merge per file �
 - Lines array: `content: ["line1", "line2"]` - supports merge strategies (append/prepend/replace)
 - Validation enforces: `.json`/`.yaml`/`.yml` must have object content; other extensions must have string/string[] content
 
+**Subdirectory Support**: File names can include paths (e.g., `.github/workflows/ci.yml`). Parent directories are created automatically. Quote paths containing `/` in YAML keys.
+
 ### Deep Merge (merge.ts)
 
 Recursive object merging with configurable array handling:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ json-config-sync --config ./config.yaml
 
 - **Multi-File Sync** - Sync multiple config files in a single run
 - **Multi-Format Output** - JSON, YAML, or plain text based on filename extension
+- **Subdirectory Support** - Sync files to any path (e.g., `.github/workflows/ci.yml`)
 - **Text Files** - Sync `.gitignore`, `.markdownlintignore`, etc. with string or lines array
 - **Content Inheritance** - Define base config once, override per-repo as needed
 - **Multi-Repo Targeting** - Apply same config to multiple repos with array syntax
@@ -486,6 +487,37 @@ repos:
 - **Lines array** (`content: ['line1', 'line2']`) - Each line joined with newlines. Supports merge strategies (`append`, `prepend`, `replace`).
 
 **Validation:** JSON/YAML file extensions (`.json`, `.yaml`, `.yml`) require object content. Other extensions require string or string[] content.
+
+### Subdirectory Paths
+
+Sync files to any subdirectory path - parent directories are created automatically:
+
+```yaml
+files:
+  # GitHub Actions workflow
+  ".github/workflows/ci.yml":
+    content:
+      name: CI
+      on: [push, pull_request]
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+
+  # Nested config directory
+  "config/settings/app.json":
+    content:
+      environment: production
+      debug: false
+
+repos:
+  - git:
+      - git@github.com:org/frontend.git
+      - git@github.com:org/backend.git
+```
+
+**Note:** Quote file paths containing `/` in YAML keys. Parent directories are created if they don't exist.
 
 ## Supported Git URL Formats
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aspruyt/json-config-sync",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aspruyt/json-config-sync",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspruyt/json-config-sync",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "CLI tool to sync JSON or YAML configuration files across multiple GitHub and Azure DevOps repositories",
   "type": "module",
   "main": "dist/index.js",

--- a/src/git-ops.test.ts
+++ b/src/git-ops.test.ts
@@ -395,13 +395,17 @@ describe("GitOps", () => {
       );
     });
 
-    test("writeFile allows nested paths without traversal", () => {
+    test("writeFile creates parent directories automatically", () => {
       const gitOps = new GitOps({ workDir });
-      const nestedDir = join(workDir, "config");
-      mkdirSync(nestedDir, { recursive: true });
-
+      // Should auto-create parent directory
       gitOps.writeFile("config/settings.json", "content");
       assert.ok(existsSync(join(workDir, "config/settings.json")));
+    });
+
+    test("writeFile creates deeply nested directories", () => {
+      const gitOps = new GitOps({ workDir });
+      gitOps.writeFile(".github/workflows/ci.yml", "name: CI");
+      assert.ok(existsSync(join(workDir, ".github/workflows/ci.yml")));
     });
 
     test("wouldChange throws on path traversal attempt", () => {

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -5,7 +5,7 @@ import {
   writeFileSync,
   readFileSync,
 } from "node:fs";
-import { join, resolve, relative, isAbsolute } from "node:path";
+import { join, resolve, relative, isAbsolute, dirname } from "node:path";
 import { escapeShellArg } from "./shell-utils.js";
 import { CommandExecutor, defaultExecutor } from "./command-executor.js";
 import { withRetry } from "./retry-utils.js";
@@ -136,6 +136,9 @@ export class GitOps {
       return;
     }
     const filePath = this.validatePath(fileName);
+
+    // Create parent directories if they don't exist
+    mkdirSync(dirname(filePath), { recursive: true });
 
     // Normalize trailing newline - ensure exactly one
     const normalized = content.endsWith("\n") ? content : content + "\n";


### PR DESCRIPTION
## Summary

Enable syncing config files to folders within repositories (e.g., `.github/workflows/ci.yml`), not just the repo root. Parent directories are created automatically when writing files.

### Changes
- Add `dirname` import and `mkdirSync` call in `writeFile()` to create parent directories
- Update tests to verify automatic directory creation for nested paths
- Add "Subdirectory Support" feature to README.md with examples
- Document subdirectory support in CLAUDE.md

### Example Usage
```yaml
files:
  ".github/workflows/ci.yml":
    content:
      name: CI
      on: [push, pull_request]
      jobs:
        build:
          runs-on: ubuntu-latest
```

## Test plan
- [x] All 547 unit tests pass
- [x] New tests verify automatic directory creation for nested paths
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)