### PR TITLE
feat: add GitHub Enterprise Server support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 TypeScript CLI tool that syncs JSON, JSON5, YAML, or text configuration files across multiple Git repositories by automatically creating pull requests. Output format is determined by content type: object content outputs JSON/JSON5/YAML (based on file extension), while string or string array content outputs plain text. Supports GitHub, Azure DevOps, and GitLab platforms (including self-hosted GitLab instances).
 
+## Documentation
+
+Full documentation is available at https://anthony-spruyt.github.io/xfg/
+
+The docs site is built with MkDocs Material and auto-deploys via GitHub Actions when changes are made to `docs/` or `mkdocs.yml`.
+
 ## Architecture
 
 ### Config Normalization Pipeline (config.ts)
@@ -213,7 +219,8 @@ npm run build                   # Compile TypeScript to dist/
 npm test                        # Run all unit tests
 npm run test:integration:github # Build + GitHub integration test (requires gh auth)
 npm run test:integration:ado    # Build + Azure DevOps integration test (requires az auth)
-npm run dev                     # Run with fixtures/test-repos-input.yaml
+npm run test:integration:gitlab # Build + GitLab integration test (requires glab auth)
+npm run dev                     # Run CLI via ts-node (pass config file as argument)
 ```
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ xfg --config ./config.yaml
 - **Override Mode** - Skip merging entirely for specific repos
 - **Empty Files** - Create files with no content (e.g., `.prettierignore`)
 - **YAML Comments** - Add header comments and schema directives to YAML files
-- **Multi-Platform** - Works with GitHub, Azure DevOps, and GitLab (including self-hosted)
+- **Multi-Platform** - Works with GitHub (including GitHub Enterprise Server), Azure DevOps, and GitLab (including self-hosted)
 - **Auto-Merge PRs** - Automatically merge PRs when checks pass, or force merge with admin privileges
 - **Dry-Run Mode** - Preview changes without creating PRs
 - **Error Resilience** - Continues processing if individual repos fail

--- a/config-schema.json
+++ b/config-schema.json
@@ -29,6 +29,14 @@
     "prTemplate": {
       "type": "string",
       "description": "Custom PR body template. Can be inline markdown or a file reference (@path/to/template.md relative to config file). Available placeholders: {{FILE_CHANGES}} - bulleted list of changed files with actions."
+    },
+    "githubHosts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$"
+      },
+      "description": "List of GitHub Enterprise Server hostnames. URLs matching these hosts will be treated as GitHub repositories instead of falling back to GitLab detection. Example: ['github.mycompany.com', 'ghe.internal.net']"
     }
   },
   "definitions": {

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -10,6 +10,12 @@ Before using with GitHub repositories, authenticate with the GitHub CLI:
 gh auth login
 ```
 
+For GitHub Enterprise Server instances:
+
+```bash
+gh auth login --hostname github.mycompany.com
+```
+
 !!! note "Required Scopes"
 Your token needs the `repo` scope to create PRs in target repositories.
 

--- a/docs/platforms/github.md
+++ b/docs/platforms/github.md
@@ -13,6 +13,64 @@
 gh auth login
 ```
 
+## GitHub Enterprise Server
+
+xfg supports GitHub Enterprise Server (GHE) instances in addition to github.com.
+
+### GHE URL Formats
+
+| Format | Example                                       |
+| ------ | --------------------------------------------- |
+| SSH    | `git@github.mycompany.com:owner/repo.git`     |
+| HTTPS  | `https://github.mycompany.com/owner/repo.git` |
+
+### Configuration
+
+To use GHE repositories, add the hostname(s) to the `githubHosts` array in your config:
+
+```yaml
+githubHosts:
+  - github.mycompany.com
+  - ghe.internal.net
+
+files:
+  config.json:
+    content:
+      key: value
+
+repos:
+  - git: git@github.mycompany.com:owner/repo.git
+  - git: https://ghe.internal.net/org/project.git
+```
+
+### Authentication
+
+Authenticate with each GHE instance using the `--hostname` flag:
+
+```bash
+gh auth login --hostname github.mycompany.com
+```
+
+### Mixed Environments
+
+You can use github.com and GHE repositories in the same config file:
+
+```yaml
+githubHosts:
+  - github.mycompany.com
+
+files:
+  shared-config.json:
+    content:
+      version: "1.0"
+
+repos:
+  # github.com (no config needed)
+  - git: git@github.com:myorg/public-repo.git
+  # GitHub Enterprise
+  - git: git@github.mycompany.com:myorg/private-repo.git
+```
+
 ## Required Permissions
 
 Your token needs the `repo` scope to create PRs in target repositories.

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -37,12 +37,13 @@ Or configure in `.vscode/settings.json`:
 
 ### Root Object
 
-| Field        | Type        | Required | Description                       |
-| ------------ | ----------- | -------- | --------------------------------- |
-| `files`      | `object`    | Yes      | Map of filenames to file configs  |
-| `repos`      | `array`     | Yes      | List of repository configurations |
-| `prOptions`  | `PROptions` | No       | Global PR merge options           |
-| `prTemplate` | `string`    | No       | Custom PR body template           |
+| Field         | Type        | Required | Description                        |
+| ------------- | ----------- | -------- | ---------------------------------- |
+| `files`       | `object`    | Yes      | Map of filenames to file configs   |
+| `repos`       | `array`     | Yes      | List of repository configurations  |
+| `prOptions`   | `PROptions` | No       | Global PR merge options            |
+| `prTemplate`  | `string`    | No       | Custom PR body template            |
+| `githubHosts` | `array`     | No       | GitHub Enterprise Server hostnames |
 
 ### File Config
 

--- a/src/config-normalizer.ts
+++ b/src/config-normalizer.ts
@@ -175,5 +175,6 @@ export function normalizeConfig(raw: RawConfig): Config {
   return {
     repos: expandedRepos,
     prTemplate: raw.prTemplate,
+    githubHosts: raw.githubHosts,
   };
 }

--- a/src/config-validator.test.ts
+++ b/src/config-validator.test.ts
@@ -847,6 +847,77 @@ describe("validateRawConfig", () => {
     });
   });
 
+  describe("githubHosts validation", () => {
+    test("accepts valid githubHosts array", () => {
+      const config = createValidConfig({
+        githubHosts: ["github.mycompany.com", "ghe.internal.net"],
+      });
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("accepts empty githubHosts array", () => {
+      const config = createValidConfig({
+        githubHosts: [],
+      });
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("accepts undefined githubHosts", () => {
+      const config = createValidConfig();
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("throws when githubHosts is not an array", () => {
+      const config = createValidConfig({
+        githubHosts: "github.mycompany.com" as never,
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /githubHosts must be an array of strings/,
+      );
+    });
+
+    test("throws when githubHosts contains non-strings", () => {
+      const config = createValidConfig({
+        githubHosts: ["valid.com", 123] as never,
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /githubHosts must be an array of strings/,
+      );
+    });
+
+    test("throws when githubHosts contains empty string", () => {
+      const config = createValidConfig({
+        githubHosts: ["github.mycompany.com", ""],
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /githubHosts entries must be non-empty hostnames/,
+      );
+    });
+
+    test("throws when githubHosts contains URL instead of hostname", () => {
+      const config = createValidConfig({
+        githubHosts: ["https://github.mycompany.com"],
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /githubHosts entries must be hostnames only, not URLs/,
+      );
+    });
+
+    test("throws when githubHosts contains path", () => {
+      const config = createValidConfig({
+        githubHosts: ["github.mycompany.com/path"],
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /githubHosts entries must be hostnames only/,
+      );
+    });
+  });
+
   describe("executable validation", () => {
     test("allows executable: true at root file level", () => {
       const config = createValidConfig({

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -128,6 +128,32 @@ export function validateRawConfig(config: RawConfig): void {
     throw new Error("Config missing required field: repos (must be an array)");
   }
 
+  // Validate githubHosts if provided
+  if (config.githubHosts !== undefined) {
+    if (
+      !Array.isArray(config.githubHosts) ||
+      !config.githubHosts.every((h) => typeof h === "string")
+    ) {
+      throw new Error("githubHosts must be an array of strings");
+    }
+
+    for (const host of config.githubHosts) {
+      if (!host) {
+        throw new Error("githubHosts entries must be non-empty hostnames");
+      }
+      if (host.includes("://")) {
+        throw new Error(
+          `githubHosts entries must be hostnames only, not URLs. Got: ${host}`,
+        );
+      }
+      if (host.includes("/")) {
+        throw new Error(
+          `githubHosts entries must be hostnames only, not paths. Got: ${host}`,
+        );
+      }
+    }
+  }
+
   // Validate each repo
   for (let i = 0; i < config.repos.length; i++) {
     const repo = config.repos[i];

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,7 @@ export interface RawConfig {
   repos: RawRepoConfig[];
   prOptions?: PRMergeOptions;
   prTemplate?: string;
+  githubHosts?: string[];
 }
 
 // =============================================================================
@@ -91,6 +92,7 @@ export interface RepoConfig {
 export interface Config {
   repos: RepoConfig[];
   prTemplate?: string;
+  githubHosts?: string[];
 }
 
 // =============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,7 +192,9 @@ async function main(): Promise<void> {
 
     let repoInfo;
     try {
-      repoInfo = parseGitUrl(repoConfig.git);
+      repoInfo = parseGitUrl(repoConfig.git, {
+        githubHosts: config.githubHosts,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(current, repoConfig.git, message);


### PR DESCRIPTION
## Summary

Closes #144

- Add support for GitHub Enterprise Server (GHE) instances via new `githubHosts` config option
- URLs matching configured hostnames are treated as GitHub repositories instead of falling back to GitLab detection
- Hostname matching is case-insensitive

## Changes

- Add `githubHosts` array to config schema and types
- Add `host` field to `GitHubRepoInfo` interface  
- Update repo detection to check GHE hosts first
- Update GitHub PR strategy to use `HOST/OWNER/REPO` format for GHE
- Add `--hostname` flag for `gh api` commands on GHE
- Add validation for `githubHosts` (hostnames only, no URLs/paths)
- Add 24 new tests for GHE detection, PR strategy, and validation
- Update documentation with GHE configuration and auth examples

## Usage

```yaml
githubHosts:
  - github.mycompany.com

files:
  config.json:
    content:
      key: value

repos:
  - git: git@github.mycompany.com:org/repo.git
```

Authentication for GHE:
```bash
gh auth login --hostname github.mycompany.com
```

## Test plan

- [x] All 768 tests pass
- [x] Build compiles successfully
- [x] Case-insensitive hostname matching verified
- [x] Backward compatibility: existing configs without `githubHosts` work unchanged
- [x] Unknown hosts still fall through to GitLab (existing behavior)

🤖 Generated with [Claude Code](https://claude.ai/code)