### PR TITLE
fix(test): use correct App ID for bypass_actors integration test

### DIFF
--- a/test/fixtures/integration-test-github-app-settings.yaml
+++ b/test/fixtures/integration-test-github-app-settings.yaml
@@ -15,7 +15,7 @@ settings:
       target: branch
       enforcement: active
       bypassActors:
-        - actorId: 2719952
+        - actorId: 2753244
           actorType: Integration
           bypassMode: always
       conditions:


### PR DESCRIPTION
Changes actorId from 2719952 (repo-operator) to 2753244 (XFG Test App) in the settings fixture.

Related: #378