### PR TITLE
feat!: namespace manifest by config ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ xfg --config ./config.yaml
 
 ```yaml
 # sync-config.yaml
+id: my-org-prettier-config
 files:
   .prettierrc.json:
     content:

--- a/config-schema.json
+++ b/config-schema.json
@@ -4,8 +4,15 @@
   "title": "xfg Configuration",
   "description": "Configuration file for xfg CLI tool that syncs JSON, YAML, or text config files across multiple Git repositories",
   "type": "object",
-  "required": ["files", "repos"],
+  "required": ["id", "files", "repos"],
   "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]+$",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Unique identifier for this config. Used to namespace managed files in .xfg.json manifest, allowing multiple configs to manage the same repo without conflicts."
+    },
     "files": {
       "type": "object",
       "description": "Map of target filenames to their configurations. Each file is synced to all repos by default.",

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -5,6 +5,7 @@ xfg uses a YAML configuration file to define which files to sync and to which re
 ## Basic Structure
 
 ```yaml
+id: my-config # Unique identifier for this config (required)
 files:
   my.config.json: # Target file (.json outputs JSON, .yaml/.yml outputs YAML)
     mergeStrategy: replace # Array merge strategy for this file (optional)
@@ -21,13 +22,14 @@ repos: # List of repositories
 
 ## Root-Level Fields
 
-| Field            | Description                                                                           | Required |
-| ---------------- | ------------------------------------------------------------------------------------- | -------- |
-| `files`          | Map of target filenames to configs                                                    | Yes      |
-| `repos`          | Array of repository configurations                                                    | Yes      |
-| `prOptions`      | Global PR merge options (can be overridden per-repo)                                  | No       |
-| `prTemplate`     | Custom PR body template (inline or `@path/to/file` reference)                         | No       |
-| `deleteOrphaned` | Global default for orphan deletion. Files removed from config are deleted from repos. | No       |
+| Field            | Description                                                                                 | Required |
+| ---------------- | ------------------------------------------------------------------------------------------- | -------- |
+| `id`             | Unique identifier for this config. Used to namespace managed files in `.xfg.json` manifest. | Yes      |
+| `files`          | Map of target filenames to configs                                                          | Yes      |
+| `repos`          | Array of repository configurations                                                          | Yes      |
+| `prOptions`      | Global PR merge options (can be overridden per-repo)                                        | No       |
+| `prTemplate`     | Custom PR body template (inline or `@path/to/file` reference)                               | No       |
+| `deleteOrphaned` | Global default for orphan deletion. Files removed from config are deleted from repos.       | No       |
 
 ## Per-File Fields
 
@@ -81,6 +83,7 @@ repos:
 Files with `deleteOrphaned: true` are tracked in a `.xfg.json` manifest file in each target repository. When a tracked file is removed from your xfg config, it will be automatically deleted from the target repos on the next sync.
 
 ```yaml
+id: my-org-standards
 files:
   .prettierrc.json:
     content: { semi: false }

--- a/docs/examples/auto-merge.md
+++ b/docs/examples/auto-merge.md
@@ -5,6 +5,7 @@ By default, xfg enables auto-merge on PRs when checks pass. You can override thi
 ## Example
 
 ```yaml
+id: my-org-config
 files:
   .prettierrc.json:
     content:
@@ -69,6 +70,7 @@ xfg --config ./config.yaml --merge direct
 The `direct` mode pushes changes directly to the default branch without creating a PR/MR:
 
 ```yaml
+id: my-org-config
 files:
   .prettierrc.json:
     content:

--- a/docs/examples/create-only.md
+++ b/docs/examples/create-only.md
@@ -5,6 +5,7 @@ Some files should only be created once as defaults, allowing repos to maintain t
 ## Example
 
 ```yaml
+id: my-org-config
 files:
   .trivyignore.yaml:
     createOnly: true # Only create if doesn't exist
@@ -46,6 +47,7 @@ repos:
 You can override `createOnly` per-repo:
 
 ```yaml
+id: my-org-config
 files:
   .trivyignore.yaml:
     createOnly: true

--- a/docs/examples/delete-orphaned.md
+++ b/docs/examples/delete-orphaned.md
@@ -9,6 +9,7 @@ When you set `deleteOrphaned: true` on a file, xfg tracks it in a `.xfg.json` ma
 ## Basic Usage
 
 ```yaml
+id: my-org-standards
 files:
   .prettierrc.json:
     content:
@@ -33,6 +34,7 @@ When you remove `.prettierrc.json` from this config and run xfg again, the file 
 ### Global Default
 
 ```yaml
+id: my-org-standards
 deleteOrphaned: true # Track all files by default
 
 files:
@@ -49,6 +51,7 @@ repos:
 ### Per-Repo Override
 
 ```yaml
+id: my-org-standards
 files:
   .prettierrc.json:
     content: { semi: false }
@@ -76,16 +79,28 @@ This is useful for:
 
 ## The Manifest File
 
-xfg creates a `.xfg.json` file in each target repository to track managed files:
+xfg creates a `.xfg.json` file in each target repository to track managed files. The manifest is namespaced by config ID, allowing multiple xfg configs to manage the same repo without conflicts:
 
 ```json
 {
-  "version": 1,
-  "managedFiles": [".prettierrc.json", ".eslintrc.json"]
+  "version": 2,
+  "configs": {
+    "my-org-standards": [".prettierrc.json", ".eslintrc.json"],
+    "team-a-config": ["team-a-specific.json"]
+  }
 }
 ```
 
-This file is committed alongside your synced files. Only files listed in the manifest can be deleted by xfg.
+This file is committed alongside your synced files. Only files listed under a config's namespace can be deleted by that config.
+
+## Multiple Configs
+
+The `id` field enables multiple xfg configs to manage the same repository without interfering with each other. Each config only manages files in its own namespace:
+
+- **Config A** (`id: team-a-standards`) manages `foo.json`, `bar.yaml`
+- **Config B** (`id: team-b-standards`) manages `baz.json`
+
+When Config A removes `foo.json` from its config, only `foo.json` is deleted - Config B's files are untouched.
 
 ## Dry Run
 
@@ -101,5 +116,6 @@ Output shows `[DELETED]` badges for files that would be removed.
 
 - **Opt-in by default**: Files are not tracked unless you explicitly set `deleteOrphaned: true`
 - **Manifest-based**: Only files previously synced with `deleteOrphaned: true` can be deleted
+- **Namespaced**: Each config ID has its own namespace - configs can't delete each other's files
 - **Runtime override**: Use `--no-delete` to skip deletions at any time
 - **Clear visibility**: Deleted files are shown prominently in dry-run output and PR descriptions

--- a/docs/examples/env-specific.md
+++ b/docs/examples/env-specific.md
@@ -5,6 +5,7 @@ Use environment variables for secrets and environment-specific values.
 ## Example
 
 ```yaml
+id: my-org-config
 files:
   app.config.json:
     content:

--- a/docs/examples/executable-files.md
+++ b/docs/examples/executable-files.md
@@ -7,6 +7,7 @@ Shell scripts (`.sh` files) are automatically marked as executable using `git up
 `.sh` files are automatically executable:
 
 ```yaml
+id: my-org-config
 files:
   deploy.sh:
     content: |-
@@ -22,6 +23,7 @@ repos:
 Disable for a specific `.sh` file:
 
 ```yaml
+id: my-org-config
 files:
   template.sh:
     executable: false
@@ -36,6 +38,7 @@ repos:
 Mark any file as executable:
 
 ```yaml
+id: my-org-config
 files:
   run:
     executable: true
@@ -52,6 +55,7 @@ repos:
 Override executable settings per-repo:
 
 ```yaml
+id: my-org-config
 files:
   deploy.sh:
     content: |-

--- a/docs/examples/file-references.md
+++ b/docs/examples/file-references.md
@@ -5,6 +5,7 @@ Load content from external template files instead of inline content.
 ## Example
 
 ```yaml
+id: my-org-config
 files:
   .prettierrc.json:
     content: "@templates/prettierrc.json"
@@ -43,6 +44,7 @@ config/
 Per-repo content overlays merge onto the resolved file content:
 
 ```yaml
+id: my-org-config
 files:
   .eslintrc.json:
     content: "@templates/eslintrc.json" # Base config from file

--- a/docs/examples/merge-strategies.md
+++ b/docs/examples/merge-strategies.md
@@ -5,6 +5,7 @@ Different files can use different array merge strategies.
 ## Example
 
 ```yaml
+id: my-org-config
 files:
   eslint.config.json:
     mergeStrategy: append # Extends will append

--- a/docs/examples/multi-file-sync.md
+++ b/docs/examples/multi-file-sync.md
@@ -5,6 +5,7 @@ Sync multiple configuration files to all repos in a single run.
 ## Example
 
 ```yaml
+id: my-org-config
 files:
   .eslintrc.json:
     content:

--- a/docs/examples/shared-config.md
+++ b/docs/examples/shared-config.md
@@ -5,6 +5,7 @@ Define common settings once, customize per team.
 ## Example
 
 ```yaml
+id: my-org-service-config
 files:
   service.config.json:
     content:

--- a/docs/examples/subdirectory-paths.md
+++ b/docs/examples/subdirectory-paths.md
@@ -5,6 +5,7 @@ Sync files to any subdirectory path. Parent directories are created automaticall
 ## Example
 
 ```yaml
+id: my-org-config
 files:
   # GitHub Actions workflow
   ".github/workflows/ci.yaml":

--- a/docs/examples/text-files.md
+++ b/docs/examples/text-files.md
@@ -5,6 +5,7 @@ Sync text files like `.gitignore`, `.markdownlintignore`, or `.env.example` usin
 ## String Content (Multiline Text)
 
 ```yaml
+id: my-org-config
 files:
   .markdownlintignore:
     createOnly: true
@@ -26,6 +27,7 @@ repos:
 ## Lines Array with Merge Strategy
 
 ```yaml
+id: my-org-config
 files:
   .gitignore:
     mergeStrategy: append

--- a/docs/examples/yaml-comments.md
+++ b/docs/examples/yaml-comments.md
@@ -5,6 +5,7 @@ Add schema directives and comments to YAML files, or create empty files.
 ## Schema Directive
 
 ```yaml
+id: my-org-config
 files:
   trivy.yaml:
     schemaUrl: https://trivy.dev/latest/docs/references/configuration/config-file/
@@ -31,6 +32,7 @@ scan:
 ## Header Comment
 
 ```yaml
+id: my-org-config
 files:
   trivy.yaml:
     schemaUrl: https://trivy.dev/latest/docs/references/configuration/config-file/
@@ -53,6 +55,7 @@ exit-code: 1
 ## Multi-Line Header
 
 ```yaml
+id: my-org-config
 files:
   config.yaml:
     header:
@@ -78,6 +81,7 @@ version: 1
 Omit `content` to create an empty file:
 
 ```yaml
+id: my-org-config
 files:
   .prettierignore:
     createOnly: true

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -37,14 +37,15 @@ Or configure in `.vscode/settings.json`:
 
 ### Root Object
 
-| Field            | Type        | Required | Description                             |
-| ---------------- | ----------- | -------- | --------------------------------------- |
-| `files`          | `object`    | Yes      | Map of filenames to file configs        |
-| `repos`          | `array`     | Yes      | List of repository configurations       |
-| `prOptions`      | `PROptions` | No       | Global PR merge options                 |
-| `prTemplate`     | `string`    | No       | Custom PR body template                 |
-| `githubHosts`    | `array`     | No       | GitHub Enterprise Server hostnames      |
-| `deleteOrphaned` | `boolean`   | No       | Global default for orphan file deletion |
+| Field            | Type        | Required | Description                                       |
+| ---------------- | ----------- | -------- | ------------------------------------------------- |
+| `id`             | `string`    | Yes      | Unique config identifier (alphanumeric, `-`, `_`) |
+| `files`          | `object`    | Yes      | Map of filenames to file configs                  |
+| `repos`          | `array`     | Yes      | List of repository configurations                 |
+| `prOptions`      | `PROptions` | No       | Global PR merge options                           |
+| `prTemplate`     | `string`    | No       | Custom PR body template                           |
+| `githubHosts`    | `array`     | No       | GitHub Enterprise Server hostnames                |
+| `deleteOrphaned` | `boolean`   | No       | Global default for orphan file deletion           |
 
 ### File Config
 

--- a/fixtures/env-vars.yaml
+++ b/fixtures/env-vars.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Fixture testing environment variable interpolation
+id: env-vars-test
 files:
   env.config.json:
     content:

--- a/fixtures/full-features.yaml
+++ b/fixtures/full-features.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Comprehensive fixture testing all features
+id: full-features-test
 files:
   service.config.json:
     content:

--- a/fixtures/global-merge-strategy.yaml
+++ b/fixtures/global-merge-strategy.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Fixture testing per-file mergeStrategy: append
+id: global-merge-test
 files:
   global-merge.config.json:
     mergeStrategy: append

--- a/fixtures/integration-test-config-ado.yaml
+++ b/fixtures/integration-test-config-ado.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config for Azure DevOps - tests root-level content with overlay merge
+id: integration-test-ado
 
 # Use manual merge mode so the PR stays open for verification during tests
 prOptions:

--- a/fixtures/integration-test-config-github.yaml
+++ b/fixtures/integration-test-config-github.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config - tests root-level content with overlay merge
+id: integration-test-github
 files:
   my.config.json:
     content:

--- a/fixtures/integration-test-config-gitlab.yaml
+++ b/fixtures/integration-test-config-gitlab.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config for GitLab - tests root-level content with overlay merge
+id: integration-test-gitlab
 
 # Use manual merge mode so the MR stays open for verification during tests
 prOptions:

--- a/fixtures/integration-test-createonly-ado.yaml
+++ b/fixtures/integration-test-createonly-ado.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config for Azure DevOps - tests createOnly behavior against base branch
+id: integration-test-createonly-ado
 
 prOptions:
   merge: manual

--- a/fixtures/integration-test-createonly-github.yaml
+++ b/fixtures/integration-test-createonly-github.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config - tests createOnly behavior against base branch
+id: integration-test-createonly-github
 files:
   createonly-test.json:
     createOnly: true

--- a/fixtures/integration-test-createonly-gitlab.yaml
+++ b/fixtures/integration-test-createonly-gitlab.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config for GitLab - tests createOnly behavior against base branch
+id: integration-test-createonly-gitlab
 
 prOptions:
   merge: manual

--- a/fixtures/integration-test-delete-orphaned-github.yaml
+++ b/fixtures/integration-test-delete-orphaned-github.yaml
@@ -1,5 +1,6 @@
 # Integration test config for deleteOrphaned feature
 # This config is used in the first phase to create the file with deleteOrphaned: true
+id: integration-test-delete-orphaned-github
 
 files:
   orphan-test.json:

--- a/fixtures/integration-test-delete-orphaned-phase2-github.yaml
+++ b/fixtures/integration-test-delete-orphaned-phase2-github.yaml
@@ -1,5 +1,6 @@
 # Integration test config for deleteOrphaned feature - Phase 2
 # This config has the orphan-test.json removed, which should trigger deletion
+id: integration-test-delete-orphaned-github
 
 files:
   # orphan-test.json is intentionally NOT here

--- a/fixtures/integration-test-direct-ado.yaml
+++ b/fixtures/integration-test-direct-ado.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config for Azure DevOps - tests direct push mode (no PR created)
+id: integration-test-direct-ado
 files:
   direct-test.config.json:
     content:

--- a/fixtures/integration-test-direct-github.yaml
+++ b/fixtures/integration-test-direct-github.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config - tests direct push mode (no PR created)
+id: integration-test-direct-github
 files:
   direct-test.config.json:
     content:

--- a/fixtures/integration-test-direct-gitlab.yaml
+++ b/fixtures/integration-test-direct-gitlab.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config for GitLab - tests direct push mode (no MR created)
+id: integration-test-direct-gitlab
 files:
   direct-test.config.json:
     content:

--- a/fixtures/integration-test-divergent-github.yaml
+++ b/fixtures/integration-test-divergent-github.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config - tests divergent branch handling (issue #183)
 # Note: branch is auto-generated as chore/sync-divergent-test from filename
+id: integration-test-divergent-github
 files:
   divergent-test.json:
     content:

--- a/fixtures/integration-test-orphan-branch-github.yaml
+++ b/fixtures/integration-test-orphan-branch-github.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config - tests orphan branch handling (issue #183 variant)
 # Note: branch is auto-generated as chore/sync-orphan-branch-test from filename
+id: integration-test-orphan-branch-github
 files:
   orphan-branch-test.json:
     content:

--- a/fixtures/integration-test-template-github.yaml
+++ b/fixtures/integration-test-template-github.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
 # Integration test config - tests template feature with ${xfg:...} variables
 # Also tests PR template interpolation
+id: integration-test-template-github
 
 prTemplate: |
   ## Test PR for ${xfg:repo.fullName}

--- a/fixtures/integration-test-unchanged-ado.yaml
+++ b/fixtures/integration-test-unchanged-ado.yaml
@@ -3,6 +3,7 @@
 # This test has two files:
 # - unchanged-test.json: content matches what's already in the repo (should not appear in PR)
 # - changed-test.json: new content (should appear in PR)
+id: integration-test-unchanged-ado
 
 prOptions:
   merge: manual

--- a/fixtures/integration-test-unchanged-github.yaml
+++ b/fixtures/integration-test-unchanged-github.yaml
@@ -3,6 +3,7 @@
 # This test has two files:
 # - unchanged-test.json: content matches what's already in the repo (should not appear in PR)
 # - changed-test.json: new content (should appear in PR)
+id: integration-test-unchanged-github
 files:
   unchanged-test.json:
     content:

--- a/fixtures/integration-test-unchanged-gitlab.yaml
+++ b/fixtures/integration-test-unchanged-gitlab.yaml
@@ -3,6 +3,7 @@
 # This test has two files:
 # - unchanged-test.json: content matches what's already in the repo (should not appear in MR)
 # - changed-test.json: new content (should appear in MR)
+id: integration-test-unchanged-gitlab
 
 prOptions:
   merge: manual

--- a/fixtures/test-repos-input.yaml
+++ b/fixtures/test-repos-input.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
+id: test-repos
 files:
   my.config.json:
     content:

--- a/src/config-normalizer.test.ts
+++ b/src/config-normalizer.test.ts
@@ -15,6 +15,7 @@ describe("normalizeConfig", () => {
   describe("git array expansion", () => {
     test("expands single git URL to one repo entry", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: { "config.json": { content: { key: "value" } } },
         repos: [{ git: "git@github.com:org/repo.git" }],
       };
@@ -26,6 +27,7 @@ describe("normalizeConfig", () => {
 
     test("expands git array to multiple repo entries", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: { "config.json": { content: { key: "value" } } },
         repos: [
           {
@@ -45,6 +47,7 @@ describe("normalizeConfig", () => {
 
     test("each expanded repo gets all files", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" } },
           "settings.yaml": { content: { enabled: true } },
@@ -66,6 +69,7 @@ describe("normalizeConfig", () => {
 
     test("handles multiple repos with mixed single and array git", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: { "config.json": { content: {} } },
         repos: [
           { git: "git@github.com:org/single.git" },
@@ -86,6 +90,7 @@ describe("normalizeConfig", () => {
   describe("all repos receive all files", () => {
     test("all files delivered to all repos by default", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "eslint.json": { content: { extends: ["base"] } },
           "prettier.json": { content: { semi: true } },
@@ -111,6 +116,7 @@ describe("normalizeConfig", () => {
   describe("file exclusion", () => {
     test("excludes file when set to false", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "eslint.json": { content: { extends: ["base"] } },
           "prettier.json": { content: { semi: true } },
@@ -134,6 +140,7 @@ describe("normalizeConfig", () => {
 
     test("excludes multiple files", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "eslint.json": { content: { extends: ["base"] } },
           "prettier.json": { content: { semi: true } },
@@ -159,6 +166,7 @@ describe("normalizeConfig", () => {
 
     test("different repos can exclude different files", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "eslint.json": { content: { extends: ["base"] } },
           "prettier.json": { content: { semi: true } },
@@ -192,6 +200,7 @@ describe("normalizeConfig", () => {
 
     test("can mix exclusion with overrides", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "eslint.json": { content: { extends: ["base"] } },
           "prettier.json": { content: { semi: true } },
@@ -222,6 +231,7 @@ describe("normalizeConfig", () => {
   describe("content merging", () => {
     test("uses file base content when repo has no override", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { base: "value" } },
         },
@@ -234,6 +244,7 @@ describe("normalizeConfig", () => {
 
     test("merges repo file content with file base content", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { base: "value", override: "original" } },
         },
@@ -257,6 +268,7 @@ describe("normalizeConfig", () => {
 
     test("deep merges nested objects", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { nested: { a: 1, b: 2 } } },
         },
@@ -278,6 +290,7 @@ describe("normalizeConfig", () => {
 
     test("uses override mode when override is true", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { base: "value" } },
         },
@@ -302,6 +315,7 @@ describe("normalizeConfig", () => {
 
     test("respects per-file mergeStrategy", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": {
             content: { items: ["a", "b"] },
@@ -326,6 +340,7 @@ describe("normalizeConfig", () => {
 
     test("strips merge directives from output", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { items: ["a"] } },
         },
@@ -352,6 +367,7 @@ describe("normalizeConfig", () => {
   describe("environment variable interpolation", () => {
     test("interpolates env vars in content", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { value: "${TEST_VAR}" } },
         },
@@ -366,6 +382,7 @@ describe("normalizeConfig", () => {
 
     test("interpolates env vars with defaults", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { value: "${MISSING:-default}" } },
         },
@@ -378,6 +395,7 @@ describe("normalizeConfig", () => {
 
     test("throws on missing required env var", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { value: "${MISSING_VAR}" } },
         },
@@ -394,6 +412,7 @@ describe("normalizeConfig", () => {
   describe("output structure", () => {
     test("preserves fileName in files array", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "my/config.json": { content: { key: "value" } },
         },
@@ -406,6 +425,7 @@ describe("normalizeConfig", () => {
 
     test("output repos are independent (no shared references)", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: { "config.json": { content: { key: "value" } } },
         repos: [
           {
@@ -428,6 +448,7 @@ describe("normalizeConfig", () => {
 
     test("returns empty repos array when input has empty repos", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: { "config.json": { content: {} } },
         repos: [],
       };
@@ -440,6 +461,7 @@ describe("normalizeConfig", () => {
   describe("multiple files with different strategies", () => {
     test("each file uses its own mergeStrategy", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "append.json": {
             content: { items: ["a"] },
@@ -477,6 +499,7 @@ describe("normalizeConfig", () => {
   describe("createOnly propagation", () => {
     test("passes root-level createOnly: true to FileContent", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" }, createOnly: true },
         },
@@ -489,6 +512,7 @@ describe("normalizeConfig", () => {
 
     test("passes root-level createOnly: false to FileContent", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" }, createOnly: false },
         },
@@ -501,6 +525,7 @@ describe("normalizeConfig", () => {
 
     test("createOnly is undefined when not specified", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" } },
         },
@@ -513,6 +538,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo createOnly overrides root-level", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" }, createOnly: true },
         },
@@ -532,6 +558,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo createOnly: true overrides undefined root", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" } },
         },
@@ -551,6 +578,7 @@ describe("normalizeConfig", () => {
 
     test("different repos can have different createOnly values", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" }, createOnly: true },
         },
@@ -574,6 +602,7 @@ describe("normalizeConfig", () => {
 
     test("createOnly works with override mode", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { base: "value" } },
         },
@@ -602,6 +631,7 @@ describe("normalizeConfig", () => {
   describe("empty file handling", () => {
     test("undefined content results in null FileContent", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           ".prettierignore": {},
         },
@@ -614,6 +644,7 @@ describe("normalizeConfig", () => {
 
     test("empty file with createOnly", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           ".prettierignore": { createOnly: true },
         },
@@ -627,6 +658,7 @@ describe("normalizeConfig", () => {
 
     test("repo content merges into undefined root content", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": {},
         },
@@ -646,6 +678,7 @@ describe("normalizeConfig", () => {
 
     test("override with no content creates empty file", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": { content: { base: "value" } },
         },
@@ -667,6 +700,7 @@ describe("normalizeConfig", () => {
   describe("header normalization", () => {
     test("string header normalized to array", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": { content: {}, header: "Single comment" },
         },
@@ -679,6 +713,7 @@ describe("normalizeConfig", () => {
 
     test("array header passed through", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": { content: {}, header: ["Line 1", "Line 2"] },
         },
@@ -691,6 +726,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo header overrides root header", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": { content: {}, header: "Root header" },
         },
@@ -710,6 +746,7 @@ describe("normalizeConfig", () => {
 
     test("header is undefined when not specified", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": { content: {} },
         },
@@ -724,6 +761,7 @@ describe("normalizeConfig", () => {
   describe("schemaUrl propagation", () => {
     test("root schemaUrl passed to FileContent", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": {
             content: {},
@@ -742,6 +780,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo schemaUrl overrides root", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": {
             content: {},
@@ -767,6 +806,7 @@ describe("normalizeConfig", () => {
 
     test("schemaUrl is undefined when not specified", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": { content: {} },
         },
@@ -779,6 +819,7 @@ describe("normalizeConfig", () => {
 
     test("empty file with schemaUrl", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.yaml": { schemaUrl: "https://example.com/schema.json" },
         },
@@ -797,6 +838,7 @@ describe("normalizeConfig", () => {
   describe("type safety", () => {
     test("throws when merging text base with object overlay", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           ".gitignore": { content: "node_modules" }, // text content
         },
@@ -821,6 +863,7 @@ describe("normalizeConfig", () => {
   describe("prTemplate propagation", () => {
     test("prTemplate passed through to Config", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: { "config.json": { content: { key: "value" } } },
         repos: [{ git: "git@github.com:org/repo.git" }],
         prTemplate: "## Custom Template\n\n${xfg:pr.fileChanges}",
@@ -835,6 +878,7 @@ describe("normalizeConfig", () => {
 
     test("missing prTemplate results in undefined", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: { "config.json": { content: { key: "value" } } },
         repos: [{ git: "git@github.com:org/repo.git" }],
       };
@@ -847,6 +891,7 @@ describe("normalizeConfig", () => {
   describe("executable propagation", () => {
     test("passes root-level executable: true to FileContent", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "deploy.sh": { content: "#!/bin/bash", executable: true },
         },
@@ -859,6 +904,7 @@ describe("normalizeConfig", () => {
 
     test("passes root-level executable: false to FileContent", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "script.sh": { content: "#!/bin/bash", executable: false },
         },
@@ -871,6 +917,7 @@ describe("normalizeConfig", () => {
 
     test("executable is undefined when not specified", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" } },
         },
@@ -883,6 +930,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo executable overrides root-level", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "script.sh": { content: "#!/bin/bash", executable: true },
         },
@@ -902,6 +950,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo executable: true overrides undefined root", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           run: { content: "#!/bin/bash" },
         },
@@ -921,6 +970,7 @@ describe("normalizeConfig", () => {
 
     test("different repos can have different executable values", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "script.sh": { content: "#!/bin/bash", executable: true },
         },
@@ -944,6 +994,7 @@ describe("normalizeConfig", () => {
   describe("template propagation", () => {
     test("template: true from root is propagated", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "README.md": { content: "# ${xfg:repo.name}", template: true },
         },
@@ -956,6 +1007,7 @@ describe("normalizeConfig", () => {
 
     test("template is undefined when not specified", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" } },
         },
@@ -968,6 +1020,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo template overrides root-level", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: {}, template: true },
         },
@@ -987,6 +1040,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo template: true overrides undefined root", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: {} },
         },
@@ -1006,6 +1060,7 @@ describe("normalizeConfig", () => {
 
     test("different repos can have different template values", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "README.md": { content: "# ${xfg:repo.name}", template: true },
         },
@@ -1029,6 +1084,7 @@ describe("normalizeConfig", () => {
   describe("vars merging", () => {
     test("root-level vars are propagated", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": {
             content: {},
@@ -1048,6 +1104,7 @@ describe("normalizeConfig", () => {
 
     test("vars is undefined when not specified", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: {}, template: true },
         },
@@ -1060,6 +1117,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo vars merge with root-level vars", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": {
             content: {},
@@ -1087,6 +1145,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo vars override root-level vars for same key", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": {
             content: {},
@@ -1113,6 +1172,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo vars only (no root vars)", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: {}, template: true },
         },
@@ -1132,6 +1192,7 @@ describe("normalizeConfig", () => {
 
     test("different repos can have different vars", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": {
             content: {},
@@ -1162,6 +1223,7 @@ describe("normalizeConfig", () => {
   describe("deleteOrphaned propagation", () => {
     test("global deleteOrphaned: true propagates to all files", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" } },
           "settings.yaml": { content: { enabled: true } },
@@ -1178,6 +1240,7 @@ describe("normalizeConfig", () => {
 
     test("deleteOrphaned is undefined when not specified", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" } },
         },
@@ -1191,6 +1254,7 @@ describe("normalizeConfig", () => {
 
     test("per-file deleteOrphaned overrides global default", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" }, deleteOrphaned: true },
           "settings.yaml": { content: { enabled: true } },
@@ -1206,6 +1270,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo deleteOrphaned overrides per-file and global", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" }, deleteOrphaned: true },
         },
@@ -1226,6 +1291,7 @@ describe("normalizeConfig", () => {
 
     test("different repos can have different deleteOrphaned values", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" }, deleteOrphaned: true },
         },
@@ -1249,6 +1315,7 @@ describe("normalizeConfig", () => {
 
     test("per-repo deleteOrphaned: true overrides undefined per-file and global", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" } },
         },
@@ -1268,6 +1335,7 @@ describe("normalizeConfig", () => {
 
     test("deleteOrphaned works with file exclusion", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "config.json": { content: { key: "value" }, deleteOrphaned: true },
           "settings.yaml": { content: { enabled: true }, deleteOrphaned: true },
@@ -1291,6 +1359,7 @@ describe("normalizeConfig", () => {
 
     test("inheritance order: per-repo > per-file > global", () => {
       const raw: RawConfig = {
+        id: "test-config",
         files: {
           "file1.json": { content: {} }, // inherits global
           "file2.json": { content: {}, deleteOrphaned: false }, // per-file overrides global

--- a/src/config-normalizer.ts
+++ b/src/config-normalizer.ts
@@ -191,6 +191,7 @@ export function normalizeConfig(raw: RawConfig): Config {
   }
 
   return {
+    id: raw.id,
     repos: expandedRepos,
     prTemplate: raw.prTemplate,
     githubHosts: raw.githubHosts,

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -33,11 +33,34 @@ function isStructuredFileExtension(fileName: string): boolean {
   );
 }
 
+// Pattern for valid config ID: alphanumeric, hyphens, underscores
+const CONFIG_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const CONFIG_ID_MAX_LENGTH = 64;
+
 /**
  * Validates raw config structure before normalization.
  * @throws Error if validation fails
  */
 export function validateRawConfig(config: RawConfig): void {
+  // Validate required id field
+  if (!config.id || typeof config.id !== "string") {
+    throw new Error(
+      "Config requires an 'id' field. This unique identifier is used to namespace managed files in .xfg.json",
+    );
+  }
+
+  if (!CONFIG_ID_PATTERN.test(config.id)) {
+    throw new Error(
+      `Config 'id' contains invalid characters: '${config.id}'. Use only alphanumeric characters, hyphens, and underscores.`,
+    );
+  }
+
+  if (config.id.length > CONFIG_ID_MAX_LENGTH) {
+    throw new Error(
+      `Config 'id' exceeds maximum length of ${CONFIG_ID_MAX_LENGTH} characters`,
+    );
+  }
+
   if (!config.files || typeof config.files !== "object") {
     throw new Error("Config missing required field: files (must be an object)");
   }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -35,6 +35,7 @@ describe("Config", () => {
   describe("validation", () => {
     test("throws when files is missing", () => {
       const path = createTestConfig(`
+id: test-config
 repos:
   - git: git@github.com:org/repo.git
 `);
@@ -46,6 +47,7 @@ repos:
 
     test("throws when repos is missing", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -59,6 +61,7 @@ files:
 
     test("throws when repos is not an array", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -70,6 +73,7 @@ repos: not-an-array
 
     test("throws when repo.git is missing", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -88,6 +92,7 @@ repos:
 
     test("throws when file name contains path traversal", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   ../escape.json:
     content:
@@ -103,6 +108,7 @@ repos:
 
     test("throws when file name is absolute path", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   /etc/passwd:
     content:
@@ -118,6 +124,7 @@ repos:
 
     test("allows nested relative paths without traversal", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config/settings.json:
     content:
@@ -131,6 +138,7 @@ repos:
 
     test("validates git field in array syntax", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -148,6 +156,7 @@ repos:
   describe("git array expansion", () => {
     test("single git string unchanged", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -162,6 +171,7 @@ repos:
 
     test("git array expands to multiple entries", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -181,6 +191,7 @@ repos:
 
     test("preserves content across expanded entries", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -199,6 +210,7 @@ repos:
   describe("content merging", () => {
     test("uses file base content when repo has no override", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -217,6 +229,7 @@ repos:
 
     test("merges repo file content onto file base content", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -240,6 +253,7 @@ repos:
 
     test("deep merges nested objects", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -263,6 +277,7 @@ repos:
 
     test("override: true uses only repo file content", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -285,6 +300,7 @@ repos:
 
     test("override requires content field", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -303,6 +319,7 @@ repos:
 
     test("arrays are replaced by default", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -325,6 +342,7 @@ repos:
 
     test("per-file mergeStrategy: append concatenates arrays", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     mergeStrategy: append
@@ -351,6 +369,7 @@ repos:
   describe("environment variable interpolation", () => {
     test("interpolates env vars in content values", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -366,6 +385,7 @@ repos:
 
     test("throws on missing env var by default", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -381,6 +401,7 @@ repos:
 
     test("uses default value when env var missing", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -398,6 +419,7 @@ repos:
   describe("multiple files", () => {
     test("all repos receive all files by default", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   eslint.json:
     content:
@@ -418,6 +440,7 @@ repos:
 
     test("each file can have its own mergeStrategy", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   append.json:
     mergeStrategy: append
@@ -455,6 +478,7 @@ repos:
   describe("integration", () => {
     test("full config with all features", () => {
       const path = createTestConfig(`
+id: test-config
 files:
   my.config.json:
     content:
@@ -518,6 +542,7 @@ repos:
       writeFileSync(templatePath, '{"base": true, "version": "1.0"}', "utf-8");
 
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content: "@templates/base.json"
@@ -541,6 +566,7 @@ repos:
       );
 
       const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content: "@templates/base.json"
@@ -565,6 +591,7 @@ repos:
       writeFileSync(templatePath, "node_modules/\ndist/", "utf-8");
 
       const path = createTestConfig(`
+id: test-config
 files:
   .gitignore:
     content: "@templates/gitignore.txt"
@@ -584,6 +611,7 @@ repos:
       writeFileSync(templatePath, "root: true\nenv:\n  node: true", "utf-8");
 
       const path = createTestConfig(`
+id: test-config
 files:
   .eslintrc.yaml:
     content: "@templates/eslint.yaml"
@@ -612,6 +640,7 @@ describe("prOptions", () => {
 
   test("parses global prOptions", () => {
     const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -633,6 +662,7 @@ repos:
 
   test("parses per-repo prOptions", () => {
     const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -652,6 +682,7 @@ repos:
 
   test("per-repo prOptions overrides global", () => {
     const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -675,6 +706,7 @@ repos:
 
   test("per-repo prOptions partial override", () => {
     const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -703,6 +735,7 @@ repos:
 
   test("no prOptions returns undefined", () => {
     const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:
@@ -716,6 +749,7 @@ repos:
 
   test("prOptions with git array expansion", () => {
     const path = createTestConfig(`
+id: test-config
 files:
   config.json:
     content:

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,7 @@ export interface RawRepoConfig {
 
 // Root config structure
 export interface RawConfig {
+  id: string;
   files: Record<string, RawFileConfig>;
   repos: RawRepoConfig[];
   prOptions?: PRMergeOptions;
@@ -100,6 +101,7 @@ export interface RepoConfig {
 
 // Normalized config
 export interface Config {
+  id: string;
   repos: RepoConfig[];
   prTemplate?: string;
   githubHosts?: string[];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -83,6 +83,7 @@ describe("CLI", () => {
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -111,6 +112,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -141,6 +143,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -171,6 +174,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -200,6 +204,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -229,6 +234,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -259,6 +265,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -289,6 +296,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -320,6 +328,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -352,6 +361,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -383,6 +393,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -415,6 +426,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -471,6 +483,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -493,6 +506,7 @@ files:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   test.json:
     content:
@@ -521,6 +535,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   my-config.json:
     content:
@@ -548,6 +563,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   my-config.json:
     content:
@@ -576,6 +592,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   config.json:
     content:
@@ -607,6 +624,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   config1.json:
     content:
@@ -644,6 +662,7 @@ repos:
       writeFileSync(
         testConfigPath,
         `
+id: test-config
 files:
   config.json:
     content:

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,7 @@ async function main(): Promise<void> {
       const result = await processor.process(repoConfig, repoInfo, {
         branchName,
         workDir,
+        configId: config.id,
         dryRun: options.dryRun,
         retries: options.retries,
         prTemplate: config.prTemplate,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,9 +3,41 @@ import { join } from "node:path";
 
 export const MANIFEST_FILENAME = ".xfg.json";
 
-export interface XfgManifest {
+// V1 manifest structure (legacy - for migration detection only)
+interface XfgManifestV1 {
   version: 1;
   managedFiles: string[];
+}
+
+// V2 manifest structure (current)
+export interface XfgManifest {
+  version: 2;
+  configs: Record<string, string[]>; // configId -> managedFiles
+}
+
+/**
+ * Type guard to check if a manifest is v1 format.
+ */
+function isV1Manifest(manifest: unknown): manifest is XfgManifestV1 {
+  return (
+    typeof manifest === "object" &&
+    manifest !== null &&
+    (manifest as XfgManifestV1).version === 1 &&
+    Array.isArray((manifest as XfgManifestV1).managedFiles)
+  );
+}
+
+/**
+ * Type guard to check if a manifest is v2 format.
+ */
+function isV2Manifest(manifest: unknown): manifest is XfgManifest {
+  return (
+    typeof manifest === "object" &&
+    manifest !== null &&
+    (manifest as XfgManifest).version === 2 &&
+    typeof (manifest as XfgManifest).configs === "object" &&
+    (manifest as XfgManifest).configs !== null
+  );
 }
 
 /**
@@ -13,17 +45,21 @@ export interface XfgManifest {
  */
 export function createEmptyManifest(): XfgManifest {
   return {
-    version: 1,
-    managedFiles: [],
+    version: 2,
+    configs: {},
   };
 }
 
 /**
  * Loads the xfg manifest from a repository's working directory.
- * Returns null if the manifest file doesn't exist.
+ * Returns null if the manifest file doesn't exist or is v1 format.
+ *
+ * V1 manifests are treated as non-existent because they lack the config ID
+ * namespace required for multi-config support. The next run will create
+ * a fresh v2 manifest.
  *
  * @param workDir - The repository working directory
- * @returns The manifest or null if not found
+ * @returns The manifest or null if not found or incompatible
  */
 export function loadManifest(workDir: string): XfgManifest | null {
   const manifestPath = join(workDir, MANIFEST_FILENAME);
@@ -34,22 +70,20 @@ export function loadManifest(workDir: string): XfgManifest | null {
 
   try {
     const content = readFileSync(manifestPath, "utf-8");
-    const parsed = JSON.parse(content) as XfgManifest;
+    const parsed = JSON.parse(content) as unknown;
 
-    // Validate the manifest structure
-    if (typeof parsed !== "object" || parsed === null) {
+    // V2 manifest - return as-is
+    if (isV2Manifest(parsed)) {
+      return parsed;
+    }
+
+    // V1 manifest - treat as no manifest (will be overwritten with v2)
+    if (isV1Manifest(parsed)) {
       return null;
     }
 
-    if (parsed.version !== 1) {
-      return null;
-    }
-
-    if (!Array.isArray(parsed.managedFiles)) {
-      return null;
-    }
-
-    return parsed;
+    // Unknown format - treat as no manifest
+    return null;
   } catch {
     return null;
   }
@@ -68,34 +102,43 @@ export function saveManifest(workDir: string, manifest: XfgManifest): void {
 }
 
 /**
- * Gets the list of managed files from a manifest.
- * Returns an empty array if the manifest is null.
+ * Gets the list of managed files for a specific config from a manifest.
+ * Returns an empty array if the manifest is null or the config isn't found.
  *
  * @param manifest - The manifest or null
- * @returns Array of managed file names
+ * @param configId - The config ID to get files for
+ * @returns Array of managed file names for the given config
  */
-export function getManagedFiles(manifest: XfgManifest | null): string[] {
+export function getManagedFiles(
+  manifest: XfgManifest | null,
+  configId: string,
+): string[] {
   if (!manifest) {
     return [];
   }
-  return [...manifest.managedFiles];
+  return [...(manifest.configs[configId] ?? [])];
 }
 
 /**
- * Updates the manifest with the current set of files that have deleteOrphaned enabled.
+ * Updates the manifest with the current set of files that have deleteOrphaned enabled
+ * for a specific config. Only modifies that config's namespace - other configs are untouched.
+ *
  * Files with deleteOrphaned: true are added to managedFiles.
  * Files with deleteOrphaned: false (explicit) are removed from managedFiles.
- * Files not in the config but in managedFiles are candidates for deletion.
+ * Files not in the config but in managedFiles for this configId are candidates for deletion.
  *
  * @param manifest - The existing manifest (or null for new repos)
+ * @param configId - The config ID to update
  * @param filesWithDeleteOrphaned - Map of fileName to deleteOrphaned value (true/false/undefined)
  * @returns Updated manifest and list of files to delete
  */
 export function updateManifest(
   manifest: XfgManifest | null,
+  configId: string,
   filesWithDeleteOrphaned: Map<string, boolean | undefined>,
 ): { manifest: XfgManifest; filesToDelete: string[] } {
-  const existingManaged = new Set(getManagedFiles(manifest));
+  // Get existing managed files for this config only
+  const existingManaged = new Set(getManagedFiles(manifest, configId));
   const newManaged = new Set<string>();
   const filesToDelete: string[] = [];
 
@@ -109,7 +152,7 @@ export function updateManifest(
     // (explicitly setting false removes from tracking)
   }
 
-  // Find orphaned files: in old manifest but not in current config
+  // Find orphaned files: in old manifest for this config but not in current config
   for (const fileName of existingManaged) {
     if (!filesWithDeleteOrphaned.has(fileName)) {
       // File was managed before but is no longer in config - delete it
@@ -117,10 +160,24 @@ export function updateManifest(
     }
   }
 
+  // Build updated manifest, preserving other configs
+  const updatedConfigs: Record<string, string[]> = {
+    ...(manifest?.configs ?? {}),
+  };
+
+  // Update this config's managed files
+  const sortedManaged = Array.from(newManaged).sort();
+  if (sortedManaged.length > 0) {
+    updatedConfigs[configId] = sortedManaged;
+  } else {
+    // Remove config entry if no managed files
+    delete updatedConfigs[configId];
+  }
+
   return {
     manifest: {
-      version: 1,
-      managedFiles: Array.from(newManaged).sort(),
+      version: 2,
+      configs: updatedConfigs,
     },
     filesToDelete,
   };

--- a/src/repository-processor.test.ts
+++ b/src/repository-processor.test.ts
@@ -60,6 +60,7 @@ describe("RepositoryProcessor", () => {
         await processor.process(mockRepoConfig, mockRepoInfo, {
           branchName: "chore/sync-config",
           workDir,
+          configId: "test-config",
           dryRun: true,
           executor: createMockExecutor(),
         });
@@ -80,6 +81,7 @@ describe("RepositoryProcessor", () => {
         await processor.process(mockRepoConfig, mockRepoInfo, {
           branchName: "chore/sync-config",
           workDir,
+          configId: "test-config",
           dryRun: false,
           executor: createMockExecutor(),
         });
@@ -218,6 +220,7 @@ describe("RepositoryProcessor", () => {
       const result = await processor.process(mockRepoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -242,6 +245,7 @@ describe("RepositoryProcessor", () => {
       const result = await processor.process(mockRepoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true, // Use dry run to avoid actual git/PR operations
       });
 
@@ -271,6 +275,7 @@ describe("RepositoryProcessor", () => {
       const result = await processor.process(mockRepoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true, // Use dry run to avoid actual git/PR operations
       });
 
@@ -390,6 +395,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -418,6 +424,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -448,6 +455,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -476,6 +484,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -680,6 +689,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -712,6 +722,7 @@ describe("RepositoryProcessor", () => {
       const result = await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -754,6 +765,7 @@ describe("RepositoryProcessor", () => {
       const result = await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -794,6 +806,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -828,6 +841,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -860,6 +874,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -934,6 +949,7 @@ describe("RepositoryProcessor", () => {
       const result = await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: mockExecutor,
       });
@@ -1048,6 +1064,7 @@ describe("RepositoryProcessor", () => {
       const result = await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -1087,6 +1104,7 @@ describe("RepositoryProcessor", () => {
       const result = await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -1133,7 +1151,10 @@ describe("RepositoryProcessor", () => {
       mkdirSync(localWorkDir, { recursive: true });
       writeFileSync(
         join(localWorkDir, ".xfg.json"),
-        JSON.stringify({ version: 1, managedFiles: ["config.json"] }),
+        JSON.stringify({
+          version: 2,
+          configs: { "test-config": ["config.json"] },
+        }),
       );
 
       const repoConfig: RepoConfig = {
@@ -1151,6 +1172,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -1276,6 +1298,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -1319,6 +1342,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -1432,6 +1456,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -1479,6 +1504,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -1698,7 +1724,10 @@ describe("RepositoryProcessor", () => {
       mkdirSync(localWorkDir, { recursive: true });
       writeFileSync(
         join(localWorkDir, ".xfg.json"),
-        JSON.stringify({ version: 1, managedFiles: ["orphaned.json"] }),
+        JSON.stringify({
+          version: 2,
+          configs: { "test-config": ["orphaned.json"] },
+        }),
       );
 
       // Config only has config.json (orphaned.json removed)
@@ -1716,6 +1745,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -1744,7 +1774,10 @@ describe("RepositoryProcessor", () => {
       mkdirSync(localWorkDir, { recursive: true });
       writeFileSync(
         join(localWorkDir, ".xfg.json"),
-        JSON.stringify({ version: 1, managedFiles: ["orphaned.json"] }),
+        JSON.stringify({
+          version: 2,
+          configs: { "test-config": ["orphaned.json"] },
+        }),
       );
 
       const repoConfig: RepoConfig = {
@@ -1755,6 +1788,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
         noDelete: true,
@@ -1789,7 +1823,10 @@ describe("RepositoryProcessor", () => {
       mkdirSync(localWorkDir, { recursive: true });
       writeFileSync(
         join(localWorkDir, ".xfg.json"),
-        JSON.stringify({ version: 1, managedFiles: ["orphaned.json"] }),
+        JSON.stringify({
+          version: 2,
+          configs: { "test-config": ["orphaned.json"] },
+        }),
       );
 
       const repoConfig: RepoConfig = {
@@ -1806,6 +1843,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: true,
         executor: createMockExecutor(),
       });
@@ -1843,7 +1881,10 @@ describe("RepositoryProcessor", () => {
       mkdirSync(localWorkDir, { recursive: true });
       writeFileSync(
         join(localWorkDir, ".xfg.json"),
-        JSON.stringify({ version: 1, managedFiles: ["orphaned.json"] }),
+        JSON.stringify({
+          version: 2,
+          configs: { "test-config": ["orphaned.json"] },
+        }),
       );
 
       const repoConfig: RepoConfig = {
@@ -1860,6 +1901,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -1992,6 +2034,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -2038,6 +2081,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -2084,6 +2128,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -2138,6 +2183,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });
@@ -2186,6 +2232,7 @@ describe("RepositoryProcessor", () => {
       await processor.process(repoConfig, mockRepoInfo, {
         branchName: "chore/sync-config",
         workDir: localWorkDir,
+        configId: "test-config",
         dryRun: false,
         executor: createMockExecutor(),
       });


### PR DESCRIPTION
## Summary

- Add required `id` field to configs to enable multiple xfg configs to manage the same repository without conflicts
- Each config's managed files are now namespaced by their config ID in the `.xfg.json` manifest
- V1 manifests are treated as no manifest (seamless migration on next run)

**BREAKING CHANGE:** Config `id` field is now required. Existing configs must add an `id` field.

## Manifest v2 Structure

```json
{
  "version": 2,
  "configs": {
    "team-a-standards": ["foo.json", "bar.yaml"],
    "team-b-standards": ["baz.json"]
  }
}
```

## Changes

- Add `id` field to `RawConfig` and `Config` interfaces
- Add validation for id (required, alphanumeric/hyphens/underscores, 1-64 chars)
- Update manifest to v2 format with `configs` namespace
- Pass `configId` through processor options to manifest functions
- Update JSON schema with `id` property
- Update all documentation and examples with `id` field
- Update all fixture configs with `id` field

## Test plan

- [x] All 1027 unit tests pass
- [ ] CI passes
- [ ] Code coverage remains above 95%
- [ ] Integration tests pass

Closes #211

🤖 Generated with [Claude Code](https://claude.ai/code)