### PR TITLE
fix(graphql): skip retries when checking branch existence

### DIFF
--- a/src/strategies/graphql-commit-strategy.test.ts
+++ b/src/strategies/graphql-commit-strategy.test.ts
@@ -20,8 +20,8 @@ function createMockGitOps(): AuthenticatedGitOps & {
   const calls: Array<{ method: string; args: unknown[] }> = [];
   return {
     calls,
-    async lsRemote(branchName: string) {
-      calls.push({ method: "lsRemote", args: [branchName] });
+    async lsRemote(branchName: string, options?: { skipRetry?: boolean }) {
+      calls.push({ method: "lsRemote", args: [branchName, options] });
       return "";
     },
     async fetchBranch(branchName: string) {
@@ -919,8 +919,14 @@ describe("GraphQLCommitStrategy", () => {
       // Create mock gitOps that throws on lsRemote (branch doesn't exist)
       const mockGitOps = createMockGitOps();
       const _originalLsRemote = mockGitOps.lsRemote.bind(mockGitOps);
-      mockGitOps.lsRemote = async (branchName: string) => {
-        mockGitOps.calls.push({ method: "lsRemote", args: [branchName] });
+      mockGitOps.lsRemote = async (
+        branchName: string,
+        options?: { skipRetry?: boolean }
+      ) => {
+        mockGitOps.calls.push({
+          method: "lsRemote",
+          args: [branchName, options],
+        });
         throw new Error("fatal: could not read from remote");
       };
 
@@ -1017,8 +1023,14 @@ describe("GraphQLCommitStrategy", () => {
 
       // Create mock gitOps that throws on lsRemote (branch doesn't exist)
       const mockGitOps = createMockGitOps();
-      mockGitOps.lsRemote = async (branchName: string) => {
-        mockGitOps.calls.push({ method: "lsRemote", args: [branchName] });
+      mockGitOps.lsRemote = async (
+        branchName: string,
+        options?: { skipRetry?: boolean }
+      ) => {
+        mockGitOps.calls.push({
+          method: "lsRemote",
+          args: [branchName, options],
+        });
         throw new Error("fatal: could not read from remote");
       };
 

--- a/src/strategies/graphql-commit-strategy.ts
+++ b/src/strategies/graphql-commit-strategy.ts
@@ -287,8 +287,9 @@ export class GraphQLCommitStrategy implements CommitStrategy {
     // Branch name was validated in commit(), safe for shell use
     try {
       // Check if the branch exists on remote
+      // Use skipRetry because failure is expected for new branches
       if (gitOps) {
-        await gitOps.lsRemote(branchName);
+        await gitOps.lsRemote(branchName, { skipRetry: true });
       } else {
         await this.executor.exec(
           `git ls-remote --exit-code --heads origin ${escapeShellArg(branchName)}`,


### PR DESCRIPTION
## Summary

- Add `skipRetry` option to `lsRemote()` to bypass retry logic when checking branch existence
- Use `skipRetry: true` in `ensureBranchExistsOnRemote()` since failure is expected for new branches
- Eliminates 3 unnecessary "Attempt X/4 failed" messages in CI logs

**Before:**
```
Committing and pushing changes...
Attempt 1/4 failed: Command failed: git ls-remote --exit-code --heads origin 'chore/sync-config'. Retrying...
Attempt 2/4 failed: Command failed: git ls-remote --exit-code --heads origin 'chore/sync-config'. Retrying...
Attempt 3/4 failed: Command failed: git ls-remote --exit-code --heads origin 'chore/sync-config'. Retrying...
Committed: abc123 (verified: true)
```

**After:**
```
Committing and pushing changes...
Committed: abc123 (verified: true)
```

## Test plan

- [x] Unit tests pass (`npm test` - 1379 tests)
- [x] Lint passes (`./lint.sh`)
- [ ] Integration test: `npm run test:integration:github` - verify no retry messages for new branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)