### PR TITLE
chore: release v1.10.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aspruyt/xfg",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aspruyt/xfg",
-      "version": "1.10.6",
+      "version": "1.10.7",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aspruyt/xfg",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "CLI tool to sync JSON, JSON5, YAML, or text configuration files across multiple Git repositories via pull requests or direct push",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v1.10.7

## Changes
- fix: prevent deletion of createOnly files tracked in manifest (#199)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)