### PR TITLE
docs: add use cases section for SEO and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,34 @@ xfg --config ./config.yaml
 - **Error Resilience** - Continues processing if individual repos fail
 - **Automatic Retries** - Retries transient network errors with exponential backoff
 
+## Use Cases
+
+### Platform Engineering Teams
+
+Enforce organization-wide standards without requiring a monorepo. Push consistent tooling configs (linters, formatters, TypeScript settings) to hundreds of microservice repos from a single source of truth.
+
+### CI/CD Workflow Standardization
+
+Keep GitHub Actions workflows, Azure Pipelines, or GitLab CI configs in sync across all repos. Update a workflow once, create PRs everywhere.
+
+### Security & Compliance Governance
+
+Roll out security scanning configs (Dependabot, CodeQL, SAST tools) or compliance policies across your entire organization. Audit and update security settings from one place.
+
+### Developer Experience Consistency
+
+Sync `.editorconfig`, `.prettierrc`, `tsconfig.json`, and other DX configs so every repo feels the same. Onboard new team members faster with consistent tooling.
+
+### Open Source Maintainers
+
+Manage configuration across multiple related projects. Keep issue templates, contributing guidelines, and CI workflows consistent across your ecosystem.
+
+### Configuration Drift Prevention
+
+Detect and fix configuration drift automatically. Run xfg on a schedule to ensure repos stay in compliance with your standards.
+
+**[See detailed use cases with examples →](https://anthony-spruyt.github.io/xfg/use-cases/)**
+
 ## Documentation
 
 Visit **[anthony-spruyt.github.io/xfg](https://anthony-spruyt.github.io/xfg/)** for:

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,8 @@ xfg --config ./config.yaml
 - **Error Resilience** - Continues processing if individual repos fail
 - **Automatic Retries** - Retries transient network errors with exponential backoff
 
+**See [Use Cases](use-cases.md)** for real-world scenarios: platform engineering, CI/CD standardization, security governance, and more.
+
 ## How It Works
 
 ```mermaid

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,295 @@
+# Use Cases
+
+xfg solves the challenge of keeping configuration files consistent across many Git repositories. Here are common scenarios where it helps.
+
+## Platform Engineering Teams
+
+**Problem:** You have dozens or hundreds of microservices, each in its own repository. Keeping tooling configs consistent is a nightmare of manual PRs or copy-paste drift.
+
+**Solution:** Define your organization's standard configs once and sync them everywhere:
+
+```yaml
+files:
+  .prettierrc.json:
+    content:
+      semi: false
+      singleQuote: true
+      printWidth: 100
+
+  tsconfig.json:
+    content:
+      compilerOptions:
+        target: ES2022
+        module: NodeNext
+        strict: true
+
+  .eslintrc.json:
+    content:
+      extends: ["@your-org/eslint-config"]
+
+repos:
+  - git:
+      - git@github.com:your-org/service-auth.git
+      - git@github.com:your-org/service-payments.git
+      - git@github.com:your-org/service-notifications.git
+      # ... hundreds more
+```
+
+Run `xfg` whenever standards change—PRs are created automatically for review.
+
+---
+
+## CI/CD Workflow Standardization
+
+**Problem:** Your GitHub Actions workflows have diverged across repos. Some have outdated Node versions, others are missing security scans, and updating them all manually would take days.
+
+**Solution:** Sync workflow files to subdirectories:
+
+```yaml
+files:
+  ".github/workflows/ci.yaml":
+    content:
+      name: CI
+      on: [push, pull_request]
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                node-version: "20"
+            - run: npm ci
+            - run: npm test
+
+  ".github/dependabot.yml":
+    content:
+      version: 2
+      updates:
+        - package-ecosystem: npm
+          directory: "/"
+          schedule:
+            interval: weekly
+
+repos:
+  - git:
+      - git@github.com:your-org/frontend.git
+      - git@github.com:your-org/backend.git
+      - git@github.com:your-org/shared-libs.git
+```
+
+---
+
+## Security & Compliance Governance
+
+**Problem:** Your security team needs to roll out CodeQL scanning and Dependabot configs to all repositories. Manual enforcement doesn't scale.
+
+**Solution:** Define security configs centrally and push to all repos:
+
+```yaml
+files:
+  ".github/dependabot.yml":
+    content:
+      version: 2
+      updates:
+        - package-ecosystem: npm
+          directory: "/"
+          schedule:
+            interval: daily
+          open-pull-requests-limit: 10
+
+  ".github/workflows/codeql.yml":
+    content: "@templates/codeql-workflow.yml"
+
+  ".github/SECURITY.md":
+    content: "@templates/SECURITY.md"
+
+repos:
+  - git:
+      - git@github.com:your-org/public-api.git
+      - git@github.com:your-org/customer-portal.git
+    prOptions:
+      merge: auto # Auto-merge when checks pass
+```
+
+Use [file references](configuration/file-references.md) to load complex templates from external files.
+
+---
+
+## Developer Experience Consistency
+
+**Problem:** Every repository has slightly different formatter settings, editor configs, and tooling. Developers waste time adjusting to each repo's quirks.
+
+**Solution:** Standardize the developer experience:
+
+```yaml
+files:
+  .editorconfig:
+    content:
+      - "root = true"
+      - ""
+      - "[*]"
+      - "indent_style = space"
+      - "indent_size = 2"
+      - "end_of_line = lf"
+      - "charset = utf-8"
+      - "trim_trailing_whitespace = true"
+      - "insert_final_newline = true"
+
+  .prettierrc.json:
+    content:
+      semi: false
+      singleQuote: true
+      tabWidth: 2
+      trailingComma: es5
+
+  .prettierignore:
+    content:
+      - "dist/"
+      - "node_modules/"
+      - "coverage/"
+
+  .nvmrc:
+    content: "20"
+
+repos:
+  - git:
+      - git@github.com:your-org/repo-1.git
+      - git@github.com:your-org/repo-2.git
+```
+
+New team members get the same experience in every repo from day one.
+
+---
+
+## Open Source Project Maintainers
+
+**Problem:** You maintain multiple related open source projects. Keeping issue templates, contributing guidelines, and CI workflows consistent is tedious.
+
+**Solution:** Manage your project ecosystem from one config:
+
+```yaml
+files:
+  ".github/ISSUE_TEMPLATE/bug_report.md":
+    content: "@templates/bug-report.md"
+
+  ".github/ISSUE_TEMPLATE/feature_request.md":
+    content: "@templates/feature-request.md"
+
+  ".github/CONTRIBUTING.md":
+    content: "@templates/CONTRIBUTING.md"
+
+  ".github/workflows/ci.yaml":
+    content: "@templates/oss-ci.yaml"
+
+  LICENSE:
+    content: "@templates/MIT-LICENSE"
+
+repos:
+  - git:
+      - git@github.com:your-name/project-core.git
+      - git@github.com:your-name/project-cli.git
+      - git@github.com:your-name/project-plugins.git
+```
+
+---
+
+## Configuration Drift Prevention
+
+**Problem:** Configurations drift over time as individual repos make local changes. You need to detect and fix drift automatically.
+
+**Solution:** Run xfg on a schedule in CI:
+
+```yaml
+# .github/workflows/sync-configs.yaml
+name: Sync Configs
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 9am
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install -g @aspruyt/xfg
+      - run: xfg --config ./config.yaml
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
+```
+
+Drift is detected weekly, and PRs are created to bring repos back into compliance.
+
+---
+
+## Migrating to New Standards
+
+**Problem:** You're adopting a new tool (like switching from ESLint to Biome, or adding Renovate) and need to roll it out across many repos.
+
+**Solution:** Use `createOnly` for new files that shouldn't overwrite existing ones:
+
+```yaml
+files:
+  renovate.json:
+    createOnly: true # Only create if doesn't exist
+    content:
+      "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+      extends:
+        - "config:recommended"
+        - ":preserveSemverRanges"
+
+  biome.json:
+    content:
+      "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json"
+      organizeImports:
+        enabled: true
+      linter:
+        enabled: true
+
+repos:
+  - git:
+      - git@github.com:your-org/repo-1.git
+      - git@github.com:your-org/repo-2.git
+```
+
+---
+
+## Hybrid Teams (Multi-Platform)
+
+**Problem:** Your organization uses GitHub for open source, Azure DevOps for enterprise apps, and GitLab for internal tools. You need consistency across all platforms.
+
+**Solution:** xfg works with all three platforms in the same config:
+
+```yaml
+files:
+  .prettierrc.json:
+    content:
+      semi: false
+      singleQuote: true
+
+repos:
+  # GitHub repos
+  - git: git@github.com:your-org/oss-project.git
+
+  # Azure DevOps repos
+  - git: git@ssh.dev.azure.com:v3/your-org/project/enterprise-app
+
+  # GitLab repos (including self-hosted)
+  - git: git@gitlab.example.com:your-org/internal-tool.git
+```
+
+---
+
+## Why xfg vs. Alternatives
+
+| Approach                | Drawback                             | xfg Advantage                           |
+| ----------------------- | ------------------------------------ | --------------------------------------- |
+| **Manual PRs**          | Doesn't scale past 10 repos          | Automates PR creation                   |
+| **Monorepo**            | Major migration, not always feasible | Works with existing multi-repo setup    |
+| **Git submodules**      | Complex, poor DX                     | Simple YAML config                      |
+| **Copy-paste**          | Leads to drift                       | Enforces single source of truth         |
+| **GitHub Actions sync** | GitHub-only                          | Works with GitHub, Azure DevOps, GitLab |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Use Cases: use-cases.md
   - Getting Started:
       - Installation: getting-started/index.md
       - Prerequisites: getting-started/prerequisites.md


### PR DESCRIPTION
## Summary

- Add "Use Cases" section to README with 6 key scenarios
- Create detailed `docs/use-cases.md` page with YAML examples
- Add Use Cases to mkdocs navigation
- Link from docs home page to use cases

**Use cases covered:**
- Platform engineering teams
- CI/CD workflow standardization  
- Security & compliance governance
- Developer experience consistency
- Open source maintainers
- Configuration drift prevention

Includes comparison table: "Why xfg vs. Alternatives" (monorepo, git submodules, manual PRs, GitHub-only sync actions).

## Test plan

- [x] `mkdocs build --strict` passes
- [ ] Review rendered markdown on GitHub
- [ ] After merge, verify https://anthony-spruyt.github.io/xfg/use-cases/ loads correctly

🤖 Generated with [Claude Code](https://claude.ai/code)