### PR TITLE
fix: only include actually changed files in PR title and commit message

### DIFF
--- a/fixtures/integration-test-unchanged.yaml
+++ b/fixtures/integration-test-unchanged.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
+# Integration test config - tests that unchanged files are not included in PR
+# This test has two files:
+# - unchanged-test.json: content matches what's already in the repo (should not appear in PR)
+# - changed-test.json: new content (should appear in PR)
+files:
+  unchanged-test.json:
+    content:
+      unchanged: true
+  changed-test.json:
+    content:
+      changed: true
+      timestamp: test-run
+
+repos:
+  - git: https://github.com/anthony-spruyt/xfg-test.git

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -161,6 +161,21 @@ export class GitOps {
   }
 
   /**
+   * Get list of files that have changes according to git status.
+   * Returns relative file paths for files that are modified, added, or untracked.
+   * Uses the same this.exec() pattern as other methods in this class.
+   */
+  async getChangedFiles(): Promise<string[]> {
+    const status = await this.exec("git status --porcelain", this.workDir);
+    if (!status) return [];
+
+    return status
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => line.slice(3)); // Remove status prefix (e.g., " M ", "?? ", "A  ")
+  }
+
+  /**
    * Check if there are staged changes ready to commit.
    * Uses `git diff --cached --quiet` which exits with 1 if there are staged changes.
    */


### PR DESCRIPTION
## Summary

- Fixes #90 - Changed files list was rebuilt incorrectly, losing skip information
- Adds `getChangedFiles()` method to GitOps that parses `git status --porcelain`
- Updates `repository-processor.ts` to filter files by actual git changes
- Adds TDD-style integration test that proves the bug exists and verifies the fix

## Problem

In non-dry-run mode, when `hasChanges()` returns true, the code was rebuilding the `changedFiles` list by adding ALL non-skipped config files unconditionally. This happened regardless of whether each file actually changed according to git.

**Impact:**
- PR titles showed files that didn't actually change
- Commit messages listed files that had no modifications
- PR descriptions incorrectly listed unchanged files

## Solution

1. Added `getChangedFiles()` method to `GitOps` that returns actual changed files from `git status --porcelain`
2. Updated the rebuild logic in `repository-processor.ts` to only include files that are in BOTH the config AND git's changed files list

## Test plan

- [x] Integration test `"PR title only includes files that actually changed (issue #90)"` - creates scenario with 2 files where one matches existing content
- [x] Test fails before fix (PR title shows both files)
- [x] Test passes after fix (PR title shows only changed file)
- [x] All 638 unit tests pass
- [x] All 4 integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)