### PR TITLE
fix: use npm install -g instead of npx for reliability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,10 @@ runs:
           git config --global credential."https://gitlab.com".useHttpPath true
         fi
 
+    - name: Install xfg
+      shell: bash
+      run: npm install -g @aspruyt/xfg
+
     - name: Run xfg
       shell: bash
       env:
@@ -104,7 +108,7 @@ runs:
         GITLAB_TOKEN: ${{ inputs.gitlab-token }}
       run: |
         # Build command with required arguments
-        CMD="npx --yes @aspruyt/xfg"
+        CMD="xfg"
         CMD="$CMD --config ${{ inputs.config }}"
         CMD="$CMD --work-dir ${{ inputs.work-dir }}"
         CMD="$CMD --retries ${{ inputs.retries }}"


### PR DESCRIPTION
npx has issues with scoped packages in CI environments. Using explicit global install ensures the xfg binary is properly available.