### PR TITLE
docs: clarify PAT requirement in action example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,17 @@ Full documentation is available at https://anthony-spruyt.github.io/xfg/
 
 The docs site is built with MkDocs Material and auto-deploys via GitHub Actions when changes are made to `docs/` or `mkdocs.yml`.
 
+**IMPORTANT: When updating documentation, update BOTH locations:**
+
+- `README.md` - Quick start, features overview, badges
+- `docs/` - Full documentation (GitHub Pages site)
+
+Examples that appear in both places:
+
+- GitHub Action usage examples
+- CLI usage examples
+- Token/authentication requirements
+
 ## Architecture
 
 ### Config Normalization Pipeline (config.ts)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       - uses: anthony-spruyt/xfg@v1
         with:
           config: ./sync-config.yaml
-          github-token: ${{ secrets.SYNC_TOKEN }}
+          github-token: ${{ secrets.GH_PAT }} # PAT with repo scope for cross-repo access
 ```
 
 ### CLI

--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -10,7 +10,7 @@ The simplest way to use xfg in GitHub Actions is with the official action:
 - uses: anthony-spruyt/xfg@v1
   with:
     config: ./sync-config.yml
-    github-token: ${{ secrets.SYNC_TOKEN }}
+    github-token: ${{ secrets.GH_PAT }} # PAT with repo scope for cross-repo access
 ```
 
 ### Action Inputs


### PR DESCRIPTION
Rename SYNC_TOKEN to GH_PAT and add comment explaining it's needed for cross-repo access.