### PR TITLE
fix: use GitHub App for release workflow

### DIFF
--- a/.github/rulesets/pr-rules.json
+++ b/.github/rulesets/pr-rules.json
@@ -2,7 +2,13 @@
   "name": "pr-rules",
   "target": "branch",
   "enforcement": "active",
-  "bypass_actors": [],
+  "bypass_actors": [
+    {
+      "actor_id": 2719952,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ],
   "conditions": {
     "ref_name": {
       "include": ["refs/heads/main"],

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,20 @@ on:
           - major
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/setup-node@v6
         with:
@@ -35,35 +42,26 @@ jobs:
       - name: Create verified commit
         uses: iarekylew00t/verified-bot-commit@v2
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           message: "chore: release v${{ steps.version.outputs.version }}"
           files: |
             package.json
             package-lock.json
-          force-push: true
 
-      - name: Create and push tag
+      - name: Create lightweight tag
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           REPO="${{ github.repository }}"
 
-          # Get the commit we just created
+          # Get the verified commit SHA
           COMMIT_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
-          echo "Commit: $COMMIT_SHA"
+          echo "Verified commit: $COMMIT_SHA"
 
-          # Create tag object
-          TAG_SHA=$(gh api "repos/$REPO/git/tags" \
-            -f tag="v${VERSION}" \
-            -f message="Release v${VERSION}" \
-            -f object="$COMMIT_SHA" \
-            -f type="commit" \
-            --jq '.sha')
-          echo "Tag object: $TAG_SHA"
-
-          # Create tag ref
+          # Create lightweight tag pointing directly to verified commit
+          # This inherits the commit's verified status
           gh api "repos/$REPO/git/refs" \
             -f ref="refs/tags/v${VERSION}" \
-            -f sha="$TAG_SHA"
+            -f sha="$COMMIT_SHA"
           echo "Created tag v${VERSION}"


### PR DESCRIPTION
Use GitHub App token instead of PAT for release workflow.

**Setup required:**
1. Create GitHub App with Contents:write permission
2. Add `RELEASE_APP_ID` as repository variable
3. Add `RELEASE_APP_PRIVATE_KEY` as repository secret
4. Install app on repo
5. Add app as bypass actor in pr-rules ruleset

🤖 Generated with [Claude Code](https://claude.ai/code)