### PR TITLE
fix: use npx --yes to ensure package download

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
         GITLAB_TOKEN: ${{ inputs.gitlab-token }}
       run: |
         # Build command with required arguments
-        CMD="npx @aspruyt/xfg"
+        CMD="npx --yes @aspruyt/xfg"
         CMD="$CMD --config ${{ inputs.config }}"
         CMD="$CMD --work-dir ${{ inputs.work-dir }}"
         CMD="$CMD --retries ${{ inputs.retries }}"


### PR DESCRIPTION
## Summary

The `npx @aspruyt/xfg` command fails with `xfg: not found` because npx doesn't automatically download scoped packages when there's no local package.json.

Adding `--yes` flag forces npx to download and execute the package.

## Test plan

- [ ] CI `integration-test-action` job passes

🤖 Generated with [Claude Code](https://claude.ai/code)