### PR TITLE
fix: isolated sync attempts with fresh branch each run

### DIFF
--- a/fixtures/integration-test-createonly.yaml
+++ b/fixtures/integration-test-createonly.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/json-config-sync/main/config-schema.json
+# Integration test config - tests createOnly behavior against base branch
+files:
+  createonly-test.json:
+    createOnly: true
+    content:
+      newContent: true
+      shouldNotAppear: "because file already exists on main"
+
+repos:
+  - git: https://github.com/anthony-spruyt/json-config-sync-test.git
+    branch: chore/sync-createonly-test

--- a/src/command-executor.ts
+++ b/src/command-executor.ts
@@ -29,9 +29,16 @@ export class ShellCommandExecutor implements CommandExecutor {
       }).trim();
     } catch (error) {
       // Ensure stderr is always a string for consistent error handling
-      const execError = error as { stderr?: Buffer | string };
+      const execError = error as {
+        stderr?: Buffer | string;
+        message?: string;
+      };
       if (execError.stderr && typeof execError.stderr !== "string") {
         execError.stderr = execError.stderr.toString();
+      }
+      // Include stderr in error message for better debugging
+      if (execError.stderr && execError.message) {
+        execError.message = `${execError.message}\n${execError.stderr}`;
       }
       throw error;
     }

--- a/src/git-ops.test.ts
+++ b/src/git-ops.test.ts
@@ -446,42 +446,18 @@ describe("GitOps", () => {
     });
   });
 
-  describe("createBranch error handling", () => {
+  describe("createBranch", () => {
     beforeEach(() => {
       mkdirSync(workDir, { recursive: true });
     });
 
-    test("throws on fetch/checkout failure that is NOT branch-not-found", async () => {
-      // Simulate an auth failure during fetch (not a missing branch)
-      const gitOps = new GitOps({
-        workDir,
-        executor: {
-          async exec(command: string, _cwd: string): Promise<string> {
-            if (command.includes("git fetch")) {
-              throw new Error("Permission denied (publickey)");
-            }
-            return "";
-          },
-        },
-        retries: 0,
-      });
-
-      await assert.rejects(
-        async () => gitOps.createBranch("feature-branch"),
-        /Failed to fetch\/checkout branch.*Permission denied/,
-      );
-    });
-
-    test("creates new branch when fetch indicates branch not found", async () => {
+    test("creates new branch with checkout -b", async () => {
       let checkoutBCalled = false;
 
       const gitOps = new GitOps({
         workDir,
         executor: {
           async exec(command: string, _cwd: string): Promise<string> {
-            if (command.includes("git fetch")) {
-              throw new Error("couldn't find remote ref feature-branch");
-            }
             if (command.includes("git checkout -b")) {
               checkoutBCalled = true;
               return "";
@@ -501,9 +477,6 @@ describe("GitOps", () => {
         workDir,
         executor: {
           async exec(command: string, _cwd: string): Promise<string> {
-            if (command.includes("git fetch")) {
-              throw new Error("pathspec 'feature-branch' did not match any");
-            }
             if (command.includes("git checkout -b")) {
               throw new Error(
                 "fatal: A branch named 'feature-branch' already exists",
@@ -519,36 +492,6 @@ describe("GitOps", () => {
         async () => gitOps.createBranch("feature-branch"),
         /Failed to create branch.*already exists/,
       );
-    });
-
-    test("reuses existing branch when fetch and checkout succeed", async () => {
-      let checkoutBCalled = false;
-      let checkoutCalled = false;
-
-      const gitOps = new GitOps({
-        workDir,
-        executor: {
-          async exec(command: string, _cwd: string): Promise<string> {
-            if (command.includes("git fetch origin")) {
-              return "";
-            }
-            if (command.includes("git checkout -b")) {
-              checkoutBCalled = true;
-              return "";
-            }
-            if (command.includes("git checkout")) {
-              checkoutCalled = true;
-              return "";
-            }
-            return "";
-          },
-        },
-        retries: 0,
-      });
-      await gitOps.createBranch("feature-branch");
-
-      assert.ok(checkoutCalled, "Should have called checkout (without -b)");
-      assert.ok(!checkoutBCalled, "Should NOT have called checkout -b");
     });
   });
 

--- a/src/repository-processor.test.ts
+++ b/src/repository-processor.test.ts
@@ -142,8 +142,17 @@ describe("RepositoryProcessor", () => {
         return true;
       }
 
-      override async commit(_message: string): Promise<void> {
-        // No-op for mock
+      override async fileExistsOnBranch(
+        _fileName: string,
+        _branch: string,
+      ): Promise<boolean> {
+        // For tests, assume file doesn't exist on base branch unless specified
+        return false;
+      }
+
+      override async commit(_message: string): Promise<boolean> {
+        // Return true to indicate commit was made
+        return true;
       }
 
       override async push(_branchName: string): Promise<void> {

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -2,10 +2,12 @@ import { RepoInfo, isGitHubRepo, isAzureDevOpsRepo } from "../repo-detector.js";
 import type { PRStrategy } from "./pr-strategy.js";
 import { GitHubPRStrategy } from "./github-pr-strategy.js";
 import { AzurePRStrategy } from "./azure-pr-strategy.js";
+import { CommandExecutor } from "../command-executor.js";
 
 export type {
   PRStrategy,
   PRStrategyOptions,
+  CloseExistingPROptions,
   PRMergeConfig,
   MergeOptions,
   MergeResult,
@@ -16,16 +18,19 @@ export { AzurePRStrategy } from "./azure-pr-strategy.js";
 
 /**
  * Factory function to get the appropriate PR strategy for a repository.
- * Note: repoInfo is passed via PRStrategyOptions.execute() rather than constructor
- * to ensure LSP compliance (all strategies have identical constructors).
+ * @param repoInfo - Repository information
+ * @param executor - Optional command executor for shell commands
  */
-export function getPRStrategy(repoInfo: RepoInfo): PRStrategy {
+export function getPRStrategy(
+  repoInfo: RepoInfo,
+  executor?: CommandExecutor,
+): PRStrategy {
   if (isGitHubRepo(repoInfo)) {
-    return new GitHubPRStrategy();
+    return new GitHubPRStrategy(executor);
   }
 
   if (isAzureDevOpsRepo(repoInfo)) {
-    return new AzurePRStrategy();
+    return new AzurePRStrategy(executor);
   }
 
   // Type exhaustiveness check - should never reach here

--- a/src/strategies/pr-strategy.ts
+++ b/src/strategies/pr-strategy.ts
@@ -36,6 +36,17 @@ export interface MergeOptions {
 }
 
 /**
+ * Options for closing an existing PR.
+ */
+export interface CloseExistingPROptions {
+  repoInfo: RepoInfo;
+  branchName: string;
+  baseBranch: string;
+  workDir: string;
+  retries?: number;
+}
+
+/**
  * Interface for PR creation strategies (platform-specific implementations).
  * Strategies focus on platform-specific logic (checkExistingPR, create, merge).
  * Use PRWorkflowExecutor for full workflow orchestration with error handling.
@@ -46,6 +57,13 @@ export interface PRStrategy {
    * @returns PR URL if exists, null otherwise
    */
   checkExistingPR(options: PRStrategyOptions): Promise<string | null>;
+
+  /**
+   * Close an existing PR and delete its branch.
+   * Used for fresh start approach - always create new PR from clean state.
+   * @returns true if PR was closed, false if no PR existed
+   */
+  closeExistingPR(options: CloseExistingPROptions): Promise<boolean>;
 
   /**
    * Create a new PR
@@ -75,6 +93,7 @@ export abstract class BasePRStrategy implements PRStrategy {
   }
 
   abstract checkExistingPR(options: PRStrategyOptions): Promise<string | null>;
+  abstract closeExistingPR(options: CloseExistingPROptions): Promise<boolean>;
   abstract create(options: PRStrategyOptions): Promise<PRResult>;
   abstract merge(options: MergeOptions): Promise<MergeResult>;
 


### PR DESCRIPTION
## Summary

- Close existing PR and delete branch before each sync (fresh start approach)
- Add `--no-verify` flag to `git commit` to skip pre-commit hooks in target repos
- Check for staged changes after `git add -A` to handle "nothing to commit" gracefully
- Fix `createOnly` to check against base branch (main) instead of working directory
- Improve error messages to include stderr for better debugging
- Add `hasStagedChanges()` and `fileExistsOnBranch()` methods to GitOps
- Add `closeExistingPR()` to PR strategies (GitHub and Azure DevOps)
- Add integration tests for re-sync and createOnly behavior

## Test plan

- [x] All 629 unit tests pass
- [x] Build compiles successfully
- [ ] Integration tests pass (CI will run these)
- [ ] Manual testing of re-sync scenario

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)