### PR TITLE
test: add coverage for settings command manifest update path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,12 @@ export interface IRepositoryProcessor {
     repoInfo: RepoInfo,
     options: ProcessorOptions
   ): Promise<ProcessorResult>;
+  updateManifestOnly(
+    repoInfo: RepoInfo,
+    repoConfig: RepoConfig,
+    options: ProcessorOptions,
+    manifestUpdate: { rulesets: string[] }
+  ): Promise<ProcessorResult>;
 }
 
 /**
@@ -281,7 +287,8 @@ export async function runSync(
 
 export async function runSettings(
   options: SettingsOptions,
-  processorFactory: RulesetProcessorFactory = defaultRulesetProcessorFactory
+  processorFactory: RulesetProcessorFactory = defaultRulesetProcessorFactory,
+  repoProcessorFactory: ProcessorFactory = defaultProcessorFactory
 ): Promise<void> {
   const configPath = resolve(options.config);
 
@@ -312,7 +319,7 @@ export async function runSettings(
   console.log(`Found ${reposWithRulesets.length} repositories with rulesets\n`);
 
   const processor = processorFactory();
-  const repoProcessor = new RepositoryProcessor();
+  const repoProcessor = repoProcessorFactory();
   const results: RepoResult[] = [];
   let successCount = 0;
   let failCount = 0;


### PR DESCRIPTION
## Summary

- Adds test coverage for the manifest update code path in `runSettings` (lines 381-386)
- Introduces `updateManifestOnly` to the `IRepositoryProcessor` interface for dependency injection
- Adds `repoProcessorFactory` parameter to `runSettings` for testing

The error handler lines (507-508) remain uncovered as they call `process.exit(1)` which would terminate the test runner.

## Test Plan

- [x] All 1313 tests pass
- [x] Build succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)