### PR TITLE
fix: correct divergent branch tests to use auto-generated branch names

### DIFF
--- a/fixtures/integration-test-divergent-github.yaml
+++ b/fixtures/integration-test-divergent-github.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config - tests divergent branch handling (issue #183)
+# Note: branch is auto-generated as chore/sync-divergent-test from filename
 files:
   divergent-test.json:
     content:
@@ -8,4 +9,3 @@ files:
 
 repos:
   - git: https://github.com/anthony-spruyt/xfg-test.git
-    branch: chore/sync-divergent

--- a/fixtures/integration-test-orphan-branch-github.yaml
+++ b/fixtures/integration-test-orphan-branch-github.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config - tests orphan branch handling (issue #183 variant)
+# Note: branch is auto-generated as chore/sync-orphan-branch-test from filename
 files:
   orphan-branch-test.json:
     content:
@@ -7,4 +8,3 @@ files:
 
 repos:
   - git: https://github.com/anthony-spruyt/xfg-test.git
-    branch: chore/sync-orphan-branch

--- a/test/integration/github.test.ts
+++ b/test/integration/github.test.ts
@@ -925,7 +925,7 @@ describe("GitHub Integration Test", () => {
     // Scenario: Existing PR on sync branch, then main advances, creating divergent history.
 
     const divergentFile = "divergent-test.json";
-    const testBranch = "chore/sync-divergent";
+    const testBranch = "chore/sync-divergent-test";
 
     console.log("\n=== Setting up divergent branch test (issue #183) ===\n");
 
@@ -1064,7 +1064,7 @@ describe("GitHub Integration Test", () => {
     // Scenario: Remote sync branch exists without a PR, and local changes would diverge.
 
     const orphanBranchFile = "orphan-branch-test.json";
-    const testBranch = "chore/sync-orphan-branch";
+    const testBranch = "chore/sync-orphan-branch-test";
 
     console.log(
       "\n=== Setting up orphan branch test (issue #183 variant) ===\n",


### PR DESCRIPTION
## Summary
- Divergent branch tests used invalid `branch` field in fixtures (not in schema, silently ignored)
- Tests were looking for wrong branch names that xfg never created
- Fixed to use correct auto-generated names from filenames

## Test plan
- [ ] CI passes including divergent branch integration tests

🤖 Generated with [Claude Code](https://claude.ai/code)