### PR TITLE
fix: add fetch --prune after closing PR to fix stale info error

### DIFF
--- a/src/git-ops.test.ts
+++ b/src/git-ops.test.ts
@@ -815,6 +815,74 @@ describe("GitOps", () => {
     });
   });
 
+  describe("fetch", () => {
+    beforeEach(() => {
+      mkdirSync(workDir, { recursive: true });
+    });
+
+    test("fetches from origin without prune by default", async () => {
+      const commands: string[] = [];
+      const mockExecutor: CommandExecutor = {
+        async exec(command: string, _cwd: string): Promise<string> {
+          commands.push(command);
+          return "";
+        },
+      };
+
+      const gitOps = new GitOps({
+        workDir,
+        executor: mockExecutor,
+        retries: 0,
+      });
+      await gitOps.fetch();
+
+      assert.equal(commands.length, 1);
+      assert.ok(commands[0].includes("git fetch origin"));
+      assert.ok(!commands[0].includes("--prune"));
+    });
+
+    test("fetches with prune flag when prune option is true", async () => {
+      const commands: string[] = [];
+      const mockExecutor: CommandExecutor = {
+        async exec(command: string, _cwd: string): Promise<string> {
+          commands.push(command);
+          return "";
+        },
+      };
+
+      const gitOps = new GitOps({
+        workDir,
+        executor: mockExecutor,
+        retries: 0,
+      });
+      await gitOps.fetch({ prune: true });
+
+      assert.equal(commands.length, 1);
+      assert.ok(commands[0].includes("git fetch origin --prune"));
+    });
+
+    test("does not include prune when prune option is false", async () => {
+      const commands: string[] = [];
+      const mockExecutor: CommandExecutor = {
+        async exec(command: string, _cwd: string): Promise<string> {
+          commands.push(command);
+          return "";
+        },
+      };
+
+      const gitOps = new GitOps({
+        workDir,
+        executor: mockExecutor,
+        retries: 0,
+      });
+      await gitOps.fetch({ prune: false });
+
+      assert.equal(commands.length, 1);
+      assert.ok(commands[0].includes("git fetch origin"));
+      assert.ok(!commands[0].includes("--prune"));
+    });
+  });
+
   describe("getDefaultBranch", () => {
     beforeEach(() => {
       mkdirSync(workDir, { recursive: true });

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -78,6 +78,15 @@ export class GitOps {
   }
 
   /**
+   * Fetch from remote with optional pruning of stale refs.
+   * Used to update local tracking refs after remote branch deletion.
+   */
+  async fetch(options?: { prune?: boolean }): Promise<void> {
+    const pruneFlag = options?.prune ? " --prune" : "";
+    await this.execWithRetry(`git fetch origin${pruneFlag}`, this.workDir);
+  }
+
+  /**
    * Create a new branch from the current HEAD.
    * Always creates fresh - existing branches should be cleaned up beforehand
    * by closing any existing PRs (which deletes the remote branch).

--- a/src/repository-processor.test.ts
+++ b/src/repository-processor.test.ts
@@ -897,6 +897,7 @@ describe("RepositoryProcessor", () => {
         return true;
       }
       override async push(): Promise<void> {}
+      override async fetch(): Promise<void> {}
 
       private getWorkDir(): string {
         return (this as unknown as { workDir: string }).workDir;

--- a/src/repository-processor.ts
+++ b/src/repository-processor.ts
@@ -147,6 +147,9 @@ export class RepositoryProcessor {
         });
         if (closed) {
           this.log.info("Closed existing PR and deleted branch for fresh sync");
+          // Prune stale remote tracking refs so --force-with-lease works correctly
+          // The remote branch was deleted but local git still has tracking info
+          await this.gitOps.fetch({ prune: true });
         }
       }
 


### PR DESCRIPTION
## Summary
- Added `git fetch --prune` after closing existing PR to update local tracking refs
- Added `fetch()` method to GitOps class with optional prune flag
- Added unit tests for new fetch method

## Root Cause
When `closeExistingPR` deletes the remote branch via API, local git still has stale tracking refs. Push with `--force-with-lease` detects mismatch and fails with "stale info".

## Test plan
- [x] Unit tests pass
- [ ] Integration tests pass on main (will verify before release)

Fixes #191

🤖 Generated with [Claude Code](https://claude.ai/code)