### PR TITLE
fix(settings): return false for automated_security_fixes when vuln alerts disabled

### DIFF
--- a/test/unit/strategies/github-repo-settings-strategy.test.ts
+++ b/test/unit/strategies/github-repo-settings-strategy.test.ts
@@ -163,6 +163,27 @@ describe("GitHubRepoSettingsStrategy", () => {
       assert.equal(result.automated_security_fixes, true);
     });
 
+    test("should return automated_security_fixes false when vulnerability_alerts is disabled", async () => {
+      mockExecutor.setResponse(
+        "/repos/test-org/test-repo'",
+        JSON.stringify({ has_issues: true })
+      );
+      // vulnerability-alerts returns 404 (disabled)
+      mockExecutor.setError("vulnerability-alerts", "gh: Not Found (HTTP 404)");
+      // automated-security-fixes endpoint would return 204, but should be ignored
+      mockExecutor.setResponse("automated-security-fixes", "");
+      mockExecutor.setResponse(
+        "private-vulnerability-reporting",
+        JSON.stringify({ enabled: false })
+      );
+
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const result = await strategy.getSettings(githubRepo);
+
+      // Should return false because vulnerability_alerts is disabled
+      assert.equal(result.automated_security_fixes, false);
+    });
+
     test("should return automated_security_fixes false when endpoint returns 404", async () => {
       mockExecutor.setResponse(
         "/repos/test-org/test-repo'",


### PR DESCRIPTION
## Summary

- Fix automated_security_fixes to return false when vulnerability_alerts is disabled
- Add unit test for the new behavior

## Root Cause

When vulnerability_alerts is disabled, the GET `/repos/.../automated-security-fixes` endpoint returns 204 (success) instead of 404. However, the feature is effectively disabled because it requires vulnerability alerts to function.

## Fix

`getAutomatedSecurityFixes` now takes the `vulnerabilityAlertsEnabled` state and returns false early if vulnerability alerts are disabled, ensuring accurate state reporting.

## Test plan

- [x] Unit test for new behavior
- [ ] Integration tests pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)