### PR TITLE
fix(test): use positive assertion for direct mode App test

### DIFF
--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -45,10 +45,11 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
     const output = exec(`node dist/cli.js --config ${configPath}`, xfgEnv);
     console.log(output);
 
-    // xfg should complete successfully (direct push)
+    // exec throws on non-zero exit code, so reaching here means success.
+    // Verify xfg reported a successful outcome.
     assert.ok(
-      !output.includes("Failed") && !output.includes("Error"),
-      "xfg direct mode should complete without errors"
+      output.includes("succeeded"),
+      "xfg direct mode should report success"
     );
   });
 


### PR DESCRIPTION
Summary line "Failed: 0" triggers the negative check. exec() already throws on non-zero exit, so check for "succeeded" instead.

Related: #378