### PR TITLE
fix: add missing GitHub App env vars to Configure git step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,8 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_APP_ID: ${{ inputs.github-app-id }}
+        GITHUB_APP_PRIVATE_KEY: ${{ inputs.github-app-private-key }}
         AZURE_DEVOPS_TOKEN: ${{ inputs.azure-devops-token }}
         GITLAB_TOKEN: ${{ inputs.gitlab-token }}
       run: |


### PR DESCRIPTION
## Summary

Add the missing GitHub App environment variables to the "Configure git" step in `action.yml`.

## Root Cause

PR #311 added a condition to skip the PAT URL rewrite when GitHub App auth is configured, but the env block didn't include the App credential variables. They were always empty, so the PAT URL rewrite was always applied.

## The Fix

Add `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` to the env block so the condition can properly detect when App auth is configured.

## Test plan

- [ ] Merge #313 first (adds tests that will fail)
- [ ] Merge this PR
- [ ] Integration tests pass with GitHub App as commit author (not github-actions[bot])

Fixes: #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
