### PR TITLE
fix: improve test assertions and error messages

### DIFF
--- a/src/config-formatter.test.ts
+++ b/src/config-formatter.test.ts
@@ -19,7 +19,7 @@ describe("detectOutputFormat", () => {
 
   test("returns yaml for .yml extension", () => {
     const result = detectOutputFormat("config.yml");
-    assert.equal(result, "yml" === "yml" ? "yaml" : "json");
+    assert.equal(result, "yaml");
   });
 
   test("handles uppercase extensions", () => {

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -161,7 +161,8 @@ export function validateRawConfig(config: RawConfig): void {
 
         if (fileOverride.override && !fileOverride.content) {
           throw new Error(
-            `Repo ${getGitDisplayName(repo.git)} has override: true for file '${fileName}' but no content defined`,
+            `Repo ${getGitDisplayName(repo.git)} has override: true for file '${fileName}' but no content defined. ` +
+              `Use content: "" for an empty text file override, or content: {} for an empty JSON/YAML override.`,
           );
         }
 

--- a/src/diff-utils.test.ts
+++ b/src/diff-utils.test.ts
@@ -25,41 +25,59 @@ describe("getFileStatus", () => {
 });
 
 describe("formatStatusBadge", () => {
-  test("returns colored badge for NEW status", () => {
+  test("returns badge with correct text for NEW status", () => {
     const badge = formatStatusBadge("NEW");
-    assert.ok(badge.includes("NEW"));
+    assert.ok(
+      badge.includes("[NEW]"),
+      "Badge should contain [NEW] in brackets",
+    );
   });
 
-  test("returns colored badge for MODIFIED status", () => {
+  test("returns badge with correct text for MODIFIED status", () => {
     const badge = formatStatusBadge("MODIFIED");
-    assert.ok(badge.includes("MODIFIED"));
+    assert.ok(
+      badge.includes("[MODIFIED]"),
+      "Badge should contain [MODIFIED] in brackets",
+    );
   });
 
-  test("returns colored badge for UNCHANGED status", () => {
+  test("returns badge with correct text for UNCHANGED status", () => {
     const badge = formatStatusBadge("UNCHANGED");
-    assert.ok(badge.includes("UNCHANGED"));
+    assert.ok(
+      badge.includes("[UNCHANGED]"),
+      "Badge should contain [UNCHANGED] in brackets",
+    );
   });
 });
 
 describe("formatDiffLine", () => {
-  test("formats addition lines in green", () => {
+  test("formats addition lines", () => {
     const result = formatDiffLine("+added line");
-    assert.ok(result.includes("+added line"));
+    assert.ok(result.includes("+added line"), "Result should contain the line");
   });
 
-  test("formats deletion lines in red", () => {
+  test("formats deletion lines", () => {
     const result = formatDiffLine("-deleted line");
-    assert.ok(result.includes("-deleted line"));
+    assert.ok(
+      result.includes("-deleted line"),
+      "Result should contain the line",
+    );
   });
 
-  test("formats hunk headers in cyan", () => {
+  test("formats hunk headers", () => {
     const result = formatDiffLine("@@ -1,3 +1,4 @@");
-    assert.ok(result.includes("@@ -1,3 +1,4 @@"));
+    assert.ok(
+      result.includes("@@ -1,3 +1,4 @@"),
+      "Result should contain hunk header",
+    );
   });
 
   test("returns context lines unchanged", () => {
     const result = formatDiffLine(" context line");
-    assert.ok(result.includes(" context line"));
+    assert.ok(
+      result.includes(" context line"),
+      "Result should contain context line",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove tautological ternary in config-formatter.test.ts that always evaluated to "yaml"
- Improve formatStatusBadge tests to verify bracket format `[STATUS]`
- Clarify formatDiffLine test names (chalk doesn't output ANSI codes in non-TTY environments)
- Improve config-validator error message to guide users on empty override files

## Test plan

- [x] All 739 unit tests pass
- [x] Changes are backwards compatible

🤖 Generated with [Claude Code](https://claude.ai/claude-code)