### PR TITLE
feat: add JSON5 file support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-TypeScript CLI tool that syncs JSON, YAML, or text configuration files across multiple Git repositories by automatically creating pull requests. Output format is determined by content type: object content outputs JSON/YAML (based on file extension), while string or string array content outputs plain text. Supports both GitHub and Azure DevOps platforms.
+TypeScript CLI tool that syncs JSON, JSON5, YAML, or text configuration files across multiple Git repositories by automatically creating pull requests. Output format is determined by content type: object content outputs JSON/JSON5/YAML (based on file extension), while string or string array content outputs plain text. Supports both GitHub and Azure DevOps platforms.
 
 ## Architecture
 
@@ -25,7 +25,7 @@ Raw YAML → Parse → Resolve file refs → Validate → Expand git arrays → 
 
 **Pipeline Steps**:
 
-1. **File Reference Resolution**: Replace `@path/to/file` content with actual file contents (JSON/YAML parsed as objects, other files as strings)
+1. **File Reference Resolution**: Replace `@path/to/file` content with actual file contents (JSON/JSON5/YAML parsed as objects, other files as strings)
 2. **Validation**: Check required fields (`files`, `repos`), validate file names (no path traversal)
 3. **Git Array Expansion**: `git: [url1, url2]` becomes two separate repo entries
 4. **Content Merge**: For each file, per-repo `content` overlays onto root-level file `content` using deep merge
@@ -52,12 +52,12 @@ Raw YAML → Parse → Resolve file refs → Validate → Expand git arrays → 
 
 - String content: `content: "line1\nline2"` or multiline `content: |-`
 - Lines array: `content: ["line1", "line2"]` - supports merge strategies (append/prepend/replace)
-- Validation enforces: `.json`/`.yaml`/`.yml` must have object content; other extensions must have string/string[] content
+- Validation enforces: `.json`/`.json5`/`.yaml`/`.yml` must have object content; other extensions must have string/string[] content
 
 **File References**: Use `content: "@path/to/file"` to load content from external template files:
 
 - Paths are relative to the config file's directory
-- JSON/YAML files are parsed as objects; other files are returned as strings
+- JSON/JSON5/YAML files are parsed as objects; other files are returned as strings
 - Resolved before validation, so content type checking works on resolved content
 - Per-repo overlays can merge onto resolved file content
 - Security: paths restricted to config directory tree (no `../` escapes, no absolute paths)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm downloads](https://img.shields.io/npm/dw/@aspruyt/json-config-sync.svg)](https://www.npmjs.com/package/@aspruyt/json-config-sync)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A CLI tool that syncs JSON, YAML, or text configuration files across multiple GitHub and Azure DevOps repositories by creating pull requests. Output format is automatically detected from the target filename extension (`.json` → JSON, `.yaml`/`.yml` → YAML, other → text).
+A CLI tool that syncs JSON, JSON5, YAML, or text configuration files across multiple GitHub and Azure DevOps repositories by creating pull requests. Output format is automatically detected from the target filename extension (`.json` → JSON, `.json5` → JSON5, `.yaml`/`.yml` → YAML, other → text).
 
 ## Table of Contents
 
@@ -536,7 +536,7 @@ repos:
 - **String content** (`content: |-`) - Direct text output with environment variable interpolation. Merging always replaces the base.
 - **Lines array** (`content: ['line1', 'line2']`) - Each line joined with newlines. Supports merge strategies (`append`, `prepend`, `replace`).
 
-**Validation:** JSON/YAML file extensions (`.json`, `.yaml`, `.yml`) require object content. Other extensions require string or string[] content.
+**Validation:** JSON/JSON5/YAML file extensions (`.json`, `.json5`, `.yaml`, `.yml`) require object content. Other extensions require string or string[] content.
 
 ### Executable Files
 
@@ -630,7 +630,7 @@ repos:
 
 - File references start with `@` followed by a relative path
 - Paths are resolved relative to the config file's directory
-- JSON/YAML files are parsed as objects, other files as strings
+- JSON/JSON5/YAML files are parsed as objects, other files as strings
 - Metadata fields (`header`, `schemaUrl`, `createOnly`, `mergeStrategy`) remain in the config
 - Per-repo overlays still work - they merge onto the resolved file content
 
@@ -728,7 +728,7 @@ flowchart TB
 
     subgraph Processing["For Each Repository"]
         CLONE[Clone Repo] --> BRANCH[Create/Checkout Branch<br/>--branch or chore/sync-config]
-        BRANCH --> WRITE[Write All Config Files<br/>JSON or YAML]
+        BRANCH --> WRITE[Write All Config Files<br/>JSON, JSON5, or YAML]
         WRITE --> CHECK{Changes?}
         CHECK -->|No| SKIP[Skip - No Changes]
         CHECK -->|Yes| COMMIT[Commit Changes]
@@ -758,7 +758,7 @@ For each repository in the config, the tool:
 4. Cleans the temporary workspace
 5. Clones the repository
 6. Creates/checks out branch (custom `--branch` or default `chore/sync-config`)
-7. Writes all config files (JSON or YAML based on filename extension)
+7. Writes all config files (JSON, JSON5, or YAML based on filename extension)
 8. Checks for changes (skips if no changes)
 9. Commits and pushes changes
 10. Creates a pull request

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^14.0.2",
+        "json5": "^2.2.3",
         "p-retry": "^7.1.1",
         "yaml": "^2.4.5"
       },
@@ -579,6 +580,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/p-retry": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^14.0.2",
+    "json5": "^2.2.3",
     "p-retry": "^7.1.1",
     "yaml": "^2.4.5"
   },

--- a/src/config-formatter.ts
+++ b/src/config-formatter.ts
@@ -1,6 +1,6 @@
 import { Document, stringify } from "yaml";
 
-export type OutputFormat = "json" | "yaml";
+export type OutputFormat = "json" | "json5" | "yaml";
 
 /**
  * Options for content conversion.
@@ -17,6 +17,9 @@ export function detectOutputFormat(fileName: string): OutputFormat {
   const ext = fileName.toLowerCase().split(".").pop();
   if (ext === "yaml" || ext === "yml") {
     return "yaml";
+  }
+  if (ext === "json5") {
+    return "json5";
   }
   return "json";
 }
@@ -128,6 +131,12 @@ export function convertContentToString(
     }
 
     return stringify(doc, { indent: 2 });
+  }
+
+  if (format === "json5") {
+    // JSON5 format - output standard JSON (which is valid JSON5)
+    // Using JSON.stringify for standard JSON output that's compatible everywhere
+    return JSON.stringify(content, null, 2) + "\n";
   }
 
   // JSON format - comments not supported, ignore header/schemaUrl

--- a/src/config-validator.test.ts
+++ b/src/config-validator.test.ts
@@ -717,6 +717,29 @@ describe("validateRawConfig", () => {
       );
     });
 
+    test("accepts object content for .json5 files", () => {
+      const config: RawConfig = {
+        files: {
+          "config.json5": { content: { key: "value" } },
+        },
+        repos: [{ git: "git@github.com:org/repo.git" }],
+      };
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("throws when JSON5 file has string content", () => {
+      const config: RawConfig = {
+        files: {
+          "config.json5": { content: "string content" as never },
+        },
+        repos: [{ git: "git@github.com:org/repo.git" }],
+      };
+      assert.throws(
+        () => validateRawConfig(config),
+        /has JSON\/YAML extension but string content/,
+      );
+    });
+
     test("throws when text file has object content", () => {
       const config: RawConfig = {
         files: {

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -28,7 +28,7 @@ function isObjectContent(content: unknown): boolean {
  */
 function isStructuredFileExtension(fileName: string): boolean {
   const ext = fileName.toLowerCase().split(".").pop();
-  return ext === "json" || ext === "yaml" || ext === "yml";
+  return ext === "json" || ext === "json5" || ext === "yaml" || ext === "yml";
 }
 
 /**

--- a/src/file-reference-resolver.test.ts
+++ b/src/file-reference-resolver.test.ts
@@ -152,6 +152,33 @@ describe("File Reference Resolver", () => {
         /Invalid YAML in "@templates\/invalid.yaml"/,
       );
     });
+
+    test("resolves JSON5 file to parsed object", () => {
+      const json5Path = join(testDir, "templates", "config.json5");
+      // JSON5 allows comments and trailing commas
+      writeFileSync(
+        json5Path,
+        `{
+  // This is a comment
+  "key": "value",
+  "num": 42,
+}`,
+        "utf-8",
+      );
+
+      const result = resolveFileReference("@templates/config.json5", testDir);
+      assert.deepStrictEqual(result, { key: "value", num: 42 });
+    });
+
+    test("throws on invalid JSON5 with clear error", () => {
+      const invalidPath = join(testDir, "templates", "invalid.json5");
+      writeFileSync(invalidPath, "{ invalid json5", "utf-8");
+
+      assert.throws(
+        () => resolveFileReference("@templates/invalid.json5", testDir),
+        /Invalid JSON5 in "@templates\/invalid.json5"/,
+      );
+    });
   });
 
   describe("resolveFileReferencesInConfig", () => {

--- a/src/file-reference-resolver.ts
+++ b/src/file-reference-resolver.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve, isAbsolute, normalize, extname } from "node:path";
+import JSON5 from "json5";
 import { parse as parseYaml } from "yaml";
 import type { ContentValue, RawConfig } from "./config.js";
 
@@ -70,6 +71,14 @@ export function resolveFileReference(
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       throw new Error(`Invalid JSON in "${reference}": ${msg}`);
+    }
+  }
+  if (ext === ".json5") {
+    try {
+      return JSON5.parse(content) as Record<string, unknown>;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid JSON5 in "${reference}": ${msg}`);
     }
   }
   if (ext === ".yaml" || ext === ".yml") {


### PR DESCRIPTION
## Summary

- Add support for `.json5` files as a structured output format
- Add `json5` dependency for parsing `.json5` template files
- Recognize `.json5` as structured file extension (allows object content)
- Parse `@path/to/file.json5` template references (supports comments, trailing commas)
- Output uses standard JSON (valid JSON5, compatible everywhere)

## Test plan

- [x] All unit tests pass (626 tests)
- [x] Build succeeds
- [x] `.json5` files accept object content
- [x] `.json5` template files with comments can be parsed
- [x] Format detection returns `json5` for `.json5` extension

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)