### PR TITLE
feat: add automated release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: chainguard-dev/actions/setup-gitsign@main
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and get new version
+        id: version
+        run: |
+          npm version ${{ inputs.version }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create release branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          BRANCH="release/v${VERSION}"
+
+          git checkout -b "$BRANCH"
+          git add package.json package-lock.json
+          git commit -S -m "chore: release v${VERSION}"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: release v${VERSION}" \
+            --body "Automated release PR for v${VERSION}" \
+            --base main
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --squash --delete-branch --auto
+
+      - name: Wait for PR to merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Waiting for CI checks and auto-merge..."
+          TIMEOUT=600
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            STATE=$(gh pr view --json state -q '.state')
+            if [ "$STATE" = "MERGED" ]; then
+              echo "PR merged successfully"
+              exit 0
+            elif [ "$STATE" = "CLOSED" ]; then
+              echo "PR was closed without merging"
+              exit 1
+            fi
+            sleep 15
+            ELAPSED=$((ELAPSED + 15))
+            echo "Still waiting... ($ELAPSED seconds)"
+          done
+          echo "Timeout waiting for PR to merge"
+          exit 1
+
+      - name: Create and push tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
+          git tag -s "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,31 +254,27 @@ npm run dev                     # Run CLI via ts-node (pass config file as argum
 
 ## Release Process
 
-Branch protection prevents direct pushes to main, so releases require a PR workflow:
+Releases are automated via GitHub Actions. To create a release:
+
+**Via GitHub UI:**
+Actions → Release → Run workflow → Select patch/minor/major → Run
+
+**Via CLI:**
 
 ```bash
-# 1. Create release branch from main
-git checkout main && git pull
-git checkout -b release/vX.Y.Z
-
-# 2. Bump version (patch/minor/major)
-npm version patch --no-git-tag-version   # or minor/major
-
-# 3. Commit, push, and create PR
-git add -A && git commit -m "chore: release vX.Y.Z"
-git push -u origin release/vX.Y.Z
-gh pr create --title "chore: release vX.Y.Z" --body "Release vX.Y.Z"
-
-# 4. Wait for CI, then merge
-gh pr merge --squash --delete-branch
-
-# 5. Create and push tag (triggers npm publish + GitHub Release)
-git checkout main && git pull
-git tag -a vX.Y.Z -m "Release vX.Y.Z"
-git push origin vX.Y.Z
+gh workflow run release.yaml -f version=patch  # or minor/major
 ```
 
-The release workflow automatically builds, tests, publishes to npm with provenance, and creates a GitHub Release.
+The workflow will:
+
+1. Bump version in package.json
+2. Create a signed release PR
+3. Wait for CI to pass
+4. Auto-merge the PR
+5. Create and push a signed version tag
+6. Trigger npm publish + GitHub Release (via ci.yaml)
+
+All commits and tags are signed with Gitsign (keyless OIDC signing).
 
 ## External Dependencies
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yaml` - a `workflow_dispatch` workflow with patch/minor/major dropdown
- Replace manual 5-step release process with single automated workflow
- Update `CLAUDE.md` with simplified release instructions

## What the workflow does
1. Bumps version in package.json based on selected type
2. Creates a signed release PR using Gitsign (keyless OIDC)
3. Waits for CI to pass and auto-merges the PR
4. Creates and pushes a signed version tag
5. Triggers npm publish + GitHub Release via existing ci.yaml

## Usage
**Via GitHub UI:** Actions → Release → Run workflow → Select patch/minor/major → Run

**Via CLI:**
```bash
gh workflow run release.yaml -f version=patch  # or minor/major
```

## Test plan
- [ ] Merge this PR
- [ ] Run the workflow with `patch` to test the full flow
- [ ] Verify PR is created, CI passes, PR auto-merges
- [ ] Verify tag is created and triggers npm publish

🤖 Generated with [Claude Code](https://claude.ai/code)