### PR TITLE
fix(release): use exact ref match for floating tag existence check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,8 @@ jobs:
           COMMIT_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
 
           # Delete and recreate the major version tag (e.g., v3)
-          if gh api "repos/$REPO/git/refs/tags/v${MAJOR}" &>/dev/null; then
+          # Use git/ref (singular) for exact match — git/refs (plural) does prefix matching
+          if gh api "repos/$REPO/git/ref/tags/v${MAJOR}" &>/dev/null; then
             gh api --method DELETE "repos/$REPO/git/refs/tags/v${MAJOR}"
             echo "Deleted existing v${MAJOR} tag"
           fi


### PR DESCRIPTION
## Summary

- Fix the floating major version tag step in the release workflow
- `git/refs` (plural) does prefix matching, so checking for `v3` matched `v3.0.0`, `v3.5.5`, etc., causing a false positive
- The subsequent DELETE on the non-existent exact `v3` ref returned HTTP 422
- Use `git/ref` (singular) for exact match

## Test plan

- [ ] Trigger a patch release and verify the floating tag step succeeds
- [ ] Verify `v3` tag is created pointing to the release commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)