### PR TITLE
fix: git update-index --chmod fails on new files (#70)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Raw YAML → Parse → Resolve file refs → Validate → Expand git arrays → 
 
 **Subdirectory Support**: File names can include paths (e.g., `.github/workflows/ci.yml`). Parent directories are created automatically. Quote paths containing `/` in YAML keys.
 
-**Executable Files**: Files ending in `.sh` are auto-marked executable via `git update-index --chmod=+x`. Use `executable: false` to disable. Non-.sh files can be marked executable with `executable: true`. Per-repo can override root-level `executable` setting.
+**Executable Files**: Files ending in `.sh` are auto-marked executable via `git update-index --add --chmod=+x`. Use `executable: false` to disable. Non-.sh files can be marked executable with `executable: true`. Per-repo can override root-level `executable` setting.
 
 ### Deep Merge (merge.ts)
 

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ repos:
 
 ### Executable Files
 
-Shell scripts (`.sh` files) are automatically marked as executable using `git update-index --chmod=+x`. You can control this behavior:
+Shell scripts (`.sh` files) are automatically marked as executable using `git update-index --add --chmod=+x`. You can control this behavior:
 
 ```yaml
 files:

--- a/config-schema.json
+++ b/config-schema.json
@@ -84,7 +84,7 @@
         },
         "executable": {
           "type": "boolean",
-          "description": "Mark the file as executable via git update-index --chmod=+x. Shell scripts (.sh) are auto-executable unless explicitly set to false. Non-.sh files can be marked executable by setting to true."
+          "description": "Mark the file as executable via git update-index --add --chmod=+x. Shell scripts (.sh) are auto-executable unless explicitly set to false. Non-.sh files can be marked executable by setting to true."
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aspruyt/json-config-sync",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aspruyt/json-config-sync",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspruyt/json-config-sync",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "CLI tool to sync JSON or YAML configuration files across multiple GitHub and Azure DevOps repositories",
   "type": "module",
   "main": "dist/index.js",

--- a/src/git-ops.test.ts
+++ b/src/git-ops.test.ts
@@ -572,7 +572,7 @@ describe("GitOps", () => {
       await gitOps.setExecutable("script.sh");
 
       assert.equal(commands.length, 1);
-      assert.ok(commands[0].includes("git update-index --chmod=+x"));
+      assert.ok(commands[0].includes("git update-index --add --chmod=+x"));
       assert.ok(commands[0].includes("script.sh"));
     });
 

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -158,7 +158,7 @@ export class GitOps {
     // Use relative path from workDir for git command
     const relativePath = relative(this.workDir, filePath);
     await this.exec(
-      `git update-index --chmod=+x ${escapeShellArg(relativePath)}`,
+      `git update-index --add --chmod=+x ${escapeShellArg(relativePath)}`,
       this.workDir,
     );
   }


### PR DESCRIPTION
## Summary
- Fixes #70 - `git update-index --chmod=+x` fails on new files that haven't been staged yet
- Added `--add` flag to allow the file to be added to the index in the same operation
- Updated tests and documentation

## Changes
- `src/git-ops.ts`: Added `--add` flag to `git update-index` command
- `src/git-ops.test.ts`: Updated test assertion
- Documentation: Updated `CLAUDE.md`, `README.md`, `config-schema.json`
- Version bump: 3.10.0 → 3.10.1

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (631 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)