### PR TITLE
fix: quote all YAML string values for YAML 1.1 compatibility

### DIFF
--- a/src/config-formatter.ts
+++ b/src/config-formatter.ts
@@ -130,7 +130,15 @@ export function convertContentToString(
       }
     }
 
-    return stringify(doc, { indent: 2 });
+    // Quote all string values for YAML 1.1 compatibility.
+    // The yaml library outputs YAML 1.2 where "06:00" is a plain string,
+    // but many tools (e.g., Dependabot) use YAML 1.1 parsers that interpret
+    // unquoted values like "06:00" as sexagesimal (360) or "yes"/"no" as booleans.
+    return stringify(doc, {
+      indent: 2,
+      defaultStringType: "QUOTE_DOUBLE",
+      defaultKeyType: "PLAIN",
+    });
   }
 
   if (format === "json5") {


### PR DESCRIPTION
## Summary
- Quote all YAML string values using `defaultStringType: "QUOTE_DOUBLE"` to ensure YAML 1.1 compatibility
- Keep keys unquoted with `defaultKeyType: "PLAIN"`
- Prevents misinterpretation of values like `06:00` as sexagesimal (360) or `yes`/`no` as booleans

Fixes #82

## Test plan
- [x] All 636 existing tests pass
- [x] Added new tests for YAML string quoting behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)