### PR TITLE
fix: use strict regex for PR URL extraction (#92)

### DIFF
--- a/src/strategies/github-pr-strategy.ts
+++ b/src/strategies/github-pr-strategy.ts
@@ -120,11 +120,17 @@ export class GitHubPRStrategy extends BasePRStrategy {
         { retries },
       );
 
-      // Extract URL from output
-      const urlMatch = result.match(/https:\/\/github\.com\/[^\s]+/);
+      // Extract URL from output - use strict regex for valid PR URLs only
+      const urlMatch = result.match(
+        /https:\/\/github\.com\/[\w-]+\/[\w.-]+\/pull\/\d+/,
+      );
+
+      if (!urlMatch) {
+        throw new Error(`Could not parse PR URL from output: ${result}`);
+      }
 
       return {
-        url: urlMatch?.[0] ?? result,
+        url: urlMatch[0],
         success: true,
         message: "PR created successfully",
       };


### PR DESCRIPTION
## Summary
- Uses stricter regex `/pull/\d+` to only match valid GitHub PR URLs
- Throws error when PR URL cannot be parsed instead of returning malformed data
- Adds 5 TDD tests proving the fix handles edge cases (no URL, trailing punctuation, non-PR URLs)

Fixes #92

## Test plan
- [x] All 643 existing tests pass
- [x] New edge case tests verify:
  - Output with no URL throws error
  - Trailing punctuation not captured
  - Issue/commit URLs rejected
  - Valid PR URLs with trailing newlines handled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)