### PR TITLE
fix: correct settings command progress indicator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,6 +343,7 @@ export async function runSettings(
   }
 
   console.log(`Found ${reposWithRulesets.length} repositories with rulesets\n`);
+  logger.setTotal(reposWithRulesets.length);
 
   const processor = processorFactory();
   const repoProcessor = repoProcessorFactory();
@@ -351,16 +352,8 @@ export async function runSettings(
   let failCount = 0;
   let skipCount = 0;
 
-  for (let i = 0; i < config.repos.length; i++) {
-    const repoConfig = config.repos[i];
-
-    // Skip repos without rulesets
-    if (
-      !repoConfig.settings?.rulesets ||
-      Object.keys(repoConfig.settings.rulesets).length === 0
-    ) {
-      continue;
-    }
+  for (let i = 0; i < reposWithRulesets.length; i++) {
+    const repoConfig = reposWithRulesets[i];
 
     let repoInfo;
     try {


### PR DESCRIPTION
## Summary

- Add `logger.setTotal(reposWithRulesets.length)` to set correct total count
- Change loop to iterate over `reposWithRulesets` instead of `config.repos`

This fixes the progress indicator showing `[4/0]` instead of `[1/1]`.

Fixes #346

## Test Plan

- [x] Build passes
- [x] All 1411 tests pass
- [ ] Manual verification with settings command

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>