### PR TITLE
fix: remove dry-run from action integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,7 +211,6 @@ jobs:
         with:
           config: ./fixtures/integration-test-config-github.yaml
           github-token: ${{ secrets.GH_PAT }}
-          dry-run: true
 
   release:
     needs:


### PR DESCRIPTION
Make the action integration test consistent with other integration tests by actually creating PRs instead of just previewing changes.