### PR TITLE
fix: correct manifest structure in seed script

### DIFF
--- a/.github/scripts/seed-manifest.sh
+++ b/.github/scripts/seed-manifest.sh
@@ -9,7 +9,8 @@ REPO="${1:?Usage: seed-manifest.sh <repo>}"
 
 # Create .xfg.json manifest so xfg will UPDATE it (not create)
 # Bug #268 only manifests when updating an existing manifest
-MANIFEST='{"version":2,"configs":{"integration-test-action-github":{"managedFiles":["action-test.json"]}}}'
+# Structure: configs[configId] = string[] (array of filenames directly)
+MANIFEST='{"version":2,"configs":{"integration-test-action-github":["action-test.json"]}}'
 
 # Check if manifest exists, create or update it
 SHA=$(gh api "repos/${REPO}/contents/.xfg.json" --jq '.sha' 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- Fix manifest structure in seed-manifest.sh
- `manifest.configs[configId]` should be an array directly, not an object with `managedFiles` property
- This was causing `TypeError: (manifest.configs[configId] ?? []) is not iterable`

## Test plan
- [ ] CI passes on this branch
- [ ] Integration tests run successfully with corrected manifest structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)