### PR TITLE
fix: use RELEASE_TOKEN PAT for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -33,7 +31,7 @@ jobs:
 
       - name: Create verified commit via GitHub API
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,11 +268,9 @@ gh workflow run release.yaml -f version=patch  # or minor/major
 The workflow will:
 
 1. Bump version in package.json
-2. Create a GitHub-verified commit directly on main (via GitHub API)
+2. Create a GitHub-verified commit directly on main (via GitHub API using `RELEASE_TOKEN` PAT)
 3. Create and push a version tag
 4. Trigger npm publish + GitHub Release (via ci.yaml)
-
-**Prerequisite**: Add `github-actions[bot]` to branch protection bypass list (Settings → Branches → main → Allow specified actors to bypass).
 
 ## External Dependencies
 


### PR DESCRIPTION
## Summary
Use `RELEASE_TOKEN` PAT instead of `GITHUB_TOKEN` for the release workflow.

## Why
`GITHUB_TOKEN` cannot bypass branch protection rules in personal repos (only org repos support adding GitHub Actions as a bypass actor).

## Changes
- Use `secrets.RELEASE_TOKEN` instead of `secrets.GITHUB_TOKEN`
- Remove `permissions` block (PAT has its own scopes)

## Test plan
1. Merge this PR
2. Run `gh workflow run release.yaml -f version=patch`
3. Verify commit is created with Verified badge and tag triggers npm publish

🤖 Generated with [Claude Code](https://claude.ai/code)