### PR TITLE
feat: use GitHub API for verified commits in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,83 +17,89 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
-      id-token: write
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: chainguard-dev/actions/setup-gitsign@main
 
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Bump version and get new version
+      - name: Bump version locally
         id: version
         run: |
           npm version ${{ inputs.version }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Create release branch and PR
+      - name: Create verified commit via GitHub API
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          BRANCH="release/v${VERSION}"
+          set -e
+          REPO="${{ github.repository }}"
 
-          git checkout -b "$BRANCH"
-          git add package.json package-lock.json
-          git commit -S -m "chore: release v${VERSION}"
-          git push -u origin "$BRANCH"
+          # Get current commit SHA of main
+          BASE_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
+          echo "Base commit: $BASE_SHA"
 
-          gh pr create \
-            --title "chore: release v${VERSION}" \
-            --body "Automated release PR for v${VERSION}" \
-            --base main
+          # Get the base tree
+          BASE_TREE=$(gh api "repos/$REPO/git/commits/$BASE_SHA" --jq '.tree.sha')
 
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --squash --delete-branch --auto
+          # Create blob for package.json
+          PKG_BLOB=$(gh api "repos/$REPO/git/blobs" \
+            -f content="$(base64 -w0 package.json)" \
+            -f encoding="base64" \
+            --jq '.sha')
+          echo "package.json blob: $PKG_BLOB"
 
-      - name: Wait for PR to merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Waiting for CI checks and auto-merge..."
-          TIMEOUT=600
-          ELAPSED=0
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            STATE=$(gh pr view --json state -q '.state')
-            if [ "$STATE" = "MERGED" ]; then
-              echo "PR merged successfully"
-              exit 0
-            elif [ "$STATE" = "CLOSED" ]; then
-              echo "PR was closed without merging"
-              exit 1
-            fi
-            sleep 15
-            ELAPSED=$((ELAPSED + 15))
-            echo "Still waiting... ($ELAPSED seconds)"
-          done
-          echo "Timeout waiting for PR to merge"
-          exit 1
+          # Create blob for package-lock.json
+          LOCK_BLOB=$(gh api "repos/$REPO/git/blobs" \
+            -f content="$(base64 -w0 package-lock.json)" \
+            -f encoding="base64" \
+            --jq '.sha')
+          echo "package-lock.json blob: $LOCK_BLOB"
 
-      - name: Create and push tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          git fetch origin main
-          git checkout main
-          git reset --hard origin/main
-          git tag -s "v${VERSION}" -m "Release v${VERSION}"
-          git push origin "v${VERSION}"
+          # Create new tree with updated files
+          TREE_SHA=$(gh api "repos/$REPO/git/trees" \
+            -f base_tree="$BASE_TREE" \
+            -f "tree[][path]=package.json" \
+            -f "tree[][mode]=100644" \
+            -f "tree[][type]=blob" \
+            -f "tree[][sha]=$PKG_BLOB" \
+            -f "tree[][path]=package-lock.json" \
+            -f "tree[][mode]=100644" \
+            -f "tree[][type]=blob" \
+            -f "tree[][sha]=$LOCK_BLOB" \
+            --jq '.sha')
+          echo "New tree: $TREE_SHA"
+
+          # Create commit (GitHub-verified)
+          COMMIT_SHA=$(gh api "repos/$REPO/git/commits" \
+            -f message="chore: release v${VERSION}" \
+            -f tree="$TREE_SHA" \
+            -f "parents[]=$BASE_SHA" \
+            --jq '.sha')
+          echo "New commit: $COMMIT_SHA"
+
+          # Update main to point to new commit
+          gh api "repos/$REPO/git/refs/heads/main" \
+            -X PATCH \
+            -f sha="$COMMIT_SHA" \
+            -f force=true
+          echo "Updated main to $COMMIT_SHA"
+
+          # Create tag
+          TAG_SHA=$(gh api "repos/$REPO/git/tags" \
+            -f tag="v${VERSION}" \
+            -f message="Release v${VERSION}" \
+            -f object="$COMMIT_SHA" \
+            -f type="commit" \
+            --jq '.sha')
+          echo "Tag object: $TAG_SHA"
+
+          # Create tag ref
+          gh api "repos/$REPO/git/refs" \
+            -f ref="refs/tags/v${VERSION}" \
+            -f sha="$TAG_SHA"
+          echo "Created tag v${VERSION}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,13 +268,11 @@ gh workflow run release.yaml -f version=patch  # or minor/major
 The workflow will:
 
 1. Bump version in package.json
-2. Create a signed release PR
-3. Wait for CI to pass
-4. Auto-merge the PR
-5. Create and push a signed version tag
-6. Trigger npm publish + GitHub Release (via ci.yaml)
+2. Create a GitHub-verified commit directly on main (via GitHub API)
+3. Create and push a version tag
+4. Trigger npm publish + GitHub Release (via ci.yaml)
 
-All commits and tags are signed with Gitsign (keyless OIDC signing).
+**Prerequisite**: Add `github-actions[bot]` to branch protection bypass list (Settings → Branches → main → Allow specified actors to bypass).
 
 ## External Dependencies
 


### PR DESCRIPTION
## Summary
Use GitHub API to create commits instead of git commands. Commits created via the API are marked as **Verified** by GitHub, satisfying branch protection requirements.

## Changes
- Remove Gitsign (doesn't provide GitHub's Verified badge)
- Use `gh api` to create blobs, trees, commits, and tags
- Push directly to main via API ref update
- Much simpler flow: bump version → API commit → create tag → done

## Prerequisite
Add `github-actions[bot]` to branch protection bypass list:
**Settings → Branches → main → Allow specified actors to bypass**

## Test plan
1. Merge this PR
2. Add `github-actions[bot]` to bypass list
3. Run `gh workflow run release.yaml -f version=patch`
4. Verify commit shows as Verified and tag triggers npm publish

🤖 Generated with [Claude Code](https://claude.ai/code)