### PR TITLE
docs: clarify header/schemaUrl are YAML-only in schema

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -292,7 +292,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
-        run: |
+        run: |-
           echo "Checking CI status for commit: $COMMIT_SHA"
 
           # Get combined status (includes status checks from main branch CI run)

--- a/config-schema.json
+++ b/config-schema.json
@@ -93,11 +93,11 @@
               "description": "Multiple comment lines"
             }
           ],
-          "description": "Comment line(s) added at the top of YAML output files. Each line gets a '# ' prefix. Ignored for JSON files."
+          "description": "YAML only. Comment line(s) added at the top of YAML files. Each line gets a '# ' prefix. Ignored for JSON and text files."
         },
         "schemaUrl": {
           "type": "string",
-          "description": "URL for yaml-language-server schema directive. Adds '# yaml-language-server: $schema=<url>' at the top of YAML files. Ignored for JSON files."
+          "description": "YAML only. URL for yaml-language-server schema directive. Adds '# yaml-language-server: $schema=<url>' at the top of YAML files. For JSON files, use $schema property in content instead."
         },
         "executable": {
           "type": "boolean",
@@ -239,11 +239,11 @@
               "description": "Multiple comment lines"
             }
           ],
-          "description": "Override the root-level header for this specific repo"
+          "description": "YAML only. Override the root-level header for this specific repo. Ignored for JSON and text files."
         },
         "schemaUrl": {
           "type": "string",
-          "description": "Override the root-level schemaUrl for this specific repo"
+          "description": "YAML only. Override the root-level schemaUrl for this specific repo. For JSON files, use $schema property in content instead."
         },
         "executable": {
           "type": "boolean",

--- a/src/config-formatter.test.ts
+++ b/src/config-formatter.test.ts
@@ -340,6 +340,17 @@ describe("convertContentToString JSON ignores comments", () => {
     assert.ok(!result.includes("schema"));
     assert.ok(result.includes('"key"'));
   });
+
+  test("$schema property in content is preserved for JSON files", () => {
+    const content = {
+      $schema: "https://json.schemastore.org/tsconfig",
+      compilerOptions: { strict: true },
+    };
+    const result = convertContentToString(content, "tsconfig.json");
+    const parsed = JSON.parse(result);
+    assert.equal(parsed.$schema, "https://json.schemastore.org/tsconfig");
+    assert.deepEqual(parsed.compilerOptions, { strict: true });
+  });
 });
 
 describe("convertContentToString with text content", () => {


### PR DESCRIPTION
## Summary
- Update config-schema.json descriptions to clarify that `header` and `schemaUrl` options only work for YAML files, not JSON or text files
- Add guidance that JSON files should use `$schema` property in content instead
- Add test verifying `$schema` property in JSON content is preserved
- Fix ci.yaml literal block syntax (`|` → `|-`) for better IDE folding

## Test plan
- [x] All 1007 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)