### PR TITLE
fix: throw error when PR number extraction fails in closeExistingPR (#93)

### DIFF
--- a/src/strategies/github-pr-strategy.ts
+++ b/src/strategies/github-pr-strategy.ts
@@ -72,10 +72,7 @@ export class GitHubPRStrategy extends BasePRStrategy {
     // Extract PR number from URL
     const prNumber = existingUrl.match(/\/pull\/(\d+)/)?.[1];
     if (!prNumber) {
-      logger.info(
-        `Warning: Could not extract PR number from URL: ${existingUrl}`,
-      );
-      return false;
+      throw new Error(`Could not extract PR number from URL: ${existingUrl}`);
     }
 
     // Close the PR and delete the branch


### PR DESCRIPTION
## Summary
- Fixed bug where `closeExistingPR` returned `false` when PR number extraction failed, incorrectly suggesting no PR exists
- Changed to throw an error instead, preventing potential duplicate PR creation
- Added comprehensive test coverage for `closeExistingPR` method

Fixes #93

## Test plan
- [x] Run `npm test` - all 649 tests pass
- [x] New test verifies error is thrown when PR URL format is invalid
- [x] Added tests for other closeExistingPR scenarios (no PR exists, PR closed successfully, close command fails)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)