### PR TITLE
fix: revert tsconfig.json and add coverage tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,19 @@ npm run test:integration:gitlab # Build + GitLab integration test (requires glab
 npm run dev                     # Run CLI via ts-node (pass config file as argument)
 ```
 
+## Pre-PR Checklist
+
+**IMPORTANT: Before creating any PR, you MUST run and verify:**
+
+1. **Unit tests pass**: `npm test`
+2. **Linting passes**: `./lint.sh`
+3. **Integration tests pass** (if code changes affect CLI behavior):
+   - `npm run test:integration:github` (requires `gh auth login`)
+   - `npm run test:integration:ado` (requires `az login`)
+   - `npm run test:integration:gitlab` (requires `glab auth login`)
+
+Do not create a PR until all applicable tests pass locally.
+
 ## Release Process
 
 Run the Release workflow via Actions UI or CLI:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,22 +4,22 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "./dist",
-    "rootDir": ".",
+    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "resolveJsonModule": true,
-    "noEmit": false
+    "resolveJsonModule": true
   },
   "include": [
-    "src/**/*",
-    "test/**/*"
+    "src/**/*"
   ],
   "exclude": [
     "node_modules",
     "dist",
-    "scripts"
+    "test",
+    "scripts",
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Revert tsconfig.json to original state (fixes broken build output from PR #230)
- Add tests for text content handling in config-normalizer
- Update CLAUDE.md with pre-PR checklist requiring tests

## Problem
PR #230 changed tsconfig.json to include test files, which broke the build output structure:
- Before: `dist/index.js`
- After: `dist/src/index.js`

This caused all integration tests to fail in CI with `Cannot find module 'dist/index.js'`.

## Test plan
- [x] Unit tests pass locally (`npm test` - 1037 tests)
- [x] Lint passes (`./lint.sh`)
- [x] GitHub integration tests pass (`npm run test:integration:github`)
- [x] Build produces correct output (`dist/index.js` exists)

Generated with [Claude Code](https://claude.com/claude-code)