### PR TITLE
fix: remove Gitsign from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,13 +18,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - uses: chainguard-dev/actions/setup-gitsign@main
 
       - uses: actions/setup-node@v6
         with:
@@ -51,7 +48,7 @@ jobs:
 
           git checkout -b "$BRANCH"
           git add package.json package-lock.json
-          git commit -S -m "chore: release v${VERSION}"
+          git commit -m "chore: release v${VERSION}"
           git push -u origin "$BRANCH"
 
           gh pr create \
@@ -95,5 +92,5 @@ jobs:
           git fetch origin main
           git checkout main
           git reset --hard origin/main
-          git tag -s "v${VERSION}" -m "Release v${VERSION}"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
           git push origin "v${VERSION}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,13 +268,11 @@ gh workflow run release.yaml -f version=patch  # or minor/major
 The workflow will:
 
 1. Bump version in package.json
-2. Create a signed release PR
+2. Create a release PR
 3. Wait for CI to pass
 4. Auto-merge the PR
-5. Create and push a signed version tag
+5. Create and push a version tag
 6. Trigger npm publish + GitHub Release (via ci.yaml)
-
-All commits and tags are signed with Gitsign (keyless OIDC signing).
 
 ## External Dependencies
 


### PR DESCRIPTION
## Summary
- Remove Gitsign signing (doesn't show as GitHub Verified)
- Use unsigned commits and annotated tags instead

## Why
Gitsign signatures don't show as 'Verified' in GitHub UI because Sigstore CA root isn't in GitHub's trust root. Since branch protection requires GitHub-verified commits, signing doesn't help.

## Required Setup
**Before testing**: Enable PR creation permission in repository settings:

Settings → Actions → General → Workflow permissions → ✅ Allow GitHub Actions to create and approve pull requests

## Test plan
1. Merge this PR
2. Enable the repository setting above
3. Run `gh workflow run release.yaml -f version=patch`
4. Verify workflow creates PR, waits for CI, merges, and tags

🤖 Generated with [Claude Code](https://claude.ai/code)