### PR TITLE
feat(settings): add webCommitSignoffRequired and defaultBranch repo settings

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -465,6 +465,14 @@
         "privateVulnerabilityReporting": {
           "type": "boolean",
           "description": "Enable or disable private vulnerability reporting"
+        },
+        "webCommitSignoffRequired": {
+          "type": "boolean",
+          "description": "Require contributors to sign off on web-based commits"
+        },
+        "defaultBranch": {
+          "type": "string",
+          "description": "The default branch for the repository"
         }
       }
     },

--- a/docs/configuration/repo-settings.md
+++ b/docs/configuration/repo-settings.md
@@ -47,6 +47,8 @@ xfg settings -c config.yaml
 | `allowForking` | boolean | Allow forking (private repos) |
 | `visibility` | string | `public`, `private`, or `internal` |
 | `archived` | boolean | Archive the repository |
+| `webCommitSignoffRequired` | boolean | Require sign-off on web-based commits |
+| `defaultBranch` | string | Set the default branch |
 
 ### Merge Options
 
@@ -112,6 +114,7 @@ xfg displays warnings for potentially destructive operations:
 | Change `visibility` | "visibility change may expose or hide repository" |
 | Set `archived: true` | "archiving makes repository read-only" |
 | Disable `hasIssues`, `hasWiki`, `hasProjects` | "may hide existing content" |
+| Change `defaultBranch` | "may affect existing PRs, CI workflows, and branch protections" |
 
 Example output:
 

--- a/src/config-validator.ts
+++ b/src/config-validator.ts
@@ -482,12 +482,18 @@ function validateRepoSettings(repo: unknown, context: string): void {
     "secretScanning",
     "secretScanningPushProtection",
     "privateVulnerabilityReporting",
+    "webCommitSignoffRequired",
   ];
 
   for (const field of booleanFields) {
     if (r[field] !== undefined && typeof r[field] !== "boolean") {
       throw new Error(`${context}: ${field} must be a boolean`);
     }
+  }
+
+  // Validate string fields
+  if (r.defaultBranch !== undefined && typeof r.defaultBranch !== "string") {
+    throw new Error(`${context}: defaultBranch must be a string`);
   }
 
   // Validate enum fields

--- a/src/config.ts
+++ b/src/config.ts
@@ -385,6 +385,8 @@ export interface GitHubRepoSettings {
   allowForking?: boolean;
   visibility?: RepoVisibility;
   archived?: boolean;
+  webCommitSignoffRequired?: boolean;
+  defaultBranch?: string;
 
   // Merge options
   allowSquashMerge?: boolean;

--- a/src/repo-settings-diff.ts
+++ b/src/repo-settings-diff.ts
@@ -32,6 +32,8 @@ const PROPERTY_MAPPING: Record<keyof GitHubRepoSettings, string> = {
   squashMergeCommitMessage: "squash_merge_commit_message",
   mergeCommitTitle: "merge_commit_title",
   mergeCommitMessage: "merge_commit_message",
+  webCommitSignoffRequired: "web_commit_signoff_required",
+  defaultBranch: "default_branch",
   vulnerabilityAlerts: "_vulnerability_alerts",
   automatedSecurityFixes: "_automated_security_fixes",
   secretScanning: "_secret_scanning",

--- a/src/repo-settings-plan-formatter.ts
+++ b/src/repo-settings-plan-formatter.ts
@@ -43,6 +43,9 @@ function getWarning(change: RepoSettingsChange): string | undefined {
   ) {
     return `disabling ${change.property} may hide existing content`;
   }
+  if (change.property === "defaultBranch") {
+    return `changing default branch may affect existing PRs, CI workflows, and branch protections`;
+  }
   return undefined;
 }
 

--- a/src/strategies/github-repo-settings-strategy.ts
+++ b/src/strategies/github-repo-settings-strategy.ts
@@ -43,6 +43,8 @@ function configToGitHubPayload(
     "squashMergeCommitMessage",
     "mergeCommitTitle",
     "mergeCommitMessage",
+    "webCommitSignoffRequired",
+    "defaultBranch",
   ];
 
   for (const key of directMappings) {

--- a/src/strategies/repo-settings-strategy.ts
+++ b/src/strategies/repo-settings-strategy.ts
@@ -28,6 +28,8 @@ export interface CurrentRepoSettings {
   squash_merge_commit_message?: string;
   merge_commit_title?: string;
   merge_commit_message?: string;
+  web_commit_signoff_required?: boolean;
+  default_branch?: string;
   security_and_analysis?: {
     secret_scanning?: { status: string };
     secret_scanning_push_protection?: { status: string };

--- a/test/unit/config-validator.test.ts
+++ b/test/unit/config-validator.test.ts
@@ -2636,6 +2636,40 @@ describe("validateRepoSettings", () => {
     assert.doesNotThrow(() => validateRawConfig(config));
   });
 
+  test("rejects non-boolean webCommitSignoffRequired", () => {
+    const config = createSettingsConfig({
+      webCommitSignoffRequired: "yes",
+    });
+    assert.throws(
+      () => validateRawConfig(config),
+      /webCommitSignoffRequired must be a boolean/
+    );
+  });
+
+  test("accepts valid webCommitSignoffRequired", () => {
+    const config = createSettingsConfig({
+      webCommitSignoffRequired: true,
+    });
+    assert.doesNotThrow(() => validateRawConfig(config));
+  });
+
+  test("rejects non-string defaultBranch", () => {
+    const config = createSettingsConfig({
+      defaultBranch: 123,
+    });
+    assert.throws(
+      () => validateRawConfig(config),
+      /defaultBranch must be a string/
+    );
+  });
+
+  test("accepts valid defaultBranch", () => {
+    const config = createSettingsConfig({
+      defaultBranch: "develop",
+    });
+    assert.doesNotThrow(() => validateRawConfig(config));
+  });
+
   test("rejects repo settings that is not an object", () => {
     const config: import("../../src/config.js").RawConfig = {
       id: "test-config",

--- a/test/unit/repo-settings-diff.test.ts
+++ b/test/unit/repo-settings-diff.test.ts
@@ -107,6 +107,36 @@ describe("diffRepoSettings", () => {
     );
   });
 
+  test("should detect changed webCommitSignoffRequired", () => {
+    const current: CurrentRepoSettings = { web_commit_signoff_required: false };
+    const desired: GitHubRepoSettings = { webCommitSignoffRequired: true };
+
+    const changes = diffRepoSettings(current, desired);
+
+    assert.equal(changes.length, 1);
+    assert.deepEqual(changes[0], {
+      property: "webCommitSignoffRequired",
+      action: "change",
+      oldValue: false,
+      newValue: true,
+    });
+  });
+
+  test("should detect changed defaultBranch", () => {
+    const current: CurrentRepoSettings = { default_branch: "main" };
+    const desired: GitHubRepoSettings = { defaultBranch: "develop" };
+
+    const changes = diffRepoSettings(current, desired);
+
+    assert.equal(changes.length, 1);
+    assert.deepEqual(changes[0], {
+      property: "defaultBranch",
+      action: "change",
+      oldValue: "main",
+      newValue: "develop",
+    });
+  });
+
   test("should ignore undefined desired values", () => {
     const current: CurrentRepoSettings = { has_wiki: true };
     const desired: GitHubRepoSettings = { hasWiki: undefined };

--- a/test/unit/repo-settings-plan-formatter.test.ts
+++ b/test/unit/repo-settings-plan-formatter.test.ts
@@ -96,6 +96,21 @@ describe("formatRepoSettingsPlan", () => {
     assert.ok(result.warnings.some((w) => w.includes("hide existing content")));
   });
 
+  test("should generate warning for defaultBranch change", () => {
+    const changes: RepoSettingsChange[] = [
+      {
+        property: "defaultBranch",
+        action: "change",
+        oldValue: "main",
+        newValue: "develop",
+      },
+    ];
+
+    const result = formatRepoSettingsPlan(changes);
+
+    assert.ok(result.warnings.some((w) => w.includes("default branch")));
+  });
+
   test("should format multiple changes", () => {
     const changes: RepoSettingsChange[] = [
       {

--- a/test/unit/strategies/github-repo-settings-strategy.test.ts
+++ b/test/unit/strategies/github-repo-settings-strategy.test.ts
@@ -85,6 +85,34 @@ describe("GitHubRepoSettingsStrategy", () => {
       assert.ok(mockExecutor.commands[0].includes("has_issues"));
     });
 
+    test("should include web_commit_signoff_required in payload", async () => {
+      mockExecutor.setResponse("/repos/test-org/test-repo", "{}");
+
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      await strategy.updateSettings(githubRepo, {
+        webCommitSignoffRequired: true,
+      });
+
+      assert.equal(mockExecutor.commands.length, 1);
+      assert.ok(mockExecutor.commands[0].includes("-X PATCH"));
+      assert.ok(
+        mockExecutor.commands[0].includes("web_commit_signoff_required")
+      );
+    });
+
+    test("should include default_branch in payload", async () => {
+      mockExecutor.setResponse("/repos/test-org/test-repo", "{}");
+
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      await strategy.updateSettings(githubRepo, {
+        defaultBranch: "develop",
+      });
+
+      assert.equal(mockExecutor.commands.length, 1);
+      assert.ok(mockExecutor.commands[0].includes("-X PATCH"));
+      assert.ok(mockExecutor.commands[0].includes("default_branch"));
+    });
+
     test("should skip update when no settings provided", async () => {
       const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
       await strategy.updateSettings(githubRepo, {});


### PR DESCRIPTION
## Summary

- Add `webCommitSignoffRequired` (boolean) - require contributors to sign off on web-based commits
- Add `defaultBranch` (string) - set the default branch for the repository
- Both map to existing GitHub REST API fields (`web_commit_signoff_required`, `default_branch`)
- Add warning for `defaultBranch` changes (may affect PRs, CI, branch protections)

Closes #412

## Test plan

- [x] Unit tests for config validation (boolean + string type checks)
- [x] Unit tests for diff mapping (detects changes correctly)
- [x] Unit tests for strategy payload (correct snake_case in API payload)
- [x] Unit test for plan formatter warning on `defaultBranch` change
- [x] `npm run build` passes
- [x] `npm test` passes (1585 tests, 0 failures)
- [x] `./lint.sh` passes (only pre-existing lychee 404 on README marketplace link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)