### PR TITLE
fix: move deleteOrphaned to root level in test fixtures

### DIFF
--- a/fixtures/integration-test-github-app-delete-phase1.yaml
+++ b/fixtures/integration-test-github-app-delete-phase1.yaml
@@ -3,9 +3,10 @@
 
 id: integration-test-github-app-delete
 
+deleteOrphaned: true
+
 prOptions:
   merge: direct
-  deleteOrphaned: true
 
 files:
   github-app-orphan-test.json:

--- a/fixtures/integration-test-github-app-delete-phase2.yaml
+++ b/fixtures/integration-test-github-app-delete-phase2.yaml
@@ -3,9 +3,10 @@
 
 id: integration-test-github-app-delete
 
+deleteOrphaned: true
+
 prOptions:
   merge: direct
-  deleteOrphaned: true
 
 files:
   # github-app-orphan-test.json removed - should be deleted


### PR DESCRIPTION
## Summary

- Move `deleteOrphaned: true` from inside `prOptions` to the root level in test fixtures
- The config normalizer looks for `raw.deleteOrphaned`, not `raw.prOptions.deleteOrphaned`
- This was causing the `.xfg.json` manifest file to not be created in the GitHub App integration tests

## Test plan

- [x] Unit tests pass
- [ ] GitHub App integration test should pass now

🤖 Generated with [Claude Code](https://claude.com/claude-code)