### PR TITLE
fix: GitHub App integration test fixtures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,12 +203,12 @@ jobs:
         run: npm run test:integration:gitlab
 
   integration-test-github-app:
-    needs: [build, security]
+    needs: [build, security, integration-test-github]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     concurrency:
-      group: integration-github-app
+      group: integration-github
       cancel-in-progress: false
 
     steps:

--- a/fixtures/integration-test-github-app-delete-phase1.yaml
+++ b/fixtures/integration-test-github-app-delete-phase1.yaml
@@ -19,4 +19,4 @@ files:
       phase: 1
 
 repos:
-  - git: git@github.com:anthony-spruyt/xfg-test.git
+  - git: https://github.com/anthony-spruyt/xfg-test.git

--- a/fixtures/integration-test-github-app-delete-phase2.yaml
+++ b/fixtures/integration-test-github-app-delete-phase2.yaml
@@ -16,4 +16,4 @@ files:
       phase: 2
 
 repos:
-  - git: git@github.com:anthony-spruyt/xfg-test.git
+  - git: https://github.com/anthony-spruyt/xfg-test.git

--- a/fixtures/integration-test-github-app-direct.yaml
+++ b/fixtures/integration-test-github-app-direct.yaml
@@ -2,6 +2,8 @@
 # Uses GH_INSTALLATION_TOKEN for GraphQL commit API
 # Pushes directly to main without creating a PR
 
+id: integration-test-github-app-direct
+
 prOptions:
   branch: chore/sync-github-app-direct
   merge: direct
@@ -14,4 +16,4 @@ files:
       verifiedCommit: true
 
 repos:
-  - git: git@github.com:anthony-spruyt/xfg-test.git
+  - git: https://github.com/anthony-spruyt/xfg-test.git

--- a/fixtures/integration-test-github-app.yaml
+++ b/fixtures/integration-test-github-app.yaml
@@ -1,6 +1,8 @@
 # Integration test config for GitHub App verified commits
 # Uses GH_INSTALLATION_TOKEN for GraphQL commit API
 
+id: integration-test-github-app
+
 prOptions:
   branch: chore/sync-github-app-test
   title: "chore: sync github-app-test.json"
@@ -14,4 +16,4 @@ files:
       verifiedCommit: true
 
 repos:
-  - git: git@github.com:anthony-spruyt/xfg-test.git
+  - git: https://github.com/anthony-spruyt/xfg-test.git


### PR DESCRIPTION
## Summary

Fixes the GitHub App integration tests that failed in CI.

## Issues Fixed

1. **Missing `id` field** - Config files now have required `id` field
2. **SSH URLs** - Changed to HTTPS URLs for token-based authentication
3. **Parallel conflicts** - GitHub App tests now run after GitHub tests (same test repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)