### PR TITLE
fix(ci): add GH_TOKEN for GitHub App integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,7 @@ jobs:
 
       - name: Run GitHub App integration tests
         env:
+          GH_TOKEN: ${{ secrets.GH_PAT }} # For test validation commands
           XFG_GITHUB_APP_ID: ${{ vars.TEST_APP_ID }}
           XFG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
         run: npm run test:integration:github-app


### PR DESCRIPTION
## Summary
- Adds `GH_TOKEN` environment variable to GitHub App integration test step
- The test's validation commands (`gh pr list`, etc.) need this token for authentication
- xfg itself uses the app credentials internally for its operations

## Test plan
- [ ] Verify CI passes for the integration-test-github job

🤖 Generated with [Claude Code](https://claude.com/claude-code)