### PR TITLE
fix(ci): prevent build job from being skipped on push to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
   build:
     needs:
       - "lint"
+    if: ${{ !cancelled() && needs.lint.result != 'failure' }}
     runs-on: ubuntu-latest
 
     concurrency:


### PR DESCRIPTION
## Summary
- PR #369 made `lint` only run on `pull_request` events, but `build` has `needs: ["lint"]`
- On push to main, lint is skipped → build is skipped → all integration tests cascade-skip
- Add `if: ${{ !cancelled() && needs.lint.result != 'failure' }}` to `build` so it runs when lint succeeds or is skipped, but not when lint fails

## Test plan
- [ ] Verify lint still runs on PRs and blocks build if it fails
- [ ] Verify build and integration tests run on push to main (no longer skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)