### PR TITLE
fix(graphql): place GH_TOKEN on correct side of pipe

### DIFF
--- a/src/strategies/graphql-commit-strategy.ts
+++ b/src/strategies/graphql-commit-strategy.ts
@@ -228,10 +228,10 @@ export class GraphQLCommitStrategy implements CommitStrategy {
 
     // Use token parameter for authentication when provided
     // This ensures the GitHub App is used as the commit author, not github-actions[bot]
-    // GH_TOKEN env var is used by gh CLI for authentication
+    // GH_TOKEN env var must be set for the gh command (after the pipe), not echo
     const tokenPrefix = token ? `GH_TOKEN=${token} ` : "";
 
-    const command = `${tokenPrefix}echo ${escapeShellArg(requestBody)} | gh api graphql ${hostnameArg} --input -`;
+    const command = `echo ${escapeShellArg(requestBody)} | ${tokenPrefix}gh api graphql ${hostnameArg} --input -`;
 
     const response = await this.executor.exec(command, workDir);
 


### PR DESCRIPTION
## Summary

Fix GH_TOKEN placement in shell command - must be set for `gh` command, not `echo`.

## Problem

```bash
# Wrong (PR #289) - GH_TOKEN set for echo, not inherited by gh after pipe
GH_TOKEN=token echo 'data' | gh api graphql

# Correct - GH_TOKEN set for gh command
echo 'data' | GH_TOKEN=token gh api graphql
```

## Test plan

- [x] Unit tests pass (1159 tests)
- [ ] Integration tests (run in CI)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)