### PR TITLE
fix(ci): decouple build from lint to prevent transitive skip cascade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,6 @@ jobs:
     secrets: "inherit"
 
   build:
-    needs:
-      - "lint"
-    if: ${{ !cancelled() && needs.lint.result != 'failure' }}
     runs-on: ubuntu-latest
 
     concurrency:


### PR DESCRIPTION
## Summary
- PR #375 fixed build being skipped on push, but integration tests were still skipped
- Root cause: GitHub Actions propagates skipped status transitively through the `needs` chain — even though `build` succeeded via `!cancelled()`, integration tests transitively depended on the skipped `lint` job and were all skipped
- Fix: remove `lint` from `build`'s `needs` entirely — they're independent (build doesn't need lint's output), and the `summary` job already gates both via branch protection
- Bonus: lint and build now run in parallel on PRs, making CI faster

## Test plan
- [ ] On this PR: lint and build both run (in parallel), integration tests skipped (expected — PR event)
- [ ] After merge to main: build runs, all integration tests run (no longer skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)