### PR TITLE
fix(test): move repo settings test to separate describe block

### DIFF
--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -122,7 +122,11 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
     const output2 = exec(`node dist/cli.js --config ${configPath2}`, xfgEnv);
     console.log(output2);
   });
+});
 
+// Separate describe block without beforeEach reset - these tests don't need full repo reset
+// and running after the main tests avoids overwriting verified commits on main
+describe("GitHub App Repo Settings Test", { skip: SKIP_TESTS }, () => {
   // Regression test for issue #418 - RepoSettingsProcessor missing GitHub App token support
   test("repo settings with GitHub App token is idempotent", () => {
     const configPath = join(
@@ -131,6 +135,7 @@ describe("GitHub App Integration Test", { skip: SKIP_TESTS }, () => {
     );
 
     // Reset repo settings to defaults (uses gh CLI with GH_TOKEN for setup)
+    // Note: This does NOT reset the repo content/commits, only settings
     resetRepoSettings();
 
     // Apply repo settings with GitHub App credentials (no GH_TOKEN)


### PR DESCRIPTION
## Summary

Fixes the integration test failure caused by my previous PR #419.

## Problem

The new repo settings test was in the main `describe` block which has `beforeEach(() => resetTestRepo())`. This reset created an unverified commit on main that the assert script then checked, instead of the verified commit from the `deleteOrphaned` test.

## Fix

Move the repo settings test to a separate `describe` block without `beforeEach` reset. The test only needs to reset repo settings (via `resetRepoSettings()`), not the entire repo.

## Test plan

- [x] Unit tests pass locally
- [ ] Integration tests pass on main after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)