### PR TITLE
feat(action): add github-app-token input for verified commits

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,7 @@ self-hosted-runner:
   labels: []
 config-variables:
   - RELEASE_APP_ID
+  - TEST_APP_ID
 paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,9 @@ inputs:
   gitlab-token:
     description: "GitLab token for authentication"
     required: false
+  github-app-token:
+    description: "GitHub App installation token for verified commits (overrides github-token for GitHub repos)"
+    required: false
 
 runs:
   using: "composite"
@@ -70,6 +73,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_APP_TOKEN: ${{ inputs.github-app-token }}
         AZURE_DEVOPS_TOKEN: ${{ inputs.azure-devops-token }}
         GITLAB_TOKEN: ${{ inputs.gitlab-token }}
       run: |
@@ -82,7 +86,10 @@ runs:
         fi
 
         # GitHub - URL rewrite for authentication
-        if [ -n "${GITHUB_TOKEN}" ]; then
+        # GitHub App token takes precedence over PAT
+        if [ -n "${GITHUB_APP_TOKEN}" ]; then
+          git config --global url."https://x-access-token:${GITHUB_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+        elif [ -n "${GITHUB_TOKEN}" ]; then
           git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         fi
 
@@ -106,6 +113,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        GH_INSTALLATION_TOKEN: ${{ inputs.github-app-token }}
         AZURE_DEVOPS_EXT_PAT: ${{ inputs.azure-devops-token }}
         GITLAB_TOKEN: ${{ inputs.gitlab-token }}
       run: |

--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -15,19 +15,20 @@ The simplest way to use xfg in GitHub Actions is with the official action:
 
 ### Action Inputs
 
-| Input                | Required | Default               | Description                                                |
-| -------------------- | -------- | --------------------- | ---------------------------------------------------------- |
-| `config`             | Yes      | -                     | Path to YAML config file                                   |
-| `dry-run`            | No       | `false`               | Preview mode - show what would change without creating PRs |
-| `work-dir`           | No       | `./tmp`               | Directory for cloning repositories                         |
-| `retries`            | No       | `3`                   | Number of network retries                                  |
-| `branch`             | No       | -                     | Override sync branch name                                  |
-| `merge`              | No       | -                     | PR merge mode (`manual`/`auto`/`force`/`direct`)           |
-| `merge-strategy`     | No       | -                     | Merge strategy (`merge`/`squash`/`rebase`)                 |
-| `delete-branch`      | No       | `false`               | Delete branch after merge                                  |
-| `github-token`       | No       | `${{ github.token }}` | GitHub token for authentication                            |
-| `azure-devops-token` | No       | -                     | Azure DevOps Personal Access Token                         |
-| `gitlab-token`       | No       | -                     | GitLab token for authentication                            |
+| Input                | Required | Default               | Description                                                                   |
+| -------------------- | -------- | --------------------- | ----------------------------------------------------------------------------- |
+| `config`             | Yes      | -                     | Path to YAML config file                                                      |
+| `dry-run`            | No       | `false`               | Preview mode - show what would change without creating PRs                    |
+| `work-dir`           | No       | `./tmp`               | Directory for cloning repositories                                            |
+| `retries`            | No       | `3`                   | Number of network retries                                                     |
+| `branch`             | No       | -                     | Override sync branch name                                                     |
+| `merge`              | No       | -                     | PR merge mode (`manual`/`auto`/`force`/`direct`)                              |
+| `merge-strategy`     | No       | -                     | Merge strategy (`merge`/`squash`/`rebase`)                                    |
+| `delete-branch`      | No       | `false`               | Delete branch after merge                                                     |
+| `github-token`       | No       | `${{ github.token }}` | GitHub token for authentication                                               |
+| `github-app-token`   | No       | -                     | GitHub App installation token for verified commits (overrides `github-token`) |
+| `azure-devops-token` | No       | -                     | Azure DevOps Personal Access Token                                            |
+| `gitlab-token`       | No       | -                     | GitLab token for authentication                                               |
 
 ### Multi-Platform Example
 
@@ -89,8 +90,7 @@ jobs:
       - uses: anthony-spruyt/xfg@v1
         with:
           config: ./sync-config.yml
-        env:
-          GH_INSTALLATION_TOKEN: ${{ steps.app-token.outputs.token }}
+          github-app-token: ${{ steps.app-token.outputs.token }}
 ```
 
 See [GitHub App Authentication](../platforms/github-app.md) for full setup instructions.

--- a/docs/plans/2026-01-29-github-app-verified-commits-design.md
+++ b/docs/plans/2026-01-29-github-app-verified-commits-design.md
@@ -22,7 +22,7 @@ Add optional GitHub App support for GitHub repositories, enabling enterprise use
 
 ## Authentication Flow
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │ GitHub Actions Workflow                                 │
 ├─────────────────────────────────────────────────────────┤

--- a/docs/platforms/github-app.md
+++ b/docs/platforms/github-app.md
@@ -49,8 +49,9 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: your-org/xfg-action@v2
-        env:
-          GH_INSTALLATION_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          config: sync-config.yaml
+          github-app-token: ${{ steps.app-token.outputs.token }}
 ```
 
 ## How It Works


### PR DESCRIPTION
## Summary

- Add `github-app-token` input to action.yml for GitHub App installation tokens
- Sets `GH_INSTALLATION_TOKEN` internally for verified commits via GraphQL API
- GitHub App token takes precedence over PAT for git authentication
- Updated documentation examples to use the new input parameter

## Changes

- `action.yml`: New `github-app-token` input, configure git and xfg with token
- `docs/ci-cd/github-actions.md`: Updated action inputs table and example
- `docs/platforms/github-app.md`: Updated workflow example
- `.github/actionlint.yaml`: Added TEST_APP_ID config variable

## Test plan

- [ ] CI passes (lint, tests)
- [ ] Integration tests for GitHub App still work
- [ ] Documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)