### PR TITLE
fix: skip integration tests on tag pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
 
   integration-test-github:
     needs: [build, security]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     concurrency:
@@ -115,7 +115,7 @@ jobs:
 
   integration-test-ado:
     needs: [build, security]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     concurrency:
@@ -159,7 +159,7 @@ jobs:
 
   integration-test-gitlab:
     needs: [build, security]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     concurrency:
@@ -204,7 +204,7 @@ jobs:
 
   integration-test-action:
     needs: [build, security, integration-test-github]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     concurrency:


### PR DESCRIPTION
## Summary
- Skip integration tests when pushing tags to prevent release job cancellation
- Integration tests already ran when code was pushed to main, so no need to re-run on tag push

## Problem
When pushing a tag for release, the integration tests would start and compete for concurrency groups, causing the release job to be cancelled.

## Solution
Added `&& !startsWith(github.ref, 'refs/tags/')` condition to all integration test jobs:
- `integration-test-github`
- `integration-test-ado`
- `integration-test-gitlab`
- `integration-test-action`

## Test plan
- [x] CI passes on this PR (build + security jobs only)
- [ ] Next tag push should skip integration tests and release successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)