### PR TITLE
fix: use --input for GraphQL API to pass complex nested JSON

### DIFF
--- a/src/strategies/graphql-commit-strategy.ts
+++ b/src/strategies/graphql-commit-strategy.ts
@@ -208,14 +208,21 @@ export class GraphQLCommitStrategy implements CommitStrategy {
       },
     };
 
+    // Build the GraphQL request body
+    const requestBody = JSON.stringify({
+      query: mutation,
+      variables,
+    });
+
     // Build the gh api graphql command
+    // Use --input - to pass the JSON body via stdin (more reliable for complex nested JSON)
     // Use --hostname for GitHub Enterprise
     const hostnameArg =
       repoInfo.host !== "github.com"
         ? `--hostname ${escapeShellArg(repoInfo.host)}`
         : "";
 
-    const command = `gh api graphql ${hostnameArg} -f query=${escapeShellArg(mutation)} -f variables=${escapeShellArg(JSON.stringify(variables))}`;
+    const command = `echo ${escapeShellArg(requestBody)} | gh api graphql ${hostnameArg} --input -`;
 
     const response = await this.executor.exec(command, workDir);
 


### PR DESCRIPTION
## Summary

- Switch from `-f variables=...` to `--input -` for passing GraphQL request body
- The gh api graphql command wasn't properly parsing complex nested JSON when passed via `-f variables=...` argument
- Using `--input -` to pipe the JSON body via stdin is more reliable for nested JSON structures like the `createCommitOnBranch` mutation input

This fixes the "Variable $input was provided invalid value" error in the GitHub App integration tests.

## Test plan

- [x] Unit tests pass
- [x] Lint passes
- [ ] GitHub App integration test should pass now

🤖 Generated with [Claude Code](https://claude.com/claude-code)