### PR TITLE
fix: correct divergent test assertion to match xfg output format

### DIFF
--- a/test/integration/github.test.ts
+++ b/test/integration/github.test.ts
@@ -1028,7 +1028,7 @@ describe("GitHub Integration Test", () => {
 
     // The key assertion: xfg should have succeeded even with divergent history
     assert.ok(
-      output2.includes("Created PR") || output2.includes("PR #"),
+      output2.includes("PR:") || output2.includes("Succeeded: 1"),
       "Output should indicate PR creation succeeded",
     );
 


### PR DESCRIPTION
## Summary
- Test was checking for "Created PR" or "PR #" but xfg outputs "PR: https://..."
- Updated assertion to check for "PR:" or "Succeeded: 1"

🤖 Generated with [Claude Code](https://claude.ai/code)