### PR TITLE
fix: skip PAT URL rewrite when GitHub App auth is configured

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,8 +96,9 @@ runs:
         fi
 
         # GitHub - URL rewrite for authentication (PAT only)
-        # Note: GitHub App auth is handled dynamically per-repo by xfg
-        if [ -n "${GITHUB_TOKEN}" ]; then
+        # Skip if GitHub App auth is configured - xfg handles auth dynamically per-repo
+        # The URL rewrite bakes PAT into clone URLs, preventing App token override
+        if [ -n "${GITHUB_TOKEN}" ] && [ -z "${GITHUB_APP_ID}" ] && [ -z "${GITHUB_APP_PRIVATE_KEY}" ]; then
           git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
         fi
 


### PR DESCRIPTION
## Root Cause
The global URL rewrite (`git config url.insteadOf`) bakes the PAT into clone URLs. When xfg later tries to push with GitHub App token, the remote URL is already `https://x-access-token:PAT@github.com/...` - our override pattern doesn't match.

## Fix
Skip the URL rewrite in action.yml when GitHub App credentials are provided. xfg handles auth dynamically.

## Why npm package fix didn't work
The `-c url.insteadOf` override matches against `https://github.com/...` but the stored remote URL is already `https://x-access-token:PAT@github.com/...` from the clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)