### PR TITLE
fix: reset remote URL after clone to enable per-command auth

### DIFF
--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -75,6 +75,16 @@ export class GitOps {
       `git clone ${escapeShellArg(gitUrl)} .`,
       this.workDir
     );
+
+    // Reset remote URL to canonical form after clone.
+    // Git's url.insteadOf rewrites can bake credentials into the remote URL
+    // during clone. This prevents per-command -c url.insteadOf overrides from
+    // matching (they match the canonical URL, not the rewritten one).
+    // Resetting ensures subsequent operations can use different credentials.
+    await this.exec(
+      `git remote set-url origin ${escapeShellArg(gitUrl)}`,
+      this.workDir
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Reset remote URL to canonical form after clone to enable per-command authentication overrides.

## The Problem

Git's `url.insteadOf` rewrites bake credentials into the remote URL during clone:

```
# Global config (set by action.yml for PAT auth)
url.https://token@github.com/.insteadOf = https://github.com/

# After clone, remote URL becomes:
https://token@github.com/owner/repo.git  # <- credential baked in
```

When GitHub App auth tries to override with `-c url.insteadOf`:

```
git -c 'url.https://app-token@github.com/owner/repo.insteadOf=https://github.com/owner/repo' push
```

It doesn't match because the remote URL already has `token@`.

## The Fix

After clone, reset the remote URL to the canonical form:

```bash
git remote set-url origin https://github.com/owner/repo
```

This ensures subsequent `-c url.insteadOf` overrides match correctly.

## Test plan

- [ ] Unit tests pass (1339 tests)
- [ ] Integration tests pass on main after merge
- [ ] GitHub App PR mode works (was failing before)

Refs: #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
