### PR TITLE
refactor: separate CLI entry point from exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "xfg": "./dist/index.js"
+    "xfg": "./dist/cli.js"
   },
   "files": [
     "dist",
@@ -24,8 +24,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts",
+    "start": "node dist/cli.js",
+    "dev": "ts-node src/cli.ts",
     "test": "node --import tsx scripts/run-tests.js",
     "test:coverage": "c8 --check-coverage --lines 95 --reporter=text --reporter=lcov --all --src=src --exclude='src/**/*.test.ts' --exclude='scripts/**' npm test",
     "test:integration:github": "npm run build && node --import tsx --test test/integration/github.test.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import { program } from "./index.js";
+
+// Handle backwards compatibility: if no subcommand is provided, default to sync
+// This maintains compatibility with existing usage like `xfg -c config.yaml`
+const args = process.argv.slice(2);
+const subcommands = ["sync", "protect", "help"];
+const versionFlags = ["-V", "--version"];
+
+// Check if the first argument is a subcommand or version flag
+const firstArg = args[0];
+const isSubcommand = firstArg && subcommands.includes(firstArg);
+const isVersionFlag = firstArg && versionFlags.includes(firstArg);
+
+if (isSubcommand || isVersionFlag) {
+  // Explicit subcommand or version flag - parse normally
+  program.parse();
+} else {
+  // No subcommand - prepend 'sync' for backwards compatibility
+  // This handles: `xfg -c config.yaml`, `xfg --help`, `xfg` (no args)
+  program.parse(["node", "xfg", "sync", ...args]);
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,25 +14,20 @@ const testDir = join(process.cwd(), "test-cli-tmp");
 const testConfigPath = join(testDir, "test-config.yaml");
 
 // Helper to run CLI and capture output
-// By default, unsets GITHUB_STEP_SUMMARY and NODE_TEST_CONTEXT to ensure child process
-// runs as normal CLI invocation, not in test mode
+// Unsets GITHUB_STEP_SUMMARY by default so tests don't write to CI summary
 function runCLI(
   args: string[],
   options?: { timeout?: number; env?: Record<string, string | undefined> }
 ): { stdout: string; stderr: string; success: boolean } {
-  // Create env with test-related vars unset by default
-  // Destructure to exclude these vars (prefixed with _ to indicate intentionally unused)
-  const {
-    GITHUB_STEP_SUMMARY: _stepSummary,
-    NODE_TEST_CONTEXT: _testContext,
-    ...envWithoutTestVars
-  } = process.env;
-  const testEnv = { ...envWithoutTestVars, ...options?.env };
+  // Unset GITHUB_STEP_SUMMARY unless explicitly provided
+  const { GITHUB_STEP_SUMMARY: _stepSummary, ...envWithoutSummary } =
+    process.env;
+  const testEnv = { ...envWithoutSummary, ...options?.env };
 
   try {
     const stdout = execFileSync(
       "node",
-      ["--import", "tsx", "src/index.ts", ...args],
+      ["--import", "tsx", "src/cli.ts", ...args],
       {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -509,30 +509,5 @@ const protectCommand = new Command("protect")
 addSharedOptions(protectCommand);
 program.addCommand(protectCommand);
 
-// Only parse CLI when run directly (not when imported for testing)
-const isTestRun =
-  process.argv.includes("--test") ||
-  process.argv.some((arg) => arg.includes(".test.ts")) ||
-  process.env.NODE_TEST_CONTEXT !== undefined;
-
-if (!isTestRun) {
-  // Handle backwards compatibility: if no subcommand is provided, default to sync
-  // This maintains compatibility with existing usage like `xfg -c config.yaml`
-  const args = process.argv.slice(2);
-  const subcommands = ["sync", "protect", "help"];
-  const versionFlags = ["-V", "--version"];
-
-  // Check if the first argument is a subcommand or version flag
-  const firstArg = args[0];
-  const isSubcommand = firstArg && subcommands.includes(firstArg);
-  const isVersionFlag = firstArg && versionFlags.includes(firstArg);
-
-  if (isSubcommand || isVersionFlag) {
-    // Explicit subcommand or version flag - parse normally
-    program.parse();
-  } else {
-    // No subcommand - prepend 'sync' for backwards compatibility
-    // This handles: `xfg -c config.yaml`, `xfg --help`, `xfg` (no args)
-    program.parse(["node", "xfg", "sync", ...args]);
-  }
-}
+// Export program for CLI entry point
+export { program };

--- a/test/integration/ado.test.ts
+++ b/test/integration/ado.test.ts
@@ -20,7 +20,6 @@ const BRANCH_NAME = "chore/sync-my-config";
 
 // This exec helper is only used in integration tests with hardcoded commands.
 // The commands are controlled and not derived from external/user input.
-// This follows the same pattern as integration-github.test.ts.
 function exec(command: string, options?: { cwd?: string }): string {
   try {
     return execSync(command, {
@@ -273,7 +272,7 @@ describe("Azure DevOps Integration Test", () => {
 
     // Run the sync tool
     console.log("Running xfg...");
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -355,7 +354,7 @@ describe("Azure DevOps Integration Test", () => {
 
     // Run the sync tool again
     console.log("\nRunning xfg again (re-sync)...");
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -462,7 +461,7 @@ describe("Azure DevOps Integration Test", () => {
       fixturesDir,
       "integration-test-createonly-ado.yaml"
     );
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -613,7 +612,7 @@ describe("Azure DevOps Integration Test", () => {
     // 5. Run sync with the test config
     console.log("\nRunning xfg with unchanged files config...");
     const configPath = join(fixturesDir, "integration-test-unchanged-ado.yaml");
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -701,7 +700,7 @@ describe("Azure DevOps Integration Test", () => {
     // 2. Run sync with direct mode config
     console.log("\nRunning xfg with direct mode config...");
     const configPath = join(fixturesDir, "integration-test-direct-ado.yaml");
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);

--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -26,7 +26,6 @@ if (SKIP_TESTS) {
 
 // This exec helper is only used in integration tests with hardcoded commands.
 // The commands are controlled and not derived from external/user input.
-// This matches the pattern used in github.test.ts lines 19-35.
 function exec(command: string, options?: { cwd?: string }): string {
   try {
     return execSync(command, {
@@ -111,7 +110,7 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
 
     // Run the sync tool with GitHub App credentials
     console.log("Running xfg with GitHub App credentials...");
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -201,7 +200,7 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
       fixturesDir,
       "integration-test-github-app-direct.yaml"
     );
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -294,7 +293,7 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
       fixturesDir,
       "integration-test-github-app-delete-phase1.yaml"
     );
-    const output1 = exec(`node dist/index.js --config ${configPath1}`, {
+    const output1 = exec(`node dist/cli.js --config ${configPath1}`, {
       cwd: projectRoot,
     });
     console.log(output1);
@@ -323,7 +322,7 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
       fixturesDir,
       "integration-test-github-app-delete-phase2.yaml"
     );
-    const output2 = exec(`node dist/index.js --config ${configPath2}`, {
+    const output2 = exec(`node dist/cli.js --config ${configPath2}`, {
       cwd: projectRoot,
     });
     console.log(output2);

--- a/test/integration/github-protect.test.ts
+++ b/test/integration/github-protect.test.ts
@@ -83,7 +83,7 @@ describe("GitHub Protect Integration Test", () => {
 
     // Run the protect command
     console.log("\nRunning xfg protect...");
-    const output = exec(`node dist/index.js protect --config ${configPath}`, {
+    const output = exec(`node dist/cli.js protect --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -128,7 +128,7 @@ describe("GitHub Protect Integration Test", () => {
 
     // Run protect again - should update existing ruleset
     console.log("\nRunning xfg protect again (update)...");
-    const output = exec(`node dist/index.js protect --config ${configPath}`, {
+    const output = exec(`node dist/cli.js protect --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -168,7 +168,7 @@ describe("GitHub Protect Integration Test", () => {
     // Run protect with dry-run
     console.log("\nRunning xfg protect --dry-run...");
     const output = exec(
-      `node dist/index.js protect --config ${configPath} --dry-run`,
+      `node dist/cli.js protect --config ${configPath} --dry-run`,
       {
         cwd: projectRoot,
       }

--- a/test/integration/gitlab.test.ts
+++ b/test/integration/gitlab.test.ts
@@ -19,7 +19,6 @@ const BRANCH_NAME = "chore/sync-my-config";
 
 // This exec helper is only used in integration tests with hardcoded commands.
 // The commands are controlled and not derived from external/user input.
-// This follows the same pattern as integration-github.test.ts and integration-ado.test.ts.
 function exec(command: string, options?: { cwd?: string }): string {
   try {
     return execSync(command, {
@@ -279,7 +278,7 @@ describe("GitLab Integration Test", () => {
 
     // Run the sync tool
     console.log("Running xfg...");
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -354,7 +353,7 @@ describe("GitLab Integration Test", () => {
 
     // Run the sync tool again
     console.log("\nRunning xfg again (re-sync)...");
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -441,7 +440,7 @@ describe("GitLab Integration Test", () => {
       fixturesDir,
       "integration-test-createonly-gitlab.yaml"
     );
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -570,7 +569,7 @@ describe("GitLab Integration Test", () => {
       fixturesDir,
       "integration-test-unchanged-gitlab.yaml"
     );
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);
@@ -647,7 +646,7 @@ describe("GitLab Integration Test", () => {
     // 2. Run sync with direct mode config
     console.log("\nRunning xfg with direct mode config...");
     const configPath = join(fixturesDir, "integration-test-direct-gitlab.yaml");
-    const output = exec(`node dist/index.js --config ${configPath}`, {
+    const output = exec(`node dist/cli.js --config ${configPath}`, {
       cwd: projectRoot,
     });
     console.log(output);


### PR DESCRIPTION
## Summary
- Extract CLI parsing to dedicated `cli.ts` file instead of using hacky `NODE_TEST_CONTEXT` environment detection
- This is the proper Node.js pattern for modules that are both CLI tools and importable libraries

## Changes
- Create `src/cli.ts` as the new bin entry point
- Export `program` from `index.ts` without auto-execution
- Update `package.json` bin to point to `dist/cli.js`
- Update all integration tests to use `dist/cli.js`
- Clean up integration tests (remove `NODE_TEST_CONTEXT` workaround)
- Add ruleset cleanup to `github.test.ts` to prevent test interference
- Fix v3 manifest format assertion in deleteOrphaned test

## Why this fix
The previous approach detected "test mode" by checking for `NODE_TEST_CONTEXT` environment variable. This was a hack that caused problems when integration tests spawned xfg as a subprocess - the subprocess inherited the env var and skipped CLI parsing entirely.

The proper solution is structural: separate the CLI entry point (`cli.ts`) from the library exports (`index.ts`). Now:
- When run as CLI → `cli.ts` is executed → parses args normally
- When imported in tests → only `index.ts` is loaded → no auto-execution

## Test plan
- [x] All 1312 unit tests pass
- [ ] All integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)