### PR TITLE
refactor(ci): remove redundant before-reset from self-resetting test jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,12 +118,6 @@ jobs:
           git config --global credential."https://dev.azure.com".helper "$(pwd)/.github/scripts/git-credential-ado.sh"
           git config --global credential."https://dev.azure.com".useHttpPath true
 
-      # Cleanup before — reset test repo to clean state
-      - name: Cleanup — reset ADO test repo
-        env:
-          AZURE_DEVOPS_EXT_PAT: ${{ secrets.AZURE_DEVOPS_EXT_PAT }}
-        run: .github/scripts/reset-test-repo-ado.sh https://dev.azure.com/aspruyt fxg fxg-test
-
       - name: Run Azure DevOps integration tests
         env:
           AZURE_DEVOPS_EXT_PAT: ${{ secrets.AZURE_DEVOPS_EXT_PAT }}
@@ -170,12 +164,6 @@ jobs:
           git config --global credential."https://gitlab.com".helper "$(pwd)/.github/scripts/git-credential-gitlab.sh"
           git config --global credential."https://gitlab.com".useHttpPath true
 
-      # Cleanup before — reset test repo to clean state
-      - name: Cleanup — reset GitLab test repo
-        env:
-          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-        run: .github/scripts/reset-test-repo-gitlab.sh anthony-spruyt1/xfg-test
-
       - name: Run GitLab integration tests
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
@@ -213,12 +201,6 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      # Cleanup before — reset test repo to clean state
-      - name: Cleanup — reset test repo
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: .github/scripts/reset-test-repo.sh anthony-spruyt/xfg-test
 
       - name: Run GitHub integration tests (PAT)
         env:


### PR DESCRIPTION
## Summary

- Removes CI-level before-reset steps from `ado-pat`, `gitlab-pat`, and `github-pat` jobs
- These test files already call `resetTestRepo()` at the start of each test, so the CI step just duplicates work
- Keeps CI before-reset for jobs whose tests **don't** self-reset: `github-app`, `github-rulesets`, `github-repo-settings`, and all 3 action jobs

## Test plan

- [x] YAML validates correctly
- [ ] CI passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)