### PR TITLE
ci: fix GitHub App integration test workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,13 +235,12 @@ jobs:
         with:
           app-id: ${{ vars.TEST_APP_ID }}
           private-key: ${{ secrets.TEST_APP_PRIVATE_KEY }}
+          owner: anthony-spruyt
 
-      - name: Configure git
+      - name: Configure git credentials
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Run GitHub App integration tests


### PR DESCRIPTION
## Summary

Fixes the GitHub App integration test workflow.

## Changes

1. Add `owner: anthony-spruyt` to specify where the app is installed (was failing with 404 trying to get installation for xfg repo instead of xfg-test)
2. Remove unnecessary git user.name/email config (GraphQL API sets commit author automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)