### PR TITLE
fix: use v3 manifest format in github-app.test.ts

### DIFF
--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -310,8 +310,9 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
       `gh api repos/${TEST_REPO}/contents/${manifestFile} --jq '.content' | base64 -d`
     );
     const manifest = JSON.parse(manifestContent);
+    // v3 manifest format uses { files: [...], rulesets: [...] }
     assert.ok(
-      manifest.configs[configId]?.includes(orphanFile),
+      manifest.configs[configId]?.files?.includes(orphanFile),
       "Manifest should track orphan file"
     );
     console.log("  Manifest tracks orphan file");


### PR DESCRIPTION
## Summary
Fix the deleteOrphaned test in github-app.test.ts which was using the old v2 manifest format assertion.

## Changes
- Changed `manifest.configs[configId]?.includes(orphanFile)` to `manifest.configs[configId]?.files?.includes(orphanFile)`
- V3 manifest uses `{ files: [...], rulesets: [...] }` structure instead of a flat array

## Note
The github-protect integration tests are still failing due to PAT permissions (HTTP 403). The GH_PAT secret needs admin scope for repository rulesets. This is a separate credentials issue.

## Test plan
- [ ] GitHub App integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)