### PR TITLE
fix(ci): use separate fixture for action tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,7 +275,7 @@ jobs:
       - name: "[PAT] Run xfg action"
         uses: ./
         with:
-          config: ./fixtures/integration-test-config-github.yaml
+          config: ./fixtures/integration-test-action-github.yaml
           github-token: ${{ secrets.GH_PAT }}
           xfg-package: "./${{ env.XFG_PACKAGE }}"
 
@@ -335,7 +335,7 @@ jobs:
       - name: "[App] Run xfg action with GitHub App token"
         uses: ./
         with:
-          config: ./fixtures/integration-test-config-github.yaml
+          config: ./fixtures/integration-test-action-github.yaml
           branch: ${{ env.APP_BRANCH }}
           github-token: ${{ steps.app-token.outputs.token }}
           github-app-token: ${{ steps.app-token.outputs.token }}

--- a/fixtures/integration-test-action-github.yaml
+++ b/fixtures/integration-test-action-github.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
+# Action integration test config - tests multiple files with deleteOrphaned to catch bug #268
+id: integration-test-action-github
+deleteOrphaned: true
+files:
+  action-test.json:
+    content:
+      syncedByAction: true
+      timestamp: ${xfg:timestamp}
+  action-test-2.yaml:
+    content:
+      setting1: value1
+      setting2: value2
+
+repos:
+  - git: https://github.com/anthony-spruyt/xfg-test.git

--- a/fixtures/integration-test-config-github.yaml
+++ b/fixtures/integration-test-config-github.yaml
@@ -1,7 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/anthony-spruyt/xfg/main/config-schema.json
-# Integration test config - tests multiple files with deleteOrphaned to catch bug #268
+# Integration test config - tests root-level content with overlay merge
 id: integration-test-github
-deleteOrphaned: true
 files:
   my.config.json:
     content:
@@ -13,10 +12,6 @@ files:
           - prop6: platform
           - prop7: engineering
       baseOnly: inherited-from-root
-  second-config.yaml:
-    content:
-      setting1: value1
-      setting2: value2
 
 repos:
   - git: https://github.com/anthony-spruyt/xfg-test.git


### PR DESCRIPTION
## Summary
- Revert changes to `integration-test-config-github.yaml` (used by node tests)
- Create new `integration-test-action-github.yaml` with `deleteOrphaned` and multiple files for testing bug #268
- Update action test steps to use the new fixture

## Why
The previous commit (#271) modified the shared fixture which broke the existing node integration tests. This fix separates the concerns by creating a dedicated fixture for action tests.

## Test plan
- [ ] Node integration tests pass (use original fixture)
- [ ] Action integration tests use new fixture with deleteOrphaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)