### PR TITLE
fix(ci): disable persist-credentials to fix per-command git auth

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -78,6 +80,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -124,6 +128,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -170,6 +176,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -217,6 +225,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -263,6 +273,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- Adds `persist-credentials: false` to all `actions/checkout` steps in CI workflow

## Problem

The per-command `-c url.insteadOf` auth approach fails in CI because `actions/checkout` with `persist-credentials: true` (default) bakes the `GITHUB_TOKEN` into a global git config:

```
url."https://x-access-token:TOKEN@github.com/".insteadOf = "https://github.com/"
```

This causes the remote URL to contain embedded credentials that don't match our `insteadOf` patterns, resulting in:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Solution

Setting `persist-credentials: false` prevents `actions/checkout` from configuring global git credentials, allowing our per-command auth to work as designed.

## Test plan

- [ ] CI passes (lint, build, unit tests)
- [ ] Integration tests pass on main after merge (GitHub PAT flow)
- [ ] GitHub App integration tests pass

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)