### PR TITLE
fix: update integration test fixtures path after reorganization

### DIFF
--- a/test/integration/ado.test.ts
+++ b/test/integration/ado.test.ts
@@ -8,7 +8,7 @@ import { rmSync, existsSync } from "node:fs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "../..");
-const fixturesDir = join(projectRoot, "fixtures");
+const fixturesDir = join(projectRoot, "test", "fixtures");
 
 // Azure DevOps test repository
 const TEST_ORG = "aspruyt";

--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -8,7 +8,7 @@ import { rmSync, existsSync } from "node:fs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "../..");
-const fixturesDir = join(projectRoot, "fixtures");
+const fixturesDir = join(projectRoot, "test", "fixtures");
 
 const TEST_REPO = "anthony-spruyt/xfg-test";
 const TARGET_FILE = "github-app-test.json";

--- a/test/integration/github-settings.test.ts
+++ b/test/integration/github-settings.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "../..");
-const fixturesDir = join(projectRoot, "fixtures");
+const fixturesDir = join(projectRoot, "test", "fixtures");
 
 const TEST_REPO = "anthony-spruyt/xfg-test";
 const RULESET_NAME = "xfg-test-ruleset";

--- a/test/integration/github.test.ts
+++ b/test/integration/github.test.ts
@@ -8,7 +8,7 @@ import { rmSync, existsSync } from "node:fs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "../..");
-const fixturesDir = join(projectRoot, "fixtures");
+const fixturesDir = join(projectRoot, "test", "fixtures");
 
 const TEST_REPO = "anthony-spruyt/xfg-test";
 const TARGET_FILE = "my.config.json";

--- a/test/integration/gitlab.test.ts
+++ b/test/integration/gitlab.test.ts
@@ -8,7 +8,7 @@ import { rmSync, existsSync } from "node:fs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "../..");
-const fixturesDir = join(projectRoot, "fixtures");
+const fixturesDir = join(projectRoot, "test", "fixtures");
 
 // GitLab test repository
 const TEST_NAMESPACE = "anthony-spruyt1";


### PR DESCRIPTION
## Summary

- Fix integration tests failing after #334 moved `fixtures/` to `test/fixtures/`
- Update `fixturesDir` constant in all 5 integration test files

## Test Plan

- [x] Unit tests pass locally
- [ ] CI passes (integration tests should now find fixtures)

🤖 Generated with [Claude Code](https://claude.ai/code)