### PR TITLE
fix(settings): use API response for automated_security_fixes state

### DIFF
--- a/src/strategies/github-repo-settings-strategy.ts
+++ b/src/strategies/github-repo-settings-strategy.ts
@@ -183,14 +183,11 @@ export class GitHubRepoSettingsStrategy implements IRepoSettingsStrategy {
   private async getAutomatedSecurityFixes(
     github: GitHubRepoInfo,
     options?: RepoSettingsStrategyOptions,
-    vulnerabilityAlertsEnabled?: boolean
+    _vulnerabilityAlertsEnabled?: boolean
   ): Promise<boolean> {
-    // Automated security fixes require vulnerability alerts to be enabled.
-    // When vuln alerts are disabled, the endpoint may return 204 (success),
-    // but the feature is effectively disabled.
-    if (vulnerabilityAlertsEnabled === false) {
-      return false;
-    }
+    // Note: Even when vulnerability alerts are disabled, this endpoint returns
+    // the configured state. This allows the diff to correctly show changes needed
+    // when vulnerability alerts will be enabled.
     const endpoint = `/repos/${github.owner}/${github.repo}/automated-security-fixes`;
     try {
       await this.ghApi("GET", endpoint, undefined, options);


### PR DESCRIPTION
## Summary

- Reverts early-return optimization that returned false when vulnerability alerts were disabled
- Trusts API to return configured state for accurate diff

## Root Cause

The early-return optimization (merged in #425) broke integration tests:
- When vuln alerts disabled: `automatedSecurityFixes` returned `false` (early return)
- Diff showed no change needed (current=false, desired=false)
- After enabling vuln alerts: GitHub's actual configured state was `true`
- Test failed: expected `false` but got `true`

## Fix

Removed the early-return. Now `getAutomatedSecurityFixes` always queries the API, returning GitHub's configured state regardless of vulnerability alerts status. This ensures the diff correctly shows changes needed.

## Test plan

- [x] Unit tests pass
- [ ] Integration tests pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)