### PR TITLE
fix: split simpleRule into individual rule definitions for IDE support

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -431,7 +431,19 @@
           "$ref": "#/definitions/requiredStatusChecksRule"
         },
         {
-          "$ref": "#/definitions/simpleRule"
+          "$ref": "#/definitions/requiredSignaturesRule"
+        },
+        {
+          "$ref": "#/definitions/requiredLinearHistoryRule"
+        },
+        {
+          "$ref": "#/definitions/nonFastForwardRule"
+        },
+        {
+          "$ref": "#/definitions/creationRule"
+        },
+        {
+          "$ref": "#/definitions/deletionRule"
         },
         {
           "$ref": "#/definitions/updateRule"
@@ -608,23 +620,63 @@
         }
       }
     },
-    "simpleRule": {
+    "requiredSignaturesRule": {
       "type": "object",
-      "description": "Simple rule with no parameters",
+      "description": "Require signed commits",
       "required": [
         "type"
       ],
       "properties": {
         "type": {
-          "type": "string",
-          "enum": [
-            "required_signatures",
-            "required_linear_history",
-            "non_fast_forward",
-            "creation",
-            "deletion"
-          ],
-          "description": "Rule type: required_signatures (require signed commits), required_linear_history (no merge commits), non_fast_forward (prevent force push), creation (restrict ref creation), deletion (restrict ref deletion)"
+          "const": "required_signatures"
+        }
+      }
+    },
+    "requiredLinearHistoryRule": {
+      "type": "object",
+      "description": "Require linear history (no merge commits)",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "required_linear_history"
+        }
+      }
+    },
+    "nonFastForwardRule": {
+      "type": "object",
+      "description": "Prevent force pushes",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "non_fast_forward"
+        }
+      }
+    },
+    "creationRule": {
+      "type": "object",
+      "description": "Restrict ref creation",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "creation"
+        }
+      }
+    },
+    "deletionRule": {
+      "type": "object",
+      "description": "Restrict ref deletion",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "const": "deletion"
         }
       }
     },


### PR DESCRIPTION
## Summary

- Split combined `simpleRule` definition into individual rule definitions
- Each rule now uses `const` instead of sharing an `enum`:
  - `requiredSignaturesRule`
  - `requiredLinearHistoryRule`
  - `nonFastForwardRule`
  - `creationRule`
  - `deletionRule`

This allows IDEs to properly autocomplete rule types when editing config files.

## Test plan

- [x] Schema is valid JSON
- [x] All 1382 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)