### PR TITLE
fix: use path.extname() for robust file extension check (#96)

### DIFF
--- a/src/config-validator.test.ts
+++ b/src/config-validator.test.ts
@@ -632,6 +632,16 @@ describe("validateRawConfig", () => {
   });
 
   describe("text file content validation", () => {
+    test("file named 'json' without extension is text file", () => {
+      const config: RawConfig = {
+        files: {
+          json: { content: "some text content" }, // file named "json" with no extension
+        },
+        repos: [{ git: "git@github.com:org/repo.git" }],
+      };
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
     test("accepts string content for text files", () => {
       const config: RawConfig = {
         files: {

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -1,4 +1,4 @@
-import { isAbsolute } from "node:path";
+import { extname, isAbsolute } from "node:path";
 import type { RawConfig } from "./config.js";
 
 const VALID_STRATEGIES = ["replace", "append", "prepend"];
@@ -27,8 +27,10 @@ function isObjectContent(content: unknown): boolean {
  * Check if file extension is for structured output (JSON/YAML).
  */
 function isStructuredFileExtension(fileName: string): boolean {
-  const ext = fileName.toLowerCase().split(".").pop();
-  return ext === "json" || ext === "json5" || ext === "yaml" || ext === "yml";
+  const ext = extname(fileName).toLowerCase();
+  return (
+    ext === ".json" || ext === ".json5" || ext === ".yaml" || ext === ".yml"
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace fragile `.split(".").pop()` pattern with `path.extname()` for file extension detection
- Fixes edge case where file named "json" (no extension) was incorrectly treated as structured JSON file
- Added test case to prevent regression

Closes #96

## Test plan
- [x] Added failing test first (TDD red phase)
- [x] Verified test fails with old implementation
- [x] Implemented fix using `path.extname()`
- [x] All 645 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)