### PR TITLE
fix(schema): support repo: false for per-repo opt-out

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -337,8 +337,17 @@
           }
         },
         "repo": {
-          "$ref": "#/definitions/githubRepoSettings",
-          "description": "GitHub repository settings (features, merge options, security)"
+          "oneOf": [
+            {
+              "type": "boolean",
+              "const": false,
+              "description": "Set to false to opt out of all inherited repository settings"
+            },
+            {
+              "$ref": "#/definitions/githubRepoSettings"
+            }
+          ],
+          "description": "GitHub repository settings (features, merge options, security). Set to false at per-repo level to opt out of inherited settings."
         },
         "deleteOrphaned": {
           "type": "boolean",


### PR DESCRIPTION
## Summary
- Add `oneOf` with `const: false` to the `repo` property in JSON schema
- Enables IDE autocomplete and validation for `repo: false` at per-repo level

## Context
The v3.7.0 release added `repo: false` support in TypeScript but the JSON schema wasn't updated, causing IDE validation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)