### PR TITLE
chore: release v1.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aspruyt/xfg",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aspruyt/xfg",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspruyt/xfg",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "CLI tool to sync JSON, JSON5, YAML, or text configuration files across multiple Git repositories via pull requests or direct push",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v1.10.1

Patch release with bug fixes, test improvements, and CI optimizations.

## Changes Since v1.10.0

### Bug Fixes
- **#172**: Fix mock executors through PR creation chain to prevent real CLI calls in tests

### Testing & CI Improvements
- **#176**: Move integration tests to test/integration for automatic discovery
  - Add helper script using Node.js `globSync` for automatic test discovery
  - Upgrade CI to Node.js 24 for consistent tooling
  - Clean separation of unit and integration tests
- **#173**: Add coverage for executor parameter in PR creation
- **#175**: Optimize release tag CI by skipping coverage collection

### Dependencies
- **#174**: Bump @anthropic-ai/claude-code from 2.1.15 to 2.1.17
- **#171**: Bump GitHub Actions dependencies
- **#170**: Bump @types/node from 25.0.9 to 25.0.10

## Release Process

After merging this PR:
1. Tag and push: `git tag -a v1.10.1 -m "Release v1.10.1" && git push origin v1.10.1`
2. CI will automatically publish to npm and create GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)