### PR TITLE
fix(test): correct security settings reset order in integration tests

### DIFF
--- a/test/integration/github-repo-settings.test.ts
+++ b/test/integration/github-repo-settings.test.ts
@@ -80,19 +80,29 @@ function getSecuritySettings(): {
 
 /**
  * Reset security settings to known state (all disabled).
+ * Order matters: automated-security-fixes requires vulnerability-alerts to be enabled first.
  */
 function resetSecuritySettings(): void {
   console.log("  Resetting security settings...");
+  // 1. Enable vulnerability alerts first (required to configure automated-security-fixes)
   try {
-    exec(`gh api -X DELETE repos/${TEST_REPO}/vulnerability-alerts`);
+    exec(`gh api -X PUT repos/${TEST_REPO}/vulnerability-alerts`);
   } catch {
-    // Already disabled
+    // Already enabled
   }
+  // 2. Disable automated security fixes (now possible since vuln alerts are enabled)
   try {
     exec(`gh api -X DELETE repos/${TEST_REPO}/automated-security-fixes`);
   } catch {
     // Already disabled
   }
+  // 3. Disable vulnerability alerts
+  try {
+    exec(`gh api -X DELETE repos/${TEST_REPO}/vulnerability-alerts`);
+  } catch {
+    // Already disabled
+  }
+  // 4. Disable private vulnerability reporting
   try {
     exec(`gh api -X DELETE repos/${TEST_REPO}/private-vulnerability-reporting`);
   } catch {


### PR DESCRIPTION
## Summary

- Fix security settings reset order in integration tests
- automated-security-fixes requires vulnerability-alerts to be enabled first

## Root Cause

The `resetSecuritySettings()` function was deleting vulnerability-alerts before automated-security-fixes. However, the GitHub API requires vulnerability alerts to be enabled to configure automated security fixes (HTTP 422 otherwise).

## Fix

Changed the order to:
1. Enable vulnerability alerts (PUT)
2. Disable automated security fixes (DELETE)
3. Disable vulnerability alerts (DELETE)
4. Disable private vulnerability reporting (DELETE)

## Test plan

- [ ] Integration tests pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)