### PR TITLE
fix: prevent integration tests from running in parallel across refs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: integration-github-${{ github.ref }}
+      group: integration-github
       cancel-in-progress: false
 
     steps:
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: integration-ado-${{ github.ref }}
+      group: integration-ado
       cancel-in-progress: false
 
     steps:
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: integration-gitlab-${{ github.ref }}
+      group: integration-gitlab
       cancel-in-progress: false
 
     steps:


### PR DESCRIPTION
## Summary
- Removes `${{ github.ref }}` from integration test concurrency groups
- Tests now queue globally per platform rather than per-ref
- Prevents concurrent runs from interfering with shared test repositories

## Problem
When a release tag is pushed while a main branch merge is running (or vice versa), integration tests could run in parallel because they had different concurrency groups:
- Tag `v1.4.0` → `integration-github-refs/tags/v1.4.0`
- Main branch → `integration-github-refs/heads/main`

## Solution
Change concurrency groups to a fixed name without the ref:
- `integration-github`
- `integration-ado`
- `integration-gitlab`

## Test plan
- [ ] CI passes on this PR
- [ ] Verify the workflow syntax is valid

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)