### PR TITLE
fix: prevent CLI tests from polluting CI job summary

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,10 +14,15 @@ const testDir = join(process.cwd(), "test-cli-tmp");
 const testConfigPath = join(testDir, "test-config.yaml");
 
 // Helper to run CLI and capture output
+// By default, unsets GITHUB_STEP_SUMMARY to prevent tests from writing to CI job summary
 function runCLI(
   args: string[],
-  options?: { timeout?: number; env?: Record<string, string> }
+  options?: { timeout?: number; env?: Record<string, string | undefined> }
 ): { stdout: string; stderr: string; success: boolean } {
+  // Create env with GITHUB_STEP_SUMMARY unset by default
+  const { GITHUB_STEP_SUMMARY: _, ...envWithoutSummary } = process.env;
+  const testEnv = { ...envWithoutSummary, ...options?.env };
+
   try {
     const stdout = execFileSync(
       "node",
@@ -26,7 +31,7 @@ function runCLI(
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
         timeout: options?.timeout ?? 10000,
-        env: { ...process.env, ...options?.env },
+        env: testEnv,
       }
     );
     return { stdout, stderr: "", success: true };


### PR DESCRIPTION
## Summary

Fixes the issue where CLI tests were writing multiple job summaries to the CI workflow.

## Problem

The runCLI helper was inheriting GITHUB_STEP_SUMMARY from the CI environment, causing every CLI test run to write a summary to the workflow's job summary file. This resulted in 20+ duplicate "Config Sync Summary" entries.

## Solution

The runCLI helper now explicitly removes GITHUB_STEP_SUMMARY from the environment before spawning the test process. Tests that need to verify the summary feature can still set it via the options parameter.

## Test plan

- [x] All 1083 tests pass
- [x] Verified no summary file is created when GITHUB_STEP_SUMMARY is set at shell level but test doesn't pass it through

🤖 Generated with [Claude Code](https://claude.com/claude-code)