### PR TITLE
feat: add escape mechanism for env var interpolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,9 @@ Replaces environment variable placeholders in string values:
 - `${VAR}`: Required variable (errors if missing in strict mode)
 - `${VAR:-default}`: Use default if variable is not set
 - `${VAR:?message}`: Required with custom error message
+- `$${VAR}`: Escape - outputs literal `${VAR}` without interpolation
+
+**Escape Mechanism**: Use `$$` prefix to prevent interpolation. `$${VAR}` outputs `${VAR}` literally. Useful for devcontainer.json, shell scripts, and other templating systems that use `${...}` syntax.
 
 **Options**:
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,38 @@ repos:
   - git: git@github.com:org/backend.git
 ```
 
+#### Escaping Variable Syntax
+
+If your target file needs literal `${VAR}` syntax (e.g., for devcontainer.json, shell scripts, or other templating systems), use `$$` to escape:
+
+```yaml
+files:
+  .devcontainer/devcontainer.json:
+    content:
+      name: my-dev-container
+      remoteEnv:
+        # Escaped - outputs literal ${localWorkspaceFolder} for VS Code
+        LOCAL_WORKSPACE_FOLDER: "$${localWorkspaceFolder}"
+        CONTAINER_WORKSPACE: "$${containerWorkspaceFolder}"
+        # Interpolated - replaced with actual env value
+        API_KEY: "${API_KEY}"
+```
+
+Output:
+
+```json
+{
+  "name": "my-dev-container",
+  "remoteEnv": {
+    "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+    "CONTAINER_WORKSPACE": "${containerWorkspaceFolder}",
+    "API_KEY": "actual-api-key-value"
+  }
+}
+```
+
+This follows the same escape convention used by Docker Compose.
+
 ### Merge Directives
 
 Control array merging with the `$arrayMerge` directive:

--- a/config-schema.json
+++ b/config-schema.json
@@ -45,7 +45,7 @@
               "description": "Lines array for text file output with merge strategy support"
             }
           ],
-          "description": "File content. Object for JSON/YAML files, string or string[] for text files. Use @path/to/file to reference external template files (paths relative to config file). Supports ${VAR} env interpolation. Omit for empty file."
+          "description": "File content. Object for JSON/YAML files, string or string[] for text files. Use @path/to/file to reference external template files (paths relative to config file). Supports ${VAR} env interpolation; use $${VAR} to output literal ${VAR}. Omit for empty file."
         },
         "mergeStrategy": {
           "type": "string",


### PR DESCRIPTION
## Summary

- Add `$${VAR}` syntax to output literal `${VAR}` without interpolation
- Useful for syncing devcontainer.json, shell scripts, and other templates that use `${...}` syntax
- Follows Docker Compose escape convention

## Changes

- **src/env.ts**: Add 3-phase escape handling in `processString()` using placeholder replacement
- **src/env.test.ts**: Add 16 comprehensive tests covering basic escapes, mixed vars, nested objects, arrays, and edge cases
- **README.md**: Document escape syntax with devcontainer.json example
- **CLAUDE.md**: Update environment interpolation section
- **config-schema.json**: Update content field description

## Test plan

- [x] All 586 unit tests pass
- [x] Build succeeds with no TypeScript errors
- [ ] Manual verification with escaped and interpolated vars in same config

Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)
