### PR TITLE
test: add github-token to GitHub App integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,6 +372,9 @@ jobs:
         with:
           config: ./fixtures/integration-test-action-github.yaml
           branch: ${{ env.APP_BRANCH }}
+          # Include github-token to simulate real usage where both are set
+          # This tests that GitHub App credentials take precedence over PAT
+          github-token: ${{ github.token }}
           github-app-id: ${{ vars.TEST_APP_ID }}
           github-app-private-key: ${{ secrets.TEST_APP_PRIVATE_KEY }}
           xfg-package: "./${{ env.XFG_PACKAGE }}"


### PR DESCRIPTION
## Summary
The integration test for GitHub App auth was missing `github-token`, so it didn't simulate real usage where both PAT and App credentials are set.

This is why v3.1.1 passed tests but failed in production - the test never exercised the URL precedence conflict.

## Changes
Added `github-token: ${{ github.token }}` to the App credentials test step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)