### PR TITLE
test: add commit author verification to GitHub App tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,9 +107,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: npm run test:integration:github
 
+      # Reconfigure URL rewrite with limited token before GitHub App tests.
+      # If xfg accidentally uses this instead of the App token, push will fail
+      # because github.token cannot push to xfg-test repo.
+      - name: Reconfigure git URL rewrite with limited token
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git config --global --unset-all url."https://x-access-token:${{ secrets.GH_PAT }}@github.com/".insteadOf || true
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+
       - name: Run GitHub App integration tests
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }} # For test validation commands
+          GH_TOKEN: ${{ secrets.GH_PAT }} # For test validation commands (gh CLI)
           XFG_GITHUB_APP_ID: ${{ vars.TEST_APP_ID }}
           XFG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
         run: npm run test:integration:github-app

--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -153,6 +153,21 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
     // Check the verification reason
     console.log(`  Verification reason: ${verification.reason}`);
 
+    // Verify commit author is the GitHub App, NOT github-actions[bot]
+    // This catches the bug where PAT URL rewrite leaks into clone and wrong credential is used
+    console.log("\nVerifying commit author is GitHub App...");
+    const commitAuthor = exec(
+      `gh api repos/${TEST_REPO}/commits/${commitSha} --jq '.commit.author.name'`
+    );
+    console.log(`  Commit author: ${commitAuthor}`);
+
+    assert.notEqual(
+      commitAuthor,
+      "github-actions[bot]",
+      "Commit author should be GitHub App, not github-actions[bot]. " +
+        "This indicates the PAT URL rewrite leaked into the clone URL."
+    );
+
     // Verify the file exists in the PR branch
     console.log("\nVerifying file exists in PR branch...");
     const fileContent = exec(
@@ -242,6 +257,19 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
       verification.verified,
       true,
       "Direct mode commit should be verified"
+    );
+
+    // Verify commit author is GitHub App, not github-actions[bot]
+    console.log("\nVerifying commit author is GitHub App...");
+    const commitAuthor = exec(
+      `gh api repos/${TEST_REPO}/commits/${mainCommitSha} --jq '.commit.author.name'`
+    );
+    console.log(`  Commit author: ${commitAuthor}`);
+
+    assert.notEqual(
+      commitAuthor,
+      "github-actions[bot]",
+      "Direct mode commit author should be GitHub App, not github-actions[bot]"
     );
 
     // 6. Cleanup
@@ -352,6 +380,19 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
       verification.verified,
       true,
       "Deletion commit should be verified"
+    );
+
+    // Verify commit author is GitHub App, not github-actions[bot]
+    console.log("\nVerifying commit author is GitHub App...");
+    const commitAuthor = exec(
+      `gh api repos/${TEST_REPO}/commits/${mainCommitSha} --jq '.commit.author.name'`
+    );
+    console.log(`  Commit author: ${commitAuthor}`);
+
+    assert.notEqual(
+      commitAuthor,
+      "github-actions[bot]",
+      "Deletion commit author should be GitHub App, not github-actions[bot]"
     );
 
     // 7. Cleanup


### PR DESCRIPTION
## Summary

Add belt-and-suspenders testing for GitHub App authentication to catch credential leakage bugs:

- **Commit author verification** - All 3 GitHub App tests now verify commit author is NOT `github-actions[bot]`
- **Limited token URL rewrite** - Before GitHub App tests, reconfigure global URL rewrite to use `github.token` which cannot push to xfg-test

## Why These Tests Are Needed

The GitHub App auth path has been broken in v3.1.0, v3.1.1, v3.1.2, and v3.1.3 despite having integration tests. The tests passed because:

1. Test PAT (`secrets.GH_PAT`) has same permissions as the GitHub App
2. When wrong credential was used, operations still succeeded

In production, users have `github.token` (limited) + GitHub App (elevated), so the bug manifests.

## Expected Result

**These tests should FAIL** with current `action.yml` because:

- `action.yml` line 101 checks `${GITHUB_APP_ID}` which is never set in the env block (lines 85-88)
- The PAT URL rewrite always applies, baking the limited token into clone URLs
- Commits are made as `github-actions[bot]` instead of the GitHub App

## Next Steps

After this PR merges (proving the bug), a follow-up PR will fix `action.yml` by adding the missing env vars:

```yaml
env:
  GITHUB_APP_ID: ${{ inputs.github-app-id }}
  GITHUB_APP_PRIVATE_KEY: ${{ inputs.github-app-private-key }}
```

## Test plan

- [ ] CI runs GitHub App tests
- [ ] Tests fail with `github-actions[bot]` as commit author (proving the bug)
- [ ] After fix PR, tests pass with GitHub App as commit author

Refs: #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)