### PR TITLE
docs: add design note explaining change detection tradeoff

### DIFF
--- a/src/repository-processor.ts
+++ b/src/repository-processor.ts
@@ -124,6 +124,17 @@ export class RepositoryProcessor {
       await this.gitOps.createBranch(branchName);
 
       // Step 5: Write all config files and track changes
+      //
+      // DESIGN NOTE: Change detection differs between dry-run and normal mode:
+      // - Dry-run: Uses wouldChange() for read-only content comparison (no side effects)
+      // - Normal: Uses git status after writing (source of truth for what git will commit)
+      //
+      // This is intentional. git status is more accurate because it respects .gitattributes
+      // (line ending normalization, filters) and detects executable bit changes. However,
+      // it requires actually writing files, which defeats dry-run's purpose.
+      //
+      // For config files (JSON/YAML), these approaches produce identical results in practice.
+      // Edge cases (repos with unusual git attributes on config files) are essentially nonexistent.
       const changedFiles: FileAction[] = [];
 
       for (const file of repoConfig.files) {


### PR DESCRIPTION
## Summary
- Add code comment explaining why dry-run and normal mode use different change detection methods
- Documents the intentional tradeoff: `git status` is more accurate but requires writing files, while `wouldChange()` enables read-only dry-run mode

Closes #91

## Test plan
- [x] Comment accurately describes the code behavior
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.ai/code)