### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aspruyt/xfg",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aspruyt/xfg",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspruyt/xfg",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CLI tool to sync JSON or YAML configuration files across multiple GitHub, Azure DevOps, and GitLab repositories",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Release v1.2.0 - GitLab platform support

### New Features
- Add GitLab as third platform alongside GitHub and Azure DevOps
- Support for GitLab merge requests via `glab` CLI
- Support for nested groups (e.g., `org/group/subgroup/repo`)
- Support for self-hosted GitLab instances

### Bug Fixes
- Fix Azure `buildPRUrl` to trim whitespace from PR ID
- Fix ReDoS vulnerability in GitLab MR URL regex

### Other
- Add `glab` CLI installation to devcontainer
- Comprehensive test coverage (739 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)