### PR TITLE
feat: add direct merge mode for pushing without PR (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm downloads](https://img.shields.io/npm/dw/@aspruyt/xfg.svg)](https://www.npmjs.com/package/@aspruyt/xfg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A CLI tool that syncs JSON, JSON5, YAML, or text configuration files across multiple GitHub, Azure DevOps, and GitLab repositories by creating pull requests.
+A CLI tool that syncs JSON, JSON5, YAML, or text configuration files across multiple GitHub, Azure DevOps, and GitLab repositories. By default, changes are made via pull requests, but you can also push directly to the default branch.
 
 **[Full Documentation](https://anthony-spruyt.github.io/xfg/)**
 
@@ -58,6 +58,7 @@ xfg --config ./config.yaml
 - **YAML Comments** - Add header comments and schema directives to YAML files
 - **Multi-Platform** - Works with GitHub (including GitHub Enterprise Server), Azure DevOps, and GitLab (including self-hosted)
 - **Auto-Merge PRs** - Automatically merge PRs when checks pass, or force merge with admin privileges
+- **Direct Push Mode** - Push directly to default branch without creating PRs
 - **Dry-Run Mode** - Preview changes without creating PRs
 - **Error Resilience** - Continues processing if individual repos fail
 - **Automatic Retries** - Retries transient network errors with exponential backoff

--- a/config-schema.json
+++ b/config-schema.json
@@ -162,9 +162,9 @@
       "properties": {
         "merge": {
           "type": "string",
-          "enum": ["manual", "auto", "force"],
+          "enum": ["manual", "auto", "force", "direct"],
           "default": "auto",
-          "description": "Merge mode: 'manual' leaves PR open for review, 'auto' enables auto-merge when checks pass, 'force' bypasses requirements using admin privileges. Default: auto"
+          "description": "Merge mode: 'manual' leaves PR open for review, 'auto' enables auto-merge when checks pass, 'force' bypasses requirements using admin privileges, 'direct' pushes directly to default branch without creating a PR. Default: auto"
         },
         "mergeStrategy": {
           "type": "string",

--- a/docs/configuration/pr-options.md
+++ b/docs/configuration/pr-options.md
@@ -4,20 +4,21 @@ Configure how PRs are handled after creation.
 
 ## PR Options Fields
 
-| Field           | Description                                                                 | Default  |
-| --------------- | --------------------------------------------------------------------------- | -------- |
-| `merge`         | Merge mode: `manual` (leave open), `auto` (merge when checks pass), `force` | `auto`   |
-| `mergeStrategy` | How to merge: `merge`, `squash`, `rebase`                                   | `squash` |
-| `deleteBranch`  | Delete source branch after merge                                            | `true`   |
-| `bypassReason`  | Reason for bypassing policies (Azure DevOps only, required for `force`)     | -        |
+| Field           | Description                                                                           | Default  |
+| --------------- | ------------------------------------------------------------------------------------- | -------- |
+| `merge`         | Merge mode: `manual` (leave open), `auto` (merge when checks pass), `force`, `direct` | `auto`   |
+| `mergeStrategy` | How to merge: `merge`, `squash`, `rebase`                                             | `squash` |
+| `deleteBranch`  | Delete source branch after merge                                                      | `true`   |
+| `bypassReason`  | Reason for bypassing policies (Azure DevOps only, required for `force`)               | -        |
 
 ## Merge Modes
 
-| Mode     | GitHub Behavior                                      | Azure DevOps Behavior                  | GitLab Behavior                            |
-| -------- | ---------------------------------------------------- | -------------------------------------- | ------------------------------------------ |
-| `manual` | Leave PR open for review                             | Leave PR open for review               | Leave MR open for review                   |
-| `auto`   | Enable auto-merge (requires repo setup, **default**) | Enable auto-complete (**default**)     | Merge when pipeline succeeds (**default**) |
-| `force`  | Merge with `--admin` (bypass checks)                 | Bypass policies with `--bypass-policy` | Merge immediately                          |
+| Mode     | GitHub Behavior                                      | Azure DevOps Behavior                   | GitLab Behavior                            |
+| -------- | ---------------------------------------------------- | --------------------------------------- | ------------------------------------------ |
+| `manual` | Leave PR open for review                             | Leave PR open for review                | Leave MR open for review                   |
+| `auto`   | Enable auto-merge (requires repo setup, **default**) | Enable auto-complete (**default**)      | Merge when pipeline succeeds (**default**) |
+| `force`  | Merge with `--admin` (bypass checks)                 | Bypass policies with `--bypass-policy`  | Merge immediately                          |
+| `direct` | Push directly to default branch (no PR)              | Push directly to default branch (no PR) | Push directly to default branch (no MR)    |
 
 ## Global vs Per-Repo Options
 
@@ -59,7 +60,28 @@ xfg --config ./config.yaml --merge manual
 
 # Force merge all PRs (useful for urgent updates)
 xfg --config ./config.yaml --merge force
+
+# Push directly to default branch without creating PRs
+xfg --config ./config.yaml --merge direct
 ```
+
+## Direct Push Mode
+
+The `direct` mode pushes changes directly to the default branch without creating a PR. This is useful for:
+
+- Repos without branch protection
+- Internal tools where PR review isn't required
+- Quick config updates where you have direct push permissions
+
+```yaml
+prOptions:
+  merge: direct
+
+repos:
+  - git: git@github.com:org/internal-tool.git
+```
+
+**Note:** If the target branch has branch protection enabled, the push will fail with a helpful error message suggesting to use `merge: force` instead.
 
 ## GitHub Auto-Merge Note
 

--- a/docs/examples/auto-merge.md
+++ b/docs/examples/auto-merge.md
@@ -32,11 +32,12 @@ repos:
 
 ## Merge Modes
 
-| Mode     | GitHub Behavior                      | Azure DevOps Behavior    | GitLab Behavior              |
-| -------- | ------------------------------------ | ------------------------ | ---------------------------- |
-| `manual` | Leave PR open for review             | Leave PR open for review | Leave MR open for review     |
-| `auto`   | Enable auto-merge (default)          | Enable auto-complete     | Merge when pipeline succeeds |
-| `force`  | Merge with `--admin` (bypass checks) | Bypass policies          | Merge immediately            |
+| Mode     | GitHub Behavior                         | Azure DevOps Behavior    | GitLab Behavior              |
+| -------- | --------------------------------------- | ------------------------ | ---------------------------- |
+| `manual` | Leave PR open for review                | Leave PR open for review | Leave MR open for review     |
+| `auto`   | Enable auto-merge (default)             | Enable auto-complete     | Merge when pipeline succeeds |
+| `force`  | Merge with `--admin` (bypass checks)    | Bypass policies          | Merge immediately            |
+| `direct` | Push directly to default branch (no PR) | Push directly (no PR)    | Push directly (no MR)        |
 
 ## GitHub Auto-Merge Note
 
@@ -58,13 +59,41 @@ xfg --config ./config.yaml --merge manual
 
 # Force merge all PRs (useful for urgent updates)
 xfg --config ./config.yaml --merge force
+
+# Push directly to default branch (no PR created)
+xfg --config ./config.yaml --merge direct
 ```
+
+## Direct Push Mode
+
+The `direct` mode pushes changes directly to the default branch without creating a PR/MR:
+
+```yaml
+files:
+  .prettierrc.json:
+    content:
+      semi: false
+
+prOptions:
+  merge: direct
+
+repos:
+  - git: git@github.com:org/internal-tool.git
+```
+
+Use `direct` mode when:
+
+- The repo has no branch protection
+- You have bypass permissions configured
+- PR review isn't required for the target repo
+
+**Note:** If branch protection rejects the push, you'll get a helpful error suggesting to use `merge: force` instead.
 
 ## PR Options Reference
 
 | Field           | Description                                                             | Default  |
 | --------------- | ----------------------------------------------------------------------- | -------- |
-| `merge`         | Merge mode: `manual`, `auto`, `force`                                   | `auto`   |
+| `merge`         | Merge mode: `manual`, `auto`, `force`, `direct`                         | `auto`   |
 | `mergeStrategy` | How to merge: `merge`, `squash`, `rebase`                               | `squash` |
 | `deleteBranch`  | Delete source branch after merge                                        | `true`   |
 | `bypassReason`  | Reason for bypassing policies (Azure DevOps only, required for `force`) | -        |

--- a/docs/platforms/azure-devops.md
+++ b/docs/platforms/azure-devops.md
@@ -46,3 +46,22 @@ xfg uses the `az repos pr` CLI commands to:
 
 1. Create the PR
 2. Enable auto-complete or bypass policies as configured
+
+## Direct Push Mode
+
+With `merge: direct`, xfg skips PR creation entirely and pushes directly to the default branch:
+
+```yaml
+prOptions:
+  merge: direct
+
+repos:
+  - git: git@ssh.dev.azure.com:v3/org/project/repo
+```
+
+This is useful for repos without branch policies or when PR review isn't required. If the branch has policies that block direct pushes, the push will fail with a helpful error suggesting to use `merge: force` instead.
+
+**When to use `direct` vs `force`:**
+
+- `direct`: Repo has no branch policies, or you want to skip PR workflow entirely
+- `force`: Repo has branch policies, but you have permissions to bypass them (creates a PR and completes with `--bypass-policy`)

--- a/docs/platforms/github.md
+++ b/docs/platforms/github.md
@@ -100,3 +100,22 @@ xfg uses the `gh` CLI to:
 1. Create the PR with `gh pr create`
 2. Enable auto-merge with `gh pr merge --auto` (if configured)
 3. Force merge with `gh pr merge --admin` (if `merge: force`)
+
+## Direct Push Mode
+
+With `merge: direct`, xfg skips PR creation entirely and pushes directly to the default branch:
+
+```yaml
+prOptions:
+  merge: direct
+
+repos:
+  - git: git@github.com:org/internal-tool.git
+```
+
+This is useful for repos without branch protection or when PR review isn't required. If the branch is protected, the push will fail with a helpful error suggesting to use `merge: force` instead.
+
+**When to use `direct` vs `force`:**
+
+- `direct`: Repo has no branch protection, or you want to skip PR workflow entirely
+- `force`: Repo has branch protection, but you have admin privileges to bypass it (creates a PR and merges with `--admin`)

--- a/docs/platforms/gitlab.md
+++ b/docs/platforms/gitlab.md
@@ -56,3 +56,22 @@ xfg uses the `glab` CLI to:
 
 1. Create the merge request with `glab mr create`
 2. Configure merge behavior based on `prOptions`
+
+## Direct Push Mode
+
+With `merge: direct`, xfg skips MR creation entirely and pushes directly to the default branch:
+
+```yaml
+prOptions:
+  merge: direct
+
+repos:
+  - git: git@gitlab.com:owner/repo.git
+```
+
+This is useful for repos without branch protection or when MR review isn't required. If the branch is protected, the push will fail with a helpful error suggesting to use `merge: force` instead.
+
+**When to use `direct` vs `force`:**
+
+- `direct`: Repo has no branch protection, or you want to skip MR workflow entirely
+- `force`: Repo has branch protection, but you have permissions to merge without pipeline (uses `glab mr merge -y` to merge immediately)

--- a/docs/reference/cli-options.md
+++ b/docs/reference/cli-options.md
@@ -8,16 +8,16 @@ xfg --config <path> [options]
 
 ## Options
 
-| Option             | Alias | Description                                    | Default                                        |
-| ------------------ | ----- | ---------------------------------------------- | ---------------------------------------------- |
-| `--config`         | `-c`  | Path to YAML config file                       | **Required**                                   |
-| `--dry-run`        | `-d`  | Show what would be done without making changes | `false`                                        |
-| `--work-dir`       | `-w`  | Temporary directory for cloning                | `./tmp`                                        |
-| `--retries`        | `-r`  | Number of retries for network operations       | `3`                                            |
-| `--branch`         | `-b`  | Override branch name                           | `chore/sync-{filename}` or `chore/sync-config` |
-| `--merge`          | `-m`  | PR merge mode: `manual`, `auto`, `force`       | `auto`                                         |
-| `--merge-strategy` |       | Merge strategy: `merge`, `squash`, `rebase`    | `squash`                                       |
-| `--delete-branch`  |       | Delete source branch after merge               | `true`                                         |
+| Option             | Alias | Description                                        | Default                                        |
+| ------------------ | ----- | -------------------------------------------------- | ---------------------------------------------- |
+| `--config`         | `-c`  | Path to YAML config file                           | **Required**                                   |
+| `--dry-run`        | `-d`  | Show what would be done without making changes     | `false`                                        |
+| `--work-dir`       | `-w`  | Temporary directory for cloning                    | `./tmp`                                        |
+| `--retries`        | `-r`  | Number of retries for network operations           | `3`                                            |
+| `--branch`         | `-b`  | Override branch name                               | `chore/sync-{filename}` or `chore/sync-config` |
+| `--merge`          | `-m`  | PR merge mode: `manual`, `auto`, `force`, `direct` | `auto`                                         |
+| `--merge-strategy` |       | Merge strategy: `merge`, `squash`, `rebase`        | `squash`                                       |
+| `--delete-branch`  |       | Delete source branch after merge                   | `true`                                         |
 
 ## Examples
 
@@ -49,6 +49,9 @@ xfg --config ./config.yaml --merge manual
 
 # Force merge (bypass checks)
 xfg --config ./config.yaml --merge force
+
+# Push directly to default branch (no PR)
+xfg --config ./config.yaml --merge direct
 ```
 
 ### Increase Retries

--- a/fixtures/integration-test-direct-ado.yaml
+++ b/fixtures/integration-test-direct-ado.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
+# Integration test config for Azure DevOps - tests direct push mode (no PR created)
+files:
+  direct-test.config.json:
+    content:
+      directMode: true
+      timestamp: direct-push-test
+
+prOptions:
+  merge: direct
+
+repos:
+  - git: https://dev.azure.com/aspruyt/fxg/_git/fxg-test

--- a/fixtures/integration-test-direct-github.yaml
+++ b/fixtures/integration-test-direct-github.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
+# Integration test config - tests direct push mode (no PR created)
+files:
+  direct-test.config.json:
+    content:
+      directMode: true
+      timestamp: direct-push-test
+
+prOptions:
+  merge: direct
+
+repos:
+  - git: https://github.com/anthony-spruyt/xfg-test.git

--- a/fixtures/integration-test-direct-gitlab.yaml
+++ b/fixtures/integration-test-direct-gitlab.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
+# Integration test config for GitLab - tests direct push mode (no MR created)
+files:
+  direct-test.config.json:
+    content:
+      directMode: true
+      timestamp: direct-push-test
+
+prOptions:
+  merge: direct
+
+repos:
+  - git: https://gitlab.com/anthony-spruyt1/xfg-test.git

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aspruyt/xfg",
   "version": "1.7.0",
-  "description": "CLI tool to sync JSON, JSON5, YAML, or text configuration files across multiple Git repositories by creating pull requests",
+  "description": "CLI tool to sync JSON, JSON5, YAML, or text configuration files across multiple Git repositories via pull requests or direct push",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export { convertContentToString } from "./config-formatter.js";
 // PR Merge Options Types
 // =============================================================================
 
-export type MergeMode = "manual" | "auto" | "force";
+export type MergeMode = "manual" | "auto" | "force" | "direct";
 export type MergeStrategy = "merge" | "squash" | "rebase";
 
 export interface PRMergeOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,9 @@ program
   )
   .option(
     "-m, --merge <mode>",
-    "PR merge mode: manual, auto (default, merge when checks pass), force (bypass requirements)",
+    "PR merge mode: manual, auto (default, merge when checks pass), force (bypass requirements), direct (push to default branch, no PR)",
     (value: string): MergeMode => {
-      const valid: MergeMode[] = ["manual", "auto", "force"];
+      const valid: MergeMode[] = ["manual", "auto", "force", "direct"];
       if (!valid.includes(value as MergeMode)) {
         throw new Error(
           `Invalid merge mode: ${value}. Valid: ${valid.join(", ")}`,

--- a/src/integration-ado.test.ts
+++ b/src/integration-ado.test.ts
@@ -669,4 +669,92 @@ describe("Azure DevOps Integration Test", () => {
 
     console.log("\n=== Unchanged files test (issue #90) passed ===\n");
   });
+
+  test("direct mode pushes directly to main branch without creating PR (issue #134)", async () => {
+    // This test verifies the direct mode feature (issue #134):
+    // Files are pushed directly to the default branch without creating a PR.
+    // NOTE: This test uses the same exec() helper defined at line 24-40, which
+    // is safe because all commands are hardcoded (not derived from user input).
+
+    const directFile = "direct-test.config.json";
+
+    console.log("\n=== Setting up direct mode test (issue #134) ===\n");
+
+    // 1. Delete the direct test file if it exists in the default branch
+    console.log(`Deleting ${directFile} if exists...`);
+    try {
+      const defaultBranch = getDefaultBranch();
+      const fileInfo = getFileContent(directFile);
+      if (fileInfo) {
+        pushFileChange(
+          directFile,
+          null,
+          `test: cleanup ${directFile}`,
+          defaultBranch,
+          fileInfo.objectId,
+        );
+        console.log("  File deleted");
+      }
+    } catch {
+      console.log("  File does not exist");
+    }
+
+    // 2. Run sync with direct mode config
+    console.log("\nRunning xfg with direct mode config...");
+    const configPath = join(fixturesDir, "integration-test-direct-ado.yaml");
+    const output = exec(`node dist/index.js --config ${configPath}`, {
+      cwd: projectRoot,
+    });
+    console.log(output);
+
+    // 3. Verify the output mentions direct push
+    assert.ok(
+      output.includes("Pushed directly") || output.includes("direct"),
+      "Output should mention direct push",
+    );
+
+    // 4. Verify NO PR was created
+    console.log("\nVerifying no PR was created...");
+    try {
+      const prList = exec(
+        `az repos pr list --repository ${TEST_REPO} --source-branch chore/sync-direct-test --org ${ORG_URL} --project ${TEST_PROJECT} --query "[0].pullRequestId" -o tsv`,
+      );
+      assert.ok(!prList, "No PR should be created in direct mode");
+    } catch {
+      console.log("  No PR found - this is correct for direct mode");
+    }
+
+    // 5. Verify the file exists directly on main branch
+    console.log("\nVerifying file exists on main branch...");
+    const fileInfo = getFileContent(directFile);
+
+    assert.ok(fileInfo, "File should exist on main branch");
+    const json = JSON.parse(fileInfo.content);
+    console.log("  File content:", JSON.stringify(json, null, 2));
+
+    assert.equal(json.directMode, true, "File should have directMode: true");
+
+    console.log("  Direct push verified - file is on main without PR");
+
+    // 6. Cleanup - delete the test file from main
+    console.log("\nCleaning up direct test file...");
+    try {
+      const defaultBranch = getDefaultBranch();
+      const cleanupFileInfo = getFileContent(directFile);
+      if (cleanupFileInfo) {
+        pushFileChange(
+          directFile,
+          null,
+          `test: cleanup ${directFile}`,
+          defaultBranch,
+          cleanupFileInfo.objectId,
+        );
+        console.log("  File deleted");
+      }
+    } catch {
+      console.log("  Could not delete file");
+    }
+
+    console.log("\n=== Direct mode test (issue #134) passed ===\n");
+  });
 });

--- a/src/integration-github.test.ts
+++ b/src/integration-github.test.ts
@@ -687,4 +687,86 @@ describe("GitHub Integration Test", () => {
 
     console.log("\n=== Template feature test (issue #133) passed ===\n");
   });
+
+  test("direct mode pushes directly to main branch without creating PR (issue #134)", async () => {
+    // This test verifies the direct mode feature (issue #134):
+    // Files are pushed directly to the default branch without creating a PR.
+    // NOTE: This test uses the same exec() helper defined at line 19-35, which
+    // is safe because all commands are hardcoded (not derived from user input).
+
+    const directFile = "direct-test.config.json";
+
+    console.log("\n=== Setting up direct mode test (issue #134) ===\n");
+
+    // 1. Delete the direct test file if it exists in the default branch
+    console.log(`Deleting ${directFile} if exists...`);
+    try {
+      const sha = exec(
+        `gh api repos/${TEST_REPO}/contents/${directFile} --jq '.sha'`,
+      );
+      if (sha && !sha.includes("Not Found")) {
+        exec(
+          `gh api --method DELETE repos/${TEST_REPO}/contents/${directFile} -f message="test: cleanup ${directFile}" -f sha="${sha}"`,
+        );
+        console.log("  File deleted");
+      }
+    } catch {
+      console.log("  File does not exist");
+    }
+
+    // 2. Run sync with direct mode config
+    console.log("\nRunning xfg with direct mode config...");
+    const configPath = join(fixturesDir, "integration-test-direct-github.yaml");
+    const output = exec(`node dist/index.js --config ${configPath}`, {
+      cwd: projectRoot,
+    });
+    console.log(output);
+
+    // 3. Verify the output mentions direct push
+    assert.ok(
+      output.includes("Pushed directly") || output.includes("direct"),
+      "Output should mention direct push",
+    );
+
+    // 4. Verify NO PR was created
+    console.log("\nVerifying no PR was created...");
+    try {
+      const prList = exec(
+        `gh pr list --repo ${TEST_REPO} --head chore/sync-direct-test --json number --jq '.[0].number'`,
+      );
+      assert.ok(!prList, "No PR should be created in direct mode");
+    } catch {
+      console.log("  No PR found - this is correct for direct mode");
+    }
+
+    // 5. Verify the file exists directly on main branch
+    console.log("\nVerifying file exists on main branch...");
+    const fileContent = exec(
+      `gh api repos/${TEST_REPO}/contents/${directFile} --jq '.content' | base64 -d`,
+    );
+
+    assert.ok(fileContent, "File should exist on main branch");
+    const json = JSON.parse(fileContent);
+    console.log("  File content:", JSON.stringify(json, null, 2));
+
+    assert.equal(json.directMode, true, "File should have directMode: true");
+
+    console.log("  Direct push verified - file is on main without PR");
+
+    // 6. Cleanup - delete the test file from main
+    console.log("\nCleaning up direct test file...");
+    try {
+      const sha = exec(
+        `gh api repos/${TEST_REPO}/contents/${directFile} --jq '.sha'`,
+      );
+      exec(
+        `gh api --method DELETE repos/${TEST_REPO}/contents/${directFile} -f message="test: cleanup ${directFile}" -f sha="${sha}"`,
+      );
+      console.log("  File deleted");
+    } catch {
+      console.log("  Could not delete file");
+    }
+
+    console.log("\n=== Direct mode test (issue #134) passed ===\n");
+  });
 });


### PR DESCRIPTION
## Summary

Adds `merge: direct` option to push changes directly to the default branch without creating a pull request. Closes #134.

- Extends `MergeMode` type to include `"direct"`
- Skips sync branch creation in direct mode (stays on default branch)
- Pushes directly to default branch with helpful error handling for branch protection
- Warns when `mergeStrategy` is set (irrelevant in direct mode)

## Merge Modes After This PR

| Mode | Behavior |
|------|----------|
| `manual` | Create PR, leave open for review |
| `auto` | Create PR, auto-merge when CI passes |
| `force` | Create PR, force merge immediately |
| `direct` | **NEW** - No PR, push directly to default branch |

## Usage

```yaml
prOptions:
  merge: direct

repos:
  - git: git@github.com:org/repo.git
```

```bash
xfg --config ./config.yaml --merge direct
```

## Test plan

- [x] Unit tests for direct mode (4 new tests)
- [x] Integration test for GitHub
- [x] Integration test fixtures for ADO and GitLab
- [x] All 845 unit tests pass
- [x] GitHub integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)