### PR TITLE
test(#268): seed manifest before App test to trigger update path

### DIFF
--- a/.github/scripts/delete-manifest.sh
+++ b/.github/scripts/delete-manifest.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Delete .xfg.json manifest from test repo
+# Usage: delete-manifest.sh <repo>
+# Requires: GH_TOKEN environment variable
+
+set -euo pipefail
+
+REPO="${1:?Usage: delete-manifest.sh <repo>}"
+
+echo "Deleting manifest..."
+SHA=$(gh api "repos/${REPO}/contents/.xfg.json" --jq '.sha' 2>/dev/null || true)
+if [ -n "$SHA" ]; then
+  gh api --method DELETE "repos/${REPO}/contents/.xfg.json" \
+    -f message="test: cleanup seeded manifest" \
+    -f sha="$SHA" || true
+  echo "Manifest deleted"
+else
+  echo "Manifest does not exist"
+fi

--- a/.github/scripts/seed-manifest.sh
+++ b/.github/scripts/seed-manifest.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Seed .xfg.json manifest in test repo to trigger update path (bug #268)
+# Usage: seed-manifest.sh <repo>
+# Requires: GH_TOKEN environment variable
+
+set -euo pipefail
+
+REPO="${1:?Usage: seed-manifest.sh <repo>}"
+
+# Create .xfg.json manifest so xfg will UPDATE it (not create)
+# Bug #268 only manifests when updating an existing manifest
+MANIFEST='{"version":2,"configs":{"integration-test-action-github":{"managedFiles":["action-test.json"]}}}'
+
+# Check if manifest exists, create or update it
+SHA=$(gh api "repos/${REPO}/contents/.xfg.json" --jq '.sha' 2>/dev/null || true)
+if [ -n "$SHA" ]; then
+  echo "Manifest exists, updating..."
+  gh api --method PUT "repos/${REPO}/contents/.xfg.json" \
+    -f message="test: seed manifest for bug #268 test" \
+    -f content="$(echo "$MANIFEST" | base64 -w0)" \
+    -f sha="$SHA"
+else
+  echo "Creating manifest..."
+  gh api --method PUT "repos/${REPO}/contents/.xfg.json" \
+    -f message="test: seed manifest for bug #268 test" \
+    -f content="$(echo "$MANIFEST" | base64 -w0)"
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,6 +267,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: .github/scripts/cleanup-test-pr.sh "${TEST_REPO}" "${PAT_BRANCH}"
 
+      - name: "[PAT] Seed manifest to trigger update path (bug #268)"
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: .github/scripts/seed-manifest.sh "${TEST_REPO}"
+
       - name: "[PAT] Configure custom git identity (to verify action preserves it)"
         run: |
           git config --global user.name "test-user"
@@ -313,11 +318,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: .github/scripts/verify-commit-file-count.sh "${TEST_REPO}" "${{ steps.pat-validate.outputs.commit_sha }}"
 
-      - name: "[PAT] Cleanup - close PR"
+      - name: "[PAT] Cleanup - close PR and delete seeded manifest"
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: .github/scripts/cleanup-test-pr.sh "${TEST_REPO}" "${PAT_BRANCH}"
+        run: |
+          .github/scripts/cleanup-test-pr.sh "${TEST_REPO}" "${PAT_BRANCH}"
+          .github/scripts/delete-manifest.sh "${TEST_REPO}"
 
       # ========== GitHub App Test ==========
       - name: "[App] Generate GitHub App token"
@@ -332,6 +339,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: .github/scripts/cleanup-test-pr.sh "${TEST_REPO}" "${APP_BRANCH}"
+
+      - name: "[App] Seed manifest to trigger update path (bug #268)"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: .github/scripts/seed-manifest.sh "${TEST_REPO}"
 
       - name: "[App] Run xfg action with GitHub App token"
         uses: ./
@@ -378,8 +390,10 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: .github/scripts/verify-commit-file-count.sh "${TEST_REPO}" "${{ steps.app-validate.outputs.commit_sha }}"
 
-      - name: "[App] Cleanup - close PR"
+      - name: "[App] Cleanup - close PR and delete seeded manifest"
         if: always()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: .github/scripts/cleanup-test-pr.sh "${TEST_REPO}" "${APP_BRANCH}"
+        run: |
+          .github/scripts/cleanup-test-pr.sh "${TEST_REPO}" "${APP_BRANCH}"
+          .github/scripts/delete-manifest.sh "${TEST_REPO}"


### PR DESCRIPTION
## Summary
- Create `.xfg.json` manifest in test repo before App action test
- Bug #268 only manifests when UPDATING an existing manifest (not creating fresh)
- Delete seeded manifest after App test

## Why
The bug wasn't being caught because the manifest file didn't exist in the test repo. The duplicate counting bug only occurs when updating an existing manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)