### PR TITLE
fix: handle divergent branch history gracefully (#183)

### DIFF
--- a/fixtures/integration-test-divergent-github.yaml
+++ b/fixtures/integration-test-divergent-github.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
+# Integration test config - tests divergent branch handling (issue #183)
+files:
+  divergent-test.json:
+    content:
+      version: 3
+      syncedByXfg: true
+
+repos:
+  - git: https://github.com/anthony-spruyt/xfg-test.git
+    branch: chore/sync-divergent

--- a/fixtures/integration-test-orphan-branch-github.yaml
+++ b/fixtures/integration-test-orphan-branch-github.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
+# Integration test config - tests orphan branch handling (issue #183 variant)
+files:
+  orphan-branch-test.json:
+    content:
+      syncedByXfg: true
+
+repos:
+  - git: https://github.com/anthony-spruyt/xfg-test.git
+    branch: chore/sync-orphan-branch

--- a/src/git-ops.test.ts
+++ b/src/git-ops.test.ts
@@ -740,6 +740,79 @@ describe("GitOps", () => {
       assert.ok(commands[0].includes("git push -u origin"));
       assert.ok(commands[0].includes("feature-branch"));
     });
+
+    test("uses --force-with-lease when force option is true", async () => {
+      const commands: string[] = [];
+      const mockExecutor: CommandExecutor = {
+        async exec(command: string, _cwd: string): Promise<string> {
+          commands.push(command);
+          return "";
+        },
+      };
+
+      const gitOps = new GitOps({
+        workDir,
+        executor: mockExecutor,
+        retries: 0,
+      });
+      await gitOps.push("sync-branch", { force: true });
+
+      assert.equal(commands.length, 1);
+      assert.ok(
+        commands[0].includes("--force-with-lease"),
+        "Should include --force-with-lease flag",
+      );
+      assert.ok(commands[0].includes("-u origin"));
+      assert.ok(commands[0].includes("sync-branch"));
+    });
+
+    test("does not use force flag when force option is false", async () => {
+      const commands: string[] = [];
+      const mockExecutor: CommandExecutor = {
+        async exec(command: string, _cwd: string): Promise<string> {
+          commands.push(command);
+          return "";
+        },
+      };
+
+      const gitOps = new GitOps({
+        workDir,
+        executor: mockExecutor,
+        retries: 0,
+      });
+      await gitOps.push("main", { force: false });
+
+      assert.equal(commands.length, 1);
+      assert.ok(
+        !commands[0].includes("--force"),
+        "Should NOT include any force flag",
+      );
+      assert.ok(commands[0].includes("git push -u origin"));
+      assert.ok(commands[0].includes("main"));
+    });
+
+    test("does not use force flag when options is undefined", async () => {
+      const commands: string[] = [];
+      const mockExecutor: CommandExecutor = {
+        async exec(command: string, _cwd: string): Promise<string> {
+          commands.push(command);
+          return "";
+        },
+      };
+
+      const gitOps = new GitOps({
+        workDir,
+        executor: mockExecutor,
+        retries: 0,
+      });
+      await gitOps.push("main");
+
+      assert.equal(commands.length, 1);
+      assert.ok(
+        !commands[0].includes("--force"),
+        "Should NOT include any force flag when options undefined",
+      );
+    });
   });
 
   describe("getDefaultBranch", () => {

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -273,12 +273,13 @@ export class GitOps {
     return true;
   }
 
-  async push(branchName: string): Promise<void> {
+  async push(branchName: string, options?: { force?: boolean }): Promise<void> {
     if (this.dryRun) {
       return;
     }
+    const forceFlag = options?.force ? "--force-with-lease " : "";
     await this.execWithRetry(
-      `git push -u origin ${escapeShellArg(branchName)}`,
+      `git push ${forceFlag}-u origin ${escapeShellArg(branchName)}`,
       this.workDir,
     );
   }

--- a/src/repository-processor.ts
+++ b/src/repository-processor.ts
@@ -402,10 +402,12 @@ export class RepositoryProcessor {
 
       // Step 8: Push
       // In direct mode, push to default branch; otherwise push to sync branch
+      // Use force-with-lease for sync branch (PR modes) to handle divergent history
+      // Never force push to default branch (direct mode) - could overwrite others' work
       const pushBranch = isDirectMode ? baseBranch : branchName;
       this.log.info(`Pushing to ${pushBranch}...`);
       try {
-        await this.gitOps.push(pushBranch);
+        await this.gitOps.push(pushBranch, { force: !isDirectMode });
       } catch (error) {
         // Handle branch protection errors in direct mode
         if (isDirectMode) {


### PR DESCRIPTION
## Summary

- Use `--force-with-lease` for sync branch pushes (PR modes) to handle divergent history gracefully
- When `closeExistingPR` fails silently and the remote branch still exists, xfg now force-pushes instead of failing with non-fast-forward error
- Direct mode (pushing to main/master) will NOT use force push - this is safe because the sync branch is xfg's own branch

## Changes

- Add optional `force` parameter to `GitOps.push()` method
- Pass `force: true` for PR modes, `force: false` for direct mode
- Add unit tests for force push behavior in git-ops.test.ts
- Add unit tests for push behavior in repository-processor.test.ts  
- Add 2 integration tests for divergent branch scenarios

## Test plan

- [x] Unit tests pass (998 tests)
- [x] Coverage at 97.71% (above 95% threshold)
- [ ] CI passes
- [ ] Integration tests validate divergent branch handling

Fixes #183

🤖 Generated with [Claude Code](https://claude.ai/code)