### PR TITLE
fix: GraphQL commit strategy resets branch to main before committing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,23 +107,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: npm run test:integration:github
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.TEST_APP_ID }}
-          private-key: ${{ secrets.TEST_APP_PRIVATE_KEY }}
-          owner: anthony-spruyt
-
-      - name: Reconfigure git for GitHub App tests
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-
       - name: Run GitHub App integration tests
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           XFG_GITHUB_APP_ID: ${{ vars.TEST_APP_ID }}
           XFG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
         run: npm run test:integration:github-app
@@ -328,22 +313,15 @@ jobs:
           .github/scripts/delete-manifest.sh "${TEST_REPO}"
 
       # ========== GitHub App Test ==========
-      - name: "[App] Generate GitHub App token"
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.TEST_APP_ID }}
-          private-key: ${{ secrets.TEST_APP_PRIVATE_KEY }}
-          owner: anthony-spruyt
-
+      # Helper scripts use PAT. The xfg action handles GitHub App auth internally.
       - name: "[App] Setup - clean up from previous runs"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: .github/scripts/cleanup-test-pr.sh "${TEST_REPO}" "${APP_BRANCH}"
 
       - name: "[App] Seed manifest to trigger update path (bug #268)"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: .github/scripts/seed-manifest.sh "${TEST_REPO}"
 
       - name: "[App] Run xfg action with GitHub App credentials"
@@ -358,7 +336,7 @@ jobs:
       - name: "[App] Validate - verify commit author is GitHub App (#268)"
         id: app-validate
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           echo "Verifying PR was created..."
           PR_INFO=$(gh pr list --repo ${TEST_REPO} --head ${APP_BRANCH} --json number,title,url --jq '.[0]')
@@ -388,13 +366,13 @@ jobs:
 
       - name: "[App] Validate - verify file count in commit message (#268)"
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: .github/scripts/verify-commit-file-count.sh "${TEST_REPO}" "${{ steps.app-validate.outputs.commit_sha }}"
 
       - name: "[App] Cleanup - close PR and delete seeded manifest"
         if: always()
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           .github/scripts/cleanup-test-pr.sh "${TEST_REPO}" "${APP_BRANCH}"
           .github/scripts/delete-manifest.sh "${TEST_REPO}"


### PR DESCRIPTION
Fixes #287

## Summary

- GraphQL commit strategy now deletes and recreates remote branch when `force=true` (PR mode) to ensure sync branch starts fresh from main
- Simplified CI test setup by removing unnecessary `actions/create-github-app-token` steps
- Helper scripts now use PAT directly; xfg handles GitHub App token generation internally

## Changes

### GraphQL Strategy Fix
When using GitHub App auth, if the sync branch already existed on remote, xfg was adding commits on top of the old branch instead of resetting to main. Now for PR branches (`force=true`), the strategy deletes the remote branch and recreates it from local HEAD (which is based on fresh main).

### CI Cleanup
Removed over-engineered token generation from CI tests:
- `integration-test-github`: Removed external token generation, GitHub App test now only uses `XFG_GITHUB_APP_ID` and `XFG_GITHUB_APP_PRIVATE_KEY`
- `integration-test-action`: Helper scripts use PAT for `gh` CLI, xfg action uses app credentials directly

## Test plan

- [x] Unit tests pass (1159 tests)
- [x] Lint passes
- [ ] Integration tests (run on main after merge)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)