### PR TITLE
fix(ci): restore lint→build graph and fix transitive skip cascade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,9 @@ jobs:
     secrets: "inherit"
 
   build:
+    needs:
+      - "lint"
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
 
     concurrency:
@@ -67,7 +70,7 @@ jobs:
   integration-test-github:
     needs:
       - "build"
-    if: github.event_name == 'push'
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
     concurrency:
@@ -112,7 +115,7 @@ jobs:
   integration-test-ado:
     needs:
       - "build"
-    if: github.event_name == 'push'
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
     concurrency:
@@ -157,7 +160,7 @@ jobs:
   integration-test-gitlab:
     needs:
       - "build"
-    if: github.event_name == 'push'
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
     concurrency:
@@ -203,7 +206,7 @@ jobs:
   integration-test-github-rulesets:
     needs:
       - "build"
-    if: github.event_name == 'push'
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
     concurrency:
@@ -241,7 +244,7 @@ jobs:
   integration-test-github-repo-settings:
     needs:
       - "build"
-    if: github.event_name == 'push'
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
     concurrency:
@@ -281,7 +284,7 @@ jobs:
     needs:
       - "build"
       - "integration-test-github"
-    if: github.event_name == 'push'
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
     concurrency:


### PR DESCRIPTION
## Summary
- PR #376 removed lint from build's `needs`, which fixed integration tests running but broke the CI dependency graph
- This PR restores `lint → build → tests → summary` graph by adding `!failure() && !cancelled()` to build and all integration test jobs
- GitHub Actions cascades skipped status transitively through `needs` chains. Adding status check functions (`!failure()`) to the `if` overrides the implicit `success()` check, allowing jobs to run when upstream dependencies are skipped (lint on push) while still stopping if they actually fail (lint on PR)

## Behavior
| Event | lint | build | integration tests | summary |
|-------|------|-------|-------------------|---------|
| PR | runs | waits for lint, runs if lint passes | skipped (push only) | gates PR |
| push to main | skipped | runs (skipped != failure) | run after build | reports |

## Test plan
- [ ] PR CI: lint runs, build runs after lint, tests skipped, summary passes
- [ ] After merge: lint skipped, build runs, all integration tests run, summary passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)