### PR TITLE
fix: add runtime type check for mergeTextContent (#94)

### DIFF
--- a/src/config-normalizer.test.ts
+++ b/src/config-normalizer.test.ts
@@ -794,6 +794,30 @@ describe("normalizeConfig", () => {
     });
   });
 
+  describe("type safety", () => {
+    test("throws when merging text base with object overlay", () => {
+      const raw: RawConfig = {
+        files: {
+          ".gitignore": { content: "node_modules" }, // text content
+        },
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              // @ts-expect-error - intentionally testing runtime type mismatch
+              ".gitignore": { content: { invalid: "object" } }, // object content - type mismatch
+            },
+          },
+        ],
+      };
+
+      assert.throws(
+        () => normalizeConfig(raw),
+        /Expected text content for .gitignore, got object/,
+      );
+    });
+  });
+
   describe("executable propagation", () => {
     test("passes root-level executable: true to FileContent", () => {
       const raw: RawConfig = {

--- a/src/config-normalizer.ts
+++ b/src/config-normalizer.ts
@@ -115,10 +115,15 @@ export function normalizeConfig(raw: RawConfig): Config {
         } else {
           // Merge mode: handle text vs object content
           if (isTextContent(fileConfig.content)) {
-            // Text content merging
+            // Text content merging - validate overlay is also text
+            if (!isTextContent(repoOverride.content)) {
+              throw new Error(
+                `Expected text content for ${fileName}, got object`,
+              );
+            }
             mergedContent = mergeTextContent(
               fileConfig.content,
-              repoOverride.content as string | string[],
+              repoOverride.content,
               fileStrategy,
             );
           } else {


### PR DESCRIPTION
## Summary
- Add runtime type guard check before calling `mergeTextContent` to validate overlay content type
- Replace unsafe `as string | string[]` cast with proper validation
- Throw clear error message when text base content is merged with object overlay

Closes #94

## Test plan
- [x] Added test case that verifies type mismatch throws error
- [x] All 644 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)