### PR TITLE
docs: improve $arrayMerge directive documentation

### DIFF
--- a/docs/examples/merge-strategies.md
+++ b/docs/examples/merge-strategies.md
@@ -58,3 +58,86 @@ repos:
 | `replace` | Overlay completely replaces base (default) |
 | `append`  | Overlay items added after base items       |
 | `prepend` | Overlay items added before base items      |
+
+## Inline `$arrayMerge` Directive
+
+For per-repo array control without setting a file-level strategy, use the `$arrayMerge` directive within content.
+
+### Wrapped Syntax
+
+```yaml
+id: my-org-config
+files:
+  service.config.json:
+    content:
+      features: ["health-check", "metrics"]
+      plugins: ["auth"]
+
+repos:
+  # Platform team - append extra features
+  - git: git@github.com:org/api-gateway.git
+    files:
+      service.config.json:
+        content:
+          features:
+            $arrayMerge: append
+            values: ["tracing", "rate-limiting"]
+
+  # Data team - prepend their plugin
+  - git: git@github.com:org/data-pipeline.git
+    files:
+      service.config.json:
+        content:
+          plugins:
+            $arrayMerge: prepend
+            values: ["data-transform"]
+```
+
+**api-gateway result:**
+
+```json
+{
+  "features": ["health-check", "metrics", "tracing", "rate-limiting"],
+  "plugins": ["auth"]
+}
+```
+
+**data-pipeline result:**
+
+```json
+{
+  "features": ["health-check", "metrics"],
+  "plugins": ["data-transform", "auth"]
+}
+```
+
+### Sibling Syntax
+
+Use `$arrayMerge` as a sibling key to apply the strategy to all arrays in that object:
+
+```yaml
+id: my-org-config
+files:
+  config.json:
+    content:
+      features: ["core"]
+      tags: ["standard"]
+
+repos:
+  - git: git@github.com:org/repo.git
+    files:
+      config.json:
+        content:
+          $arrayMerge: append
+          features: ["custom"]
+          tags: ["team-a"]
+```
+
+**Result** (both arrays appended):
+
+```json
+{
+  "features": ["core", "custom"],
+  "tags": ["standard", "team-a"]
+}
+```


### PR DESCRIPTION
## Summary

- Add "File-Level vs Inline Control" section explaining when to use `mergeStrategy` vs `$arrayMerge`
- Document the sibling directive syntax (previously undocumented) where `$arrayMerge` applies to all child arrays
- Show all three strategies (append, prepend, replace) with clear examples
- Add note that directives are stripped from final output
- Add comprehensive examples to the examples page demonstrating both syntaxes

## Test plan

- [ ] Preview docs locally with `mkdocs serve`
- [ ] Verify code blocks render correctly
- [ ] Check examples match behavior in `src/merge.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)