### PR TITLE
chore: optimize release tag CI by skipping coverage collection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,9 +35,15 @@ jobs:
         run: npm run build
 
       - name: Run unit tests with coverage
+        if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/')
         run: npm run test:coverage
 
+      - name: Run unit tests (no coverage)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        run: npm test
+
       - name: Upload coverage to Codecov
+        if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/')
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -258,13 +264,7 @@ jobs:
           done
 
   release:
-    needs:
-      [
-        integration-test-github,
-        integration-test-ado,
-        integration-test-gitlab,
-        integration-test-action,
-      ]
+    needs: [build, security]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: npm


### PR DESCRIPTION
## Summary

Optimize the release tag CI workflow by skipping coverage collection and Codecov upload on tag pushes while maintaining critical safety checks (unit tests and security scanning) before npm publish.

## Changes

**Optimized test execution on tag pushes:**
- Run `npm test` instead of `npm run test:coverage` on tag pushes
- Skip Codecov upload on tag pushes (add conditional)
- Run `npm run test:coverage` + upload on PRs and main pushes (unchanged)

**Clarified release job dependencies:**
- Changed from `needs: [integration-test-github, integration-test-ado, integration-test-gitlab, integration-test-action]`
- To `needs: [build, security]`
- Integration tests are always skipped on tag pushes, so the dependency was misleading

## CI Behavior After Changes

| Event Type | Build | Unit Tests | Coverage Collection | Codecov Upload | Security Scan | Integration Tests | Release |
|------------|-------|------------|---------------------|----------------|---------------|-------------------|---------|
| PR         | ✅    | ✅         | ✅                  | ✅             | ✅            | ⏭️                | ⏭️      |
| Main push  | ✅    | ✅         | ✅                  | ✅             | ✅            | ✅                | ⏭️      |
| Tag push   | ✅    | ✅         | ⏭️                  | ⏭️             | ✅            | ⏭️                | ✅      |

## Rationale

**Why skip coverage on tags?**
- Coverage was already collected and uploaded when the code was merged to main
- Coverage collection adds overhead to test execution
- No benefit to re-uploading the same coverage data

**Why keep unit tests on tags?**
- Fast safety check to verify the built artifact works correctly
- Industry best practice: npm and Snyk recommend running tests before `npm publish`
- Minimal time cost (tests run in seconds)

**Why keep security scan on tags?**
- Final gate before publishing to npm registry
- Protects against supply chain attacks
- OSSF guidelines emphasize defense in depth

## Benefits

- ⏱️ Faster CI on releases (skip coverage overhead + upload)
- ✅ Maintains unit tests as safety check
- 🛡️ Maintains security scan for supply chain protection
- 🎯 Clearer job dependencies
- 📊 Avoids duplicate Codecov uploads

Closes #169