### PR TITLE
fix(test): create repo-settings test repo as public

### DIFF
--- a/test/integration/github-repo-settings.test.ts
+++ b/test/integration/github-repo-settings.test.ts
@@ -55,7 +55,7 @@ function createTestRepo(): void {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       console.log(`  Creating ${TEST_REPO} (attempt ${attempt})...`);
-      exec(`gh repo create ${TEST_REPO} --private --add-readme`);
+      exec(`gh repo create ${TEST_REPO} --public --add-readme`);
       console.log(`  Created ${TEST_REPO}`);
       return;
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

- Create `xfg-test-repo-settings` as public instead of private
- Private repos have slow API propagation — `gh api` returns 404 for 30+ seconds after creation, causing `waitForRepoReady` to time out every run
- Public repos are immediately visible via the API
- Also saves private repo action minutes

## Test plan

- [x] `npm run build` compiles
- [x] `npm test` — 1576 tests pass
- [x] `./lint.sh` — all linters pass
- [ ] CI on main — repo-settings job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)