### PR TITLE
fix: pin @types/node to v24 to match Node runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "xfg": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^25.0.7",
+        "@types/node": "^24.0.0",
         "c8": "^10.1.3",
         "tsx": "^4.15.0",
         "typescript": "^5.4.5"
@@ -555,9 +555,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "version": "24.10.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
+      "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "yaml": "^2.4.5"
   },
   "devDependencies": {
-    "@types/node": "^25.0.7",
+    "@types/node": "^24.0.0",
     "c8": "^10.1.3",
     "tsx": "^4.15.0",
     "typescript": "^5.4.5"


### PR DESCRIPTION
## Summary

- Pin `@types/node` to `^24.0.0` to match the Node 24 runtime used in CI
- Previously was at v25 which is for unreleased Node 25

## Context

- All CI workflows use `node-version: "24"`
- `@types/node` v25 types are for Node 25 (not yet released)
- Related: https://github.com/anthony-spruyt/repo-operator/issues/58 (Renovate config fix)

## Test plan

- [x] `npm install` succeeds
- [x] Types still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)