### PR TITLE
fix(ci): pass branch explicitly to PAT action test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,6 +276,7 @@ jobs:
         uses: ./
         with:
           config: ./fixtures/integration-test-action-github.yaml
+          branch: ${{ env.PAT_BRANCH }}
           github-token: ${{ secrets.GH_PAT }}
           xfg-package: "./${{ env.XFG_PACKAGE }}"
 


### PR DESCRIPTION
## Summary
Pass the branch name explicitly to the PAT action test to match what the validation step expects.

## Why
The previous fix created a new fixture but the PAT test wasn't passing the branch name, so xfg used the default branch name which didn't match `PAT_BRANCH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)