### PR TITLE
fix(settings): add GitHub App token support to RepoSettingsProcessor

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -25,22 +25,24 @@ repos: # List of repositories
 | Field            | Description                                                                                 | Required |
 | ---------------- | ------------------------------------------------------------------------------------------- | -------- |
 | `id`             | Unique identifier for this config. Used to namespace managed files in `.xfg.json` manifest. | Yes      |
-| `files`          | Map of target filenames to configs                                                          | *        |
+| `files`          | Map of target filenames to configs                                                          | \*       |
 | `repos`          | Array of repository configurations                                                          | Yes      |
-| `settings`       | Global settings. See [Repo Settings](repo-settings.md) and [Rulesets](rulesets.md)          | *        |
+| `settings`       | Global settings. See [Repo Settings](repo-settings.md) and [Rulesets](rulesets.md)          | \*       |
 | `prOptions`      | Global PR merge options (can be overridden per-repo)                                        | No       |
 | `prTemplate`     | Custom PR body template (inline or `@path/to/file` reference)                               | No       |
 | `deleteOrphaned` | Global default for orphan deletion. Files/rulesets removed from config are deleted.         | No       |
 | `githubHosts`    | Array of GitHub Enterprise hostnames (e.g., `github.mycompany.com`)                         | No       |
 
 <!-- markdownlint-disable MD046 -->
+
 !!! note "files/settings requirement"
-    At least one of `files` or `settings` must be present:
+At least one of `files` or `settings` must be present:
 
     - **`xfg sync`** requires `files` with at least one file
     - **`xfg settings`** requires `settings` with actionable config (e.g., rulesets)
 
     A config can have both for use with both commands.
+
 <!-- markdownlint-enable MD046 -->
 
 ## Per-File Fields

--- a/docs/configuration/repo-settings.md
+++ b/docs/configuration/repo-settings.md
@@ -3,7 +3,7 @@
 xfg can manage GitHub repository settings declaratively using the `settings` command. Configure features, merge options, and security settings in your config file, and xfg will update repositories to match your desired state.
 
 !!! note "GitHub-Only Feature"
-    Repository settings are only available for GitHub repositories. Azure DevOps and GitLab repos will be skipped when running `xfg settings`.
+Repository settings are only available for GitHub repositories. Azure DevOps and GitLab repos will be skipped when running `xfg settings`.
 
 ## Quick Start
 
@@ -37,42 +37,42 @@ xfg settings -c config.yaml
 
 ### Features
 
-| Setting | Type | Description |
-| ------- | ---- | ----------- |
-| `hasIssues` | boolean | Enable/disable GitHub Issues |
-| `hasProjects` | boolean | Enable/disable GitHub Projects |
-| `hasWiki` | boolean | Enable/disable the repository wiki |
-| `hasDiscussions` | boolean | Enable/disable GitHub Discussions |
-| `isTemplate` | boolean | Mark as a template repository |
-| `allowForking` | boolean | Allow forking (private repos) |
-| `visibility` | string | `public`, `private`, or `internal` |
-| `archived` | boolean | Archive the repository |
+| Setting                    | Type    | Description                           |
+| -------------------------- | ------- | ------------------------------------- |
+| `hasIssues`                | boolean | Enable/disable GitHub Issues          |
+| `hasProjects`              | boolean | Enable/disable GitHub Projects        |
+| `hasWiki`                  | boolean | Enable/disable the repository wiki    |
+| `hasDiscussions`           | boolean | Enable/disable GitHub Discussions     |
+| `isTemplate`               | boolean | Mark as a template repository         |
+| `allowForking`             | boolean | Allow forking (private repos)         |
+| `visibility`               | string  | `public`, `private`, or `internal`    |
+| `archived`                 | boolean | Archive the repository                |
 | `webCommitSignoffRequired` | boolean | Require sign-off on web-based commits |
-| `defaultBranch` | string | Set the default branch |
+| `defaultBranch`            | string  | Set the default branch                |
 
 ### Merge Options
 
-| Setting | Type | Description |
-| ------- | ---- | ----------- |
-| `allowSquashMerge` | boolean | Allow squash merging |
-| `allowMergeCommit` | boolean | Allow merge commits |
-| `allowRebaseMerge` | boolean | Allow rebase merging |
-| `allowAutoMerge` | boolean | Allow auto-merge |
-| `deleteBranchOnMerge` | boolean | Auto-delete head branches |
-| `allowUpdateBranch` | boolean | Show "Update branch" button |
-| `squashMergeCommitTitle` | string | `PR_TITLE` or `COMMIT_OR_PR_TITLE` |
-| `squashMergeCommitMessage` | string | `PR_BODY`, `COMMIT_MESSAGES`, or `BLANK` |
-| `mergeCommitTitle` | string | `PR_TITLE` or `MERGE_MESSAGE` |
-| `mergeCommitMessage` | string | `PR_BODY`, `PR_TITLE`, or `BLANK` |
+| Setting                    | Type    | Description                              |
+| -------------------------- | ------- | ---------------------------------------- |
+| `allowSquashMerge`         | boolean | Allow squash merging                     |
+| `allowMergeCommit`         | boolean | Allow merge commits                      |
+| `allowRebaseMerge`         | boolean | Allow rebase merging                     |
+| `allowAutoMerge`           | boolean | Allow auto-merge                         |
+| `deleteBranchOnMerge`      | boolean | Auto-delete head branches                |
+| `allowUpdateBranch`        | boolean | Show "Update branch" button              |
+| `squashMergeCommitTitle`   | string  | `PR_TITLE` or `COMMIT_OR_PR_TITLE`       |
+| `squashMergeCommitMessage` | string  | `PR_BODY`, `COMMIT_MESSAGES`, or `BLANK` |
+| `mergeCommitTitle`         | string  | `PR_TITLE` or `MERGE_MESSAGE`            |
+| `mergeCommitMessage`       | string  | `PR_BODY`, `PR_TITLE`, or `BLANK`        |
 
 ### Security
 
-| Setting | Type | Description |
-| ------- | ---- | ----------- |
-| `vulnerabilityAlerts` | boolean | Dependabot vulnerability alerts |
-| `automatedSecurityFixes` | boolean | Dependabot security updates |
-| `secretScanning` | boolean | Secret scanning |
-| `secretScanningPushProtection` | boolean | Push protection for secrets |
+| Setting                         | Type    | Description                     |
+| ------------------------------- | ------- | ------------------------------- |
+| `vulnerabilityAlerts`           | boolean | Dependabot vulnerability alerts |
+| `automatedSecurityFixes`        | boolean | Dependabot security updates     |
+| `secretScanning`                | boolean | Secret scanning                 |
+| `secretScanningPushProtection`  | boolean | Push protection for secrets     |
 | `privateVulnerabilityReporting` | boolean | Private vulnerability reporting |
 
 ## Inheritance
@@ -140,18 +140,18 @@ repos:
 ```
 
 !!! note
-    `repo: false` is only valid at the per-repo level when root-level repo settings are defined. It cannot be used at the root level.
+`repo: false` is only valid at the per-repo level when root-level repo settings are defined. It cannot be used at the root level.
 
 ## Warnings
 
 xfg displays warnings for potentially destructive operations:
 
-| Operation | Warning |
-| --------- | ------- |
-| Change `visibility` | "visibility change may expose or hide repository" |
-| Set `archived: true` | "archiving makes repository read-only" |
-| Disable `hasIssues`, `hasWiki`, `hasProjects` | "may hide existing content" |
-| Change `defaultBranch` | "may affect existing PRs, CI workflows, and branch protections" |
+| Operation                                     | Warning                                                         |
+| --------------------------------------------- | --------------------------------------------------------------- |
+| Change `visibility`                           | "visibility change may expose or hide repository"               |
+| Set `archived: true`                          | "archiving makes repository read-only"                          |
+| Disable `hasIssues`, `hasWiki`, `hasProjects` | "may hide existing content"                                     |
+| Change `defaultBranch`                        | "may affect existing PRs, CI workflows, and branch protections" |
 
 Example output:
 

--- a/docs/configuration/rulesets.md
+++ b/docs/configuration/rulesets.md
@@ -3,7 +3,7 @@
 xfg can manage GitHub Rulesets declaratively using the `settings` command. Define rulesets in your config file, and xfg will create, update, or delete them to match your desired state.
 
 !!! note "GitHub-Only Feature"
-    Rulesets are only available for GitHub repositories. Azure DevOps and GitLab repos will be skipped when running `xfg settings`.
+Rulesets are only available for GitHub repositories. Azure DevOps and GitLab repos will be skipped when running `xfg settings`.
 
 ## Quick Start
 
@@ -297,7 +297,7 @@ bypassActors:
 ```
 
 !!! tip "Finding Actor IDs"
-    Use the GitHub API to find actor IDs.
+Use the GitHub API to find actor IDs.
 
 ```bash
 # Team ID

--- a/docs/reference/cli-options.md
+++ b/docs/reference/cli-options.md
@@ -21,7 +21,7 @@ xfg --config <path> [options]
 ```
 
 !!! warning "Config Requirement"
-    The sync command requires a `files` section with at least one file defined. If your config only has `settings`, use `xfg settings` instead.
+The sync command requires a `files` section with at least one file defined. If your config only has `settings`, use `xfg settings` instead.
 
 ### Sync Options
 
@@ -67,10 +67,10 @@ xfg settings --config <path> [options]
 ```
 
 !!! warning "Config Requirement"
-    The settings command requires a `settings` section with actionable configuration (e.g., rulesets). If your config only has `files`, use `xfg sync` instead.
+The settings command requires a `settings` section with actionable configuration (e.g., rulesets). If your config only has `files`, use `xfg sync` instead.
 
 !!! note "GitHub-Only"
-    The settings command only works with GitHub repositories. Azure DevOps and GitLab repos are skipped.
+The settings command only works with GitHub repositories. Azure DevOps and GitLab repos are skipped.
 
 ### Settings Options
 

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -40,16 +40,16 @@ Or configure in `.vscode/settings.json`:
 | Field            | Type        | Required | Description                                       |
 | ---------------- | ----------- | -------- | ------------------------------------------------- |
 | `id`             | `string`    | Yes      | Unique config identifier (alphanumeric, `-`, `_`) |
-| `files`          | `object`    | *        | Map of filenames to file configs                  |
+| `files`          | `object`    | \*       | Map of filenames to file configs                  |
 | `repos`          | `array`     | Yes      | List of repository configurations                 |
-| `settings`       | `object`    | *        | Repository settings (rulesets, etc.)              |
+| `settings`       | `object`    | \*       | Repository settings (rulesets, etc.)              |
 | `prOptions`      | `PROptions` | No       | Global PR merge options                           |
 | `prTemplate`     | `string`    | No       | Custom PR body template                           |
 | `githubHosts`    | `array`     | No       | GitHub Enterprise Server hostnames                |
 | `deleteOrphaned` | `boolean`   | No       | Global default for orphan file deletion           |
 
 !!! note "files/settings requirement"
-    At least one of `files` or `settings` must be present. The `sync` command requires `files`, while the `settings` command requires `settings`.
+At least one of `files` or `settings` must be present. The `sync` command requires `files`, while the `settings` command requires `settings`.
 
 ### File Config
 


### PR DESCRIPTION
## Summary

- RepoSettingsProcessor was missing GitHub App token management that RulesetProcessor has
- This caused all repo settings to appear as "additions" in dry-run output when using GitHub App auth
- The `gh api` calls were made without proper authentication, returning empty/incomplete data

## Changes

- Added `tokenManager` field initialized from `XFG_GITHUB_APP_ID` and `XFG_GITHUB_APP_PRIVATE_KEY` env vars
- Added `getInstallationToken()` method to resolve App installation tokens per-repo
- Updated `process()` to use `effectiveToken` pattern matching `RulesetProcessor`

## Test plan

- [ ] Run `xfg settings --dry-run` with GitHub App auth against a repo with existing settings
- [ ] Verify settings show as unchanged (not additions) when they match

🤖 Generated with [Claude Code](https://claude.ai/claude-code)