### PR TITLE
chore: release v3.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ Raw YAML → Parse → Resolve file refs → Validate → Expand git arrays → 
 
 **Subdirectory Support**: File names can include paths (e.g., `.github/workflows/ci.yml`). Parent directories are created automatically. Quote paths containing `/` in YAML keys.
 
+**Executable Files**: Files ending in `.sh` are auto-marked executable via `git update-index --chmod=+x`. Use `executable: false` to disable. Non-.sh files can be marked executable with `executable: true`. Per-repo can override root-level `executable` setting.
+
 ### Deep Merge (merge.ts)
 
 Recursive object merging with configurable array handling:

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ repos: # List of repositories
 | `content`       | Base config: object for JSON/YAML files, string or string[] for text files, or `@path/to/file` to load from external template (omit for empty file) | No       |
 | `mergeStrategy` | Merge strategy: `replace`, `append`, `prepend` (for arrays and text lines)                                                                          | No       |
 | `createOnly`    | If `true`, only create file if it doesn't exist                                                                                                     | No       |
+| `executable`    | Mark file as executable. `.sh` files are auto-executable unless set to `false`. Set to `true` for non-.sh files.                                    | No       |
 | `header`        | Comment line(s) at top of YAML files (string or array)                                                                                              | No       |
 | `schemaUrl`     | Adds `# yaml-language-server: $schema=<url>` to YAML files                                                                                          | No       |
 
@@ -193,6 +194,7 @@ repos: # List of repositories
 | `content`    | Content overlay merged onto file's base content         | No       |
 | `override`   | If `true`, ignore base content and use only this repo's | No       |
 | `createOnly` | Override root-level `createOnly` for this repo          | No       |
+| `executable` | Override root-level `executable` for this repo          | No       |
 | `header`     | Override root-level `header` for this repo              | No       |
 | `schemaUrl`  | Override root-level `schemaUrl` for this repo           | No       |
 
@@ -488,6 +490,44 @@ repos:
 - **Lines array** (`content: ['line1', 'line2']`) - Each line joined with newlines. Supports merge strategies (`append`, `prepend`, `replace`).
 
 **Validation:** JSON/YAML file extensions (`.json`, `.yaml`, `.yml`) require object content. Other extensions require string or string[] content.
+
+### Executable Files
+
+Shell scripts (`.sh` files) are automatically marked as executable using `git update-index --chmod=+x`. You can control this behavior:
+
+```yaml
+files:
+  # .sh files are auto-executable (no config needed)
+  deploy.sh:
+    content: |-
+      #!/bin/bash
+      echo "Deploying..."
+
+  # Disable auto-executable for a specific .sh file
+  template.sh:
+    executable: false
+    content: "# This is just a template"
+
+  # Make a non-.sh file executable
+  run:
+    executable: true
+    content: |-
+      #!/usr/bin/env python3
+      print("Hello")
+
+repos:
+  - git: git@github.com:org/repo.git
+    files:
+      # Override executable per-repo
+      deploy.sh:
+        executable: false # Disable for this repo
+```
+
+**Behavior:**
+
+- `.sh` files: Automatically executable unless `executable: false`
+- Other files: Not executable unless `executable: true`
+- Per-repo settings override root-level settings
 
 ### Subdirectory Paths
 

--- a/config-schema.json
+++ b/config-schema.json
@@ -77,6 +77,10 @@
         "schemaUrl": {
           "type": "string",
           "description": "URL for yaml-language-server schema directive. Adds '# yaml-language-server: $schema=<url>' at the top of YAML files. Ignored for JSON files."
+        },
+        "executable": {
+          "type": "boolean",
+          "description": "Mark the file as executable via git update-index --chmod=+x. Shell scripts (.sh) are auto-executable unless explicitly set to false. Non-.sh files can be marked executable by setting to true."
         }
       }
     },
@@ -171,6 +175,10 @@
         "schemaUrl": {
           "type": "string",
           "description": "Override the root-level schemaUrl for this specific repo"
+        },
+        "executable": {
+          "type": "boolean",
+          "description": "Override the root-level executable setting for this specific repo. Set to true to mark executable, or false to disable auto-executable behavior for .sh files."
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aspruyt/json-config-sync",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aspruyt/json-config-sync",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspruyt/json-config-sync",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "CLI tool to sync JSON or YAML configuration files across multiple GitHub and Azure DevOps repositories",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config-normalizer.ts
+++ b/src/config-normalizer.ts
@@ -113,6 +113,7 @@ export function normalizeConfig(raw: RawConfig): Config {
 
         // Resolve fields: per-repo overrides root level
         const createOnly = repoOverride?.createOnly ?? fileConfig.createOnly;
+        const executable = repoOverride?.executable ?? fileConfig.executable;
         const header = normalizeHeader(
           repoOverride?.header ?? fileConfig.header,
         );
@@ -122,6 +123,7 @@ export function normalizeConfig(raw: RawConfig): Config {
           fileName,
           content: mergedContent,
           createOnly,
+          executable,
           header,
           schemaUrl,
         });

--- a/src/config-validator.test.ts
+++ b/src/config-validator.test.ts
@@ -813,4 +813,81 @@ describe("validateRawConfig", () => {
       assert.doesNotThrow(() => validateRawConfig(config));
     });
   });
+
+  describe("executable validation", () => {
+    test("allows executable: true at root file level", () => {
+      const config = createValidConfig({
+        files: { "deploy.sh": { content: "#!/bin/bash", executable: true } },
+      });
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("allows executable: false at root file level", () => {
+      const config = createValidConfig({
+        files: { "script.sh": { content: "#!/bin/bash", executable: false } },
+      });
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("allows undefined executable at root file level", () => {
+      const config = createValidConfig({
+        files: { "script.sh": { content: "#!/bin/bash" } },
+      });
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("throws when executable is not a boolean at root level", () => {
+      const config = createValidConfig({
+        files: {
+          "script.sh": { content: "#!/bin/bash", executable: "yes" as never },
+        },
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /executable must be a boolean/,
+      );
+    });
+
+    test("allows executable: true at per-repo level", () => {
+      const config = createValidConfig({
+        files: { run: { content: "#!/bin/bash" } },
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: { run: { executable: true } },
+          },
+        ],
+      });
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("allows executable: false at per-repo level", () => {
+      const config = createValidConfig({
+        files: { "script.sh": { content: "#!/bin/bash" } },
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: { "script.sh": { executable: false } },
+          },
+        ],
+      });
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("throws when executable is not a boolean at per-repo level", () => {
+      const config = createValidConfig({
+        files: { "script.sh": { content: "#!/bin/bash" } },
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: { "script.sh": { executable: 123 as never } },
+          },
+        ],
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /executable must be a boolean/,
+      );
+    });
+  });
 });

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -95,6 +95,13 @@ export function validateRawConfig(config: RawConfig): void {
       throw new Error(`File '${fileName}' createOnly must be a boolean`);
     }
 
+    if (
+      fileConfig.executable !== undefined &&
+      typeof fileConfig.executable !== "boolean"
+    ) {
+      throw new Error(`File '${fileName}' executable must be a boolean`);
+    }
+
     if (fileConfig.header !== undefined) {
       if (
         typeof fileConfig.header !== "string" &&
@@ -187,6 +194,15 @@ export function validateRawConfig(config: RawConfig): void {
         ) {
           throw new Error(
             `Repo ${getGitDisplayName(repo.git)}: file '${fileName}' createOnly must be a boolean`,
+          );
+        }
+
+        if (
+          fileOverride.executable !== undefined &&
+          typeof fileOverride.executable !== "boolean"
+        ) {
+          throw new Error(
+            `Repo ${getGitDisplayName(repo.git)}: file '${fileName}' executable must be a boolean`,
           );
         }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export interface RawFileConfig {
   content?: ContentValue;
   mergeStrategy?: ArrayMergeStrategy;
   createOnly?: boolean;
+  executable?: boolean;
   header?: string | string[];
   schemaUrl?: string;
 }
@@ -30,6 +31,7 @@ export interface RawRepoFileOverride {
   content?: ContentValue;
   override?: boolean;
   createOnly?: boolean;
+  executable?: boolean;
   header?: string | string[];
   schemaUrl?: string;
 }
@@ -56,6 +58,7 @@ export interface FileContent {
   fileName: string;
   content: ContentValue | null;
   createOnly?: boolean;
+  executable?: boolean;
   header?: string[];
   schemaUrl?: string;
 }

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -146,6 +146,24 @@ export class GitOps {
   }
 
   /**
+   * Marks a file as executable in git using update-index --chmod=+x.
+   * This modifies the file mode in git's index, not the filesystem.
+   * @param fileName - The file path relative to the work directory
+   */
+  async setExecutable(fileName: string): Promise<void> {
+    if (this.dryRun) {
+      return;
+    }
+    const filePath = this.validatePath(fileName);
+    // Use relative path from workDir for git command
+    const relativePath = relative(this.workDir, filePath);
+    await this.exec(
+      `git update-index --chmod=+x ${escapeShellArg(relativePath)}`,
+      this.workDir,
+    );
+  }
+
+  /**
    * Checks if writing the given content would result in changes.
    * Works in both normal and dry-run modes by comparing content directly.
    */


### PR DESCRIPTION
## Summary

- feat: auto-mark .sh files as executable in git (#57)

### Features

- Shell scripts (`.sh` files) are automatically marked executable via `git update-index --chmod=+x`
- Optional `executable` field for explicit control at root and per-repo levels
- Non-.sh files can be marked executable with `executable: true`
- Per-repo settings override root-level settings

### Changes

- Added `executable` property to config schema
- Added `executable` field to TypeScript types
- Added validation for `executable` field
- Added `setExecutable()` method to GitOps class
- Updated repository processor to handle executable files
- Added comprehensive tests
- Updated documentation (README.md, CLAUDE.md)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)