### PR TITLE
refactor(test): move CI reset into test files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,15 +240,11 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Cleanup before — reset test repo to clean state
-      - name: Cleanup — reset test repo
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: .github/scripts/reset-test-repo.sh anthony-spruyt/xfg-test
-
-      # Act — only App credentials, no GH_TOKEN
+      # GH_TOKEN needed for resetTestRepo() in tests (cross-repo access).
+      # xfg commands strip GH_TOKEN via xfgEnv — only App credentials are used.
       - name: Act — run GitHub App integration tests
         env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           XFG_GITHUB_APP_ID: ${{ vars.TEST_APP_ID }}
           XFG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
         run: npm run test:integration:github-app
@@ -292,12 +288,6 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      # Cleanup before — reset test repo to clean state
-      - name: Cleanup — reset test repo
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: .github/scripts/reset-test-repo.sh anthony-spruyt/xfg-test
-
       - name: Run GitHub settings integration tests
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -335,12 +325,6 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      # Cleanup before — reset test repo to clean state
-      - name: Cleanup — reset test repo
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: .github/scripts/reset-test-repo.sh anthony-spruyt/xfg-test
 
       - name: Run GitHub repo settings integration tests
         env:

--- a/test/integration/ado.test.ts
+++ b/test/integration/ado.test.ts
@@ -1,4 +1,4 @@
-import { test, describe } from "node:test";
+import { test, describe, beforeEach } from "node:test";
 import { strict as assert } from "node:assert";
 import { join } from "node:path";
 import { exec, projectRoot } from "./test-helpers.js";
@@ -128,9 +128,11 @@ function resetTestRepo(): void {
 }
 
 describe("Azure DevOps Integration Test", () => {
-  test("sync creates a PR in the test repository", async () => {
+  beforeEach(() => {
     resetTestRepo();
+  });
 
+  test("sync creates a PR in the test repository", async () => {
     const configPath = join(fixturesDir, "integration-test-config-ado.yaml");
 
     // Run the sync tool
@@ -200,8 +202,6 @@ describe("Azure DevOps Integration Test", () => {
   });
 
   test("re-sync closes existing PR and creates fresh one", async () => {
-    resetTestRepo();
-
     // Arrange — create initial PR by running xfg
     const configPath = join(fixturesDir, "integration-test-config-ado.yaml");
     console.log("Creating initial PR...");
@@ -258,8 +258,6 @@ describe("Azure DevOps Integration Test", () => {
   });
 
   test("createOnly skips file when it exists on base branch", async () => {
-    resetTestRepo();
-
     const createOnlyFile = "createonly-test.json";
     const createOnlyBranch = "chore/sync-createonly-test";
 
@@ -326,8 +324,6 @@ describe("Azure DevOps Integration Test", () => {
   });
 
   test("PR title only includes files that actually changed (issue #90)", async () => {
-    resetTestRepo();
-
     const unchangedFile = "unchanged-test.json";
     const changedFile = "changed-test.json";
     const testBranch = "chore/sync-config";
@@ -382,8 +378,6 @@ describe("Azure DevOps Integration Test", () => {
   });
 
   test("direct mode pushes directly to main branch without creating PR (issue #134)", async () => {
-    resetTestRepo();
-
     const directFile = "direct-test.config.json";
 
     console.log("\n=== Setting up direct mode test (issue #134) ===\n");

--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -1,4 +1,4 @@
-import { test, describe } from "node:test";
+import { test, describe, beforeEach } from "node:test";
 import { join } from "node:path";
 import { exec, projectRoot } from "./test-helpers.js";
 
@@ -17,9 +17,21 @@ if (SKIP_TESTS) {
 // xfg commands must NOT see GH_TOKEN — only App credentials
 const xfgEnv = { cwd: projectRoot, env: { GH_TOKEN: undefined } };
 
+const RESET_SCRIPT = join(projectRoot, ".github/scripts/reset-test-repo.sh");
+
+function resetTestRepo(): void {
+  console.log("\n=== Resetting test repo to clean state ===\n");
+  exec(`bash ${RESET_SCRIPT} anthony-spruyt/xfg-test`);
+  console.log("\n=== Reset complete ===\n");
+}
+
 // Act only — exec() throws on non-zero exit code.
 // All assertions (commit verified, author is App) are in the Assert CI step.
 describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
+  beforeEach(() => {
+    resetTestRepo();
+  });
+
   test("sync creates PR via GraphQL API with GitHub App credentials", () => {
     const configPath = join(fixturesDir, "integration-test-github-app.yaml");
     console.log("Running xfg sync with GitHub App credentials...");

--- a/test/integration/github-rulesets.test.ts
+++ b/test/integration/github-rulesets.test.ts
@@ -1,4 +1,4 @@
-import { test, describe, before, after } from "node:test";
+import { test, describe, beforeEach } from "node:test";
 import { strict as assert } from "node:assert";
 import { join } from "node:path";
 import {
@@ -36,25 +36,17 @@ async function waitForRulesetVisible(
   return waitForRulesetVisibleBase(TEST_REPO, rulesetId, timeoutMs);
 }
 
+const RESET_SCRIPT = join(projectRoot, ".github/scripts/reset-test-repo.sh");
+
+function resetTestRepo(): void {
+  console.log("\n=== Resetting test repo to clean state ===\n");
+  exec(`bash ${RESET_SCRIPT} ${TEST_REPO}`);
+  console.log("\n=== Reset complete ===\n");
+}
+
 describe("GitHub Settings Integration Test", () => {
-  before(() => {
-    console.log("\n=== Setting up settings integration test ===\n");
-
-    // Delete test ruleset if it exists from previous runs
-    console.log("Cleaning up any existing test rulesets...");
-    deleteRulesetIfExists();
-
-    console.log("\n=== Setup complete ===\n");
-  });
-
-  after(() => {
-    console.log("\n=== Cleaning up ===\n");
-
-    // Delete test ruleset created during tests
-    console.log("Deleting test ruleset...");
-    deleteRulesetIfExists();
-
-    console.log("\n=== Cleanup complete ===\n");
+  beforeEach(() => {
+    resetTestRepo();
   });
 
   test("settings creates a ruleset in the test repository", async () => {

--- a/test/integration/github.test.ts
+++ b/test/integration/github.test.ts
@@ -1,4 +1,4 @@
-import { test, describe } from "node:test";
+import { test, describe, beforeEach } from "node:test";
 import { strict as assert } from "node:assert";
 import { join } from "node:path";
 import {
@@ -30,9 +30,11 @@ function resetTestRepo(): void {
 }
 
 describe("GitHub Integration Test", () => {
-  test("sync creates a PR in the test repository", async () => {
+  beforeEach(() => {
     resetTestRepo();
+  });
 
+  test("sync creates a PR in the test repository", async () => {
     const configPath = join(fixturesDir, "integration-test-config-github.yaml");
 
     // Run the sync tool
@@ -102,8 +104,6 @@ describe("GitHub Integration Test", () => {
   });
 
   test("re-sync closes existing PR and creates fresh one", async () => {
-    resetTestRepo();
-
     // Arrange — create initial PR by running xfg
     const configPath = join(fixturesDir, "integration-test-config-github.yaml");
     console.log("Creating initial PR...");
@@ -159,8 +159,6 @@ describe("GitHub Integration Test", () => {
   });
 
   test("createOnly skips file when it exists on base branch", async () => {
-    resetTestRepo();
-
     // This test uses a separate config file with createOnly: true
     const createOnlyFile = "createonly-test.json";
     const createOnlyBranch = "chore/sync-createonly-test";
@@ -231,8 +229,6 @@ describe("GitHub Integration Test", () => {
   });
 
   test("PR title only includes files that actually changed (issue #90)", async () => {
-    resetTestRepo();
-
     // This test verifies the bug fix for issue #90:
     // When some files in the config don't actually change (content matches repo),
     // they should NOT appear in the PR title or commit message.
@@ -295,8 +291,6 @@ describe("GitHub Integration Test", () => {
   });
 
   test("template feature interpolates ${xfg:...} variables in files and PR body", async () => {
-    resetTestRepo();
-
     // This test verifies the template feature (issue #133):
     // 1. Files with template: true should have ${xfg:...} variables interpolated
     // 2. Custom prTemplate should have ${xfg:...} variables interpolated in PR body
@@ -421,8 +415,6 @@ describe("GitHub Integration Test", () => {
   });
 
   test("direct mode pushes directly to main branch without creating PR (issue #134)", async () => {
-    resetTestRepo();
-
     // This test verifies the direct mode feature (issue #134):
     // Files are pushed directly to the default branch without creating a PR.
 
@@ -471,8 +463,6 @@ describe("GitHub Integration Test", () => {
   });
 
   test("deleteOrphaned removes files when removed from config (issue #132)", async () => {
-    resetTestRepo();
-
     // This test verifies the deleteOrphaned feature (issue #132):
     // 1. Sync a file with deleteOrphaned: true (tracked in .xfg.json manifest)
     // 2. Remove the file from config
@@ -555,8 +545,6 @@ describe("GitHub Integration Test", () => {
   });
 
   test("handles divergent branch when existing PR is present (issue #183)", async () => {
-    resetTestRepo();
-
     // This test verifies the fix for issue #183:
     // When xfg tries to push to a sync branch that has diverged from the new local changes,
     // it should use --force-with-lease to handle the divergent history gracefully.
@@ -634,8 +622,6 @@ describe("GitHub Integration Test", () => {
   });
 
   test("handles divergent branch when no PR exists but branch exists (issue #183)", async () => {
-    resetTestRepo();
-
     // This test verifies the fix for issue #183, specifically the case where:
     // - closeExistingPR has nothing to close (no PR exists)
     // - But the remote sync branch still exists from a previous run

--- a/test/integration/gitlab.test.ts
+++ b/test/integration/gitlab.test.ts
@@ -1,4 +1,4 @@
-import { test, describe } from "node:test";
+import { test, describe, beforeEach } from "node:test";
 import { strict as assert } from "node:assert";
 import { join } from "node:path";
 import { exec, projectRoot } from "./test-helpers.js";
@@ -133,9 +133,11 @@ function resetTestRepo(): void {
 }
 
 describe("GitLab Integration Test", () => {
-  test("sync creates a MR in the test repository", async () => {
+  beforeEach(() => {
     resetTestRepo();
+  });
 
+  test("sync creates a MR in the test repository", async () => {
     const configPath = join(fixturesDir, "integration-test-config-gitlab.yaml");
 
     // Run the sync tool
@@ -200,8 +202,6 @@ describe("GitLab Integration Test", () => {
   });
 
   test("re-sync closes existing MR and creates fresh one", async () => {
-    resetTestRepo();
-
     // Arrange — create initial MR by running xfg
     const configPath = join(fixturesDir, "integration-test-config-gitlab.yaml");
     console.log("Creating initial MR...");
@@ -253,8 +253,6 @@ describe("GitLab Integration Test", () => {
   });
 
   test("createOnly skips file when it exists on base branch", async () => {
-    resetTestRepo();
-
     const createOnlyFile = "createonly-test.json";
     const createOnlyBranch = "chore/sync-createonly-test";
 
@@ -319,8 +317,6 @@ describe("GitLab Integration Test", () => {
   });
 
   test("MR title only includes files that actually changed (issue #90)", async () => {
-    resetTestRepo();
-
     const unchangedFile = "unchanged-test.json";
     const changedFile = "changed-test.json";
     const testBranch = "chore/sync-config";
@@ -375,8 +371,6 @@ describe("GitLab Integration Test", () => {
   });
 
   test("direct mode pushes directly to main branch without creating MR (issue #134)", async () => {
-    resetTestRepo();
-
     const directFile = "direct-test.config.json";
 
     console.log("\n=== Setting up direct mode test (issue #134) ===\n");


### PR DESCRIPTION
## Summary
- Adds `resetTestRepo()` calls at the start of each test in `github-app.test.ts`, `github-rulesets.test.ts`, and `github-repo-settings.test.ts`
- Removes CI-level "Cleanup — reset test repo" steps that are now redundant
- Makes test 3 in repo-settings self-contained (applies settings before checking idempotency)
- For github-app, adds `GH_TOKEN` to the test step env so `resetTestRepo()` can authenticate cross-repo (xfg commands still strip it via `xfgEnv`)

## Test plan
- [ ] CI build passes
- [ ] Integration tests pass on main (tests are now fully self-contained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)