### PR TITLE
docs: update documentation to reflect new defaults and fresh-start workflow

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Make all shell scripts executable (runs from repo root via postCreateCommand)
-sudo find . -type f -name '*.sh' -exec chmod u+x {} +
+find . -type f -name '*.sh' -exec chmod +x {} +
 
 # Change to script directory for package.json access
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/fixtures/integration-test-createonly.yaml
+++ b/fixtures/integration-test-createonly.yaml
@@ -9,4 +9,3 @@ files:
 
 repos:
   - git: https://github.com/anthony-spruyt/xfg-test.git
-    branch: chore/sync-createonly-test


### PR DESCRIPTION
## Summary
- Update CLI options table to show new defaults (auto-merge, squash, delete-branch)
- Document the fresh-start approach that closes existing PRs and deletes branches before creating new ones
- Update workflow diagram and processing steps to reflect current behavior
- Remove `sudo` from post-create.sh and use `chmod +x` for broader compatibility
- Remove per-repo branch override from integration test fixture
- Remove License section from README

## Test plan
- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm CLI options table accurately reflects current defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)