### PR TITLE
chore: release v3.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aspruyt/json-config-sync",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aspruyt/json-config-sync",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspruyt/json-config-sync",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "CLI tool to sync JSON or YAML configuration files across multiple GitHub and Azure DevOps repositories",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v3.7.0

## Changes
- feat: add escape mechanism for env var interpolation (#60)
  - Use `$${VAR}` to output literal `${VAR}` without interpolation
  - Useful for devcontainer.json, shell scripts, and other templates