### PR TITLE
feat: add auto-merge and force-merge options for PRs

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -21,6 +21,10 @@
       "items": {
         "$ref": "#/definitions/repo"
       }
+    },
+    "prOptions": {
+      "$ref": "#/definitions/prOptions",
+      "description": "Global PR merge options. Can be overridden per-repo."
     }
   },
   "definitions": {
@@ -121,6 +125,37 @@
               }
             ]
           }
+        },
+        "prOptions": {
+          "$ref": "#/definitions/prOptions",
+          "description": "Per-repo PR merge options. Overrides global prOptions."
+        }
+      }
+    },
+    "prOptions": {
+      "type": "object",
+      "description": "PR merge behavior options",
+      "properties": {
+        "merge": {
+          "type": "string",
+          "enum": ["manual", "auto", "force"],
+          "default": "manual",
+          "description": "Merge mode: 'manual' leaves PR open for review (default), 'auto' enables auto-merge when checks pass, 'force' bypasses requirements using admin privileges"
+        },
+        "mergeStrategy": {
+          "type": "string",
+          "enum": ["merge", "squash", "rebase"],
+          "default": "merge",
+          "description": "How to merge the PR: 'merge' creates a merge commit, 'squash' squashes all commits, 'rebase' rebases commits onto base"
+        },
+        "deleteBranch": {
+          "type": "boolean",
+          "default": false,
+          "description": "Delete the source branch after merge completes"
+        },
+        "bypassReason": {
+          "type": "string",
+          "description": "Reason for bypassing policies (Azure DevOps only, required when merge=force)"
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,20 @@ import { resolveFileReferencesInConfig } from "./file-reference-resolver.js";
 export { convertContentToString } from "./config-formatter.js";
 
 // =============================================================================
+// PR Merge Options Types
+// =============================================================================
+
+export type MergeMode = "manual" | "auto" | "force";
+export type MergeStrategy = "merge" | "squash" | "rebase";
+
+export interface PRMergeOptions {
+  merge?: MergeMode;
+  mergeStrategy?: MergeStrategy;
+  deleteBranch?: boolean;
+  bypassReason?: string;
+}
+
+// =============================================================================
 // Raw Config Types (as parsed from YAML)
 // =============================================================================
 
@@ -41,12 +55,14 @@ export interface RawRepoFileOverride {
 export interface RawRepoConfig {
   git: string | string[];
   files?: Record<string, RawRepoFileOverride | false>;
+  prOptions?: PRMergeOptions;
 }
 
 // Root config structure
 export interface RawConfig {
   files: Record<string, RawFileConfig>;
   repos: RawRepoConfig[];
+  prOptions?: PRMergeOptions;
 }
 
 // =============================================================================
@@ -67,6 +83,7 @@ export interface FileContent {
 export interface RepoConfig {
   git: string;
   files: FileContent[];
+  prOptions?: PRMergeOptions;
 }
 
 // Normalized config

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -3,7 +3,13 @@ import type { PRStrategy } from "./pr-strategy.js";
 import { GitHubPRStrategy } from "./github-pr-strategy.js";
 import { AzurePRStrategy } from "./azure-pr-strategy.js";
 
-export type { PRStrategy, PRStrategyOptions } from "./pr-strategy.js";
+export type {
+  PRStrategy,
+  PRStrategyOptions,
+  PRMergeConfig,
+  MergeOptions,
+  MergeResult,
+} from "./pr-strategy.js";
 export { BasePRStrategy, PRWorkflowExecutor } from "./pr-strategy.js";
 export { GitHubPRStrategy } from "./github-pr-strategy.js";
 export { AzurePRStrategy } from "./azure-pr-strategy.js";


### PR DESCRIPTION
## Summary
- Adds `prOptions` configuration to automatically merge PRs or force merge using admin privileges
- Supports both GitHub (`gh pr merge --auto/--admin`) and Azure DevOps (`az repos pr update --auto-complete/--bypass-policy`)
- Global and per-repo configuration with CLI flag overrides
- Graceful handling when GitHub auto-merge is not enabled on repository

## Changes
- Added `PRMergeOptions` types to config.ts
- Implemented `merge()` method in GitHub and Azure strategies
- Added CLI flags: `--merge`, `--merge-strategy`, `--delete-branch`
- Updated config-schema.json with prOptions definition
- Added 24 new unit tests for config parsing and strategy merge functionality
- Updated README.md and CLAUDE.md documentation

## Test plan
- [x] All 616 unit tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [ ] CI passes on this PR
- [ ] Manual dry-run test: `npm run dev -- --merge auto --dry-run`

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)