### PR TITLE
fix: add null byte validation to escapeShellArg for defense-in-depth (#95)

### DIFF
--- a/src/shell-utils.test.ts
+++ b/src/shell-utils.test.ts
@@ -158,10 +158,11 @@ describe("escapeShellArg", () => {
       assert.strictEqual(escaped, "'$(cat /etc/passwd)'");
     });
 
-    test("handles null bytes", () => {
+    test("throws on null bytes", () => {
       const withNull = "test\x00injected";
-      const escaped = escapeShellArg(withNull);
-      assert.strictEqual(escaped, "'test\x00injected'");
+      assert.throws(() => escapeShellArg(withNull), {
+        message: "Shell argument contains null byte",
+      });
     });
   });
 });

--- a/src/shell-utils.ts
+++ b/src/shell-utils.ts
@@ -6,6 +6,10 @@
  * @returns The escaped string wrapped in single quotes
  */
 export function escapeShellArg(arg: string): string {
+  // Defense-in-depth: reject null bytes even if upstream validation should catch them
+  if (arg.includes("\0")) {
+    throw new Error("Shell argument contains null byte");
+  }
   // Use single quotes and escape any single quotes within
   // 'string' -> quote ends, escaped quote, quote starts again
   return `'${arg.replace(/'/g, "'\\''")}'`;


### PR DESCRIPTION
## Summary
- Add defense-in-depth null byte validation directly in `escapeShellArg()` rather than relying solely on upstream validation in `config-validator.ts`
- Throws `"Shell argument contains null byte"` error when null bytes are detected

Fixes #95

## Test plan
- [x] Updated existing test to verify `escapeShellArg` throws on null bytes
- [x] All 645 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)