### PR TITLE
feat(settings): add setPrivateVulnerabilityReporting setter

### DIFF
--- a/src/repo-settings-processor.ts
+++ b/src/repo-settings-processor.ts
@@ -153,8 +153,12 @@ export class RepoSettingsProcessor implements IRepoSettingsProcessor {
     options: { token?: string; host?: string }
   ): Promise<void> {
     // Extract settings that need separate API calls
-    const { vulnerabilityAlerts, automatedSecurityFixes, ...mainSettings } =
-      settings;
+    const {
+      vulnerabilityAlerts,
+      automatedSecurityFixes,
+      privateVulnerabilityReporting,
+      ...mainSettings
+    } = settings;
 
     // Update main settings via PATCH /repos
     if (Object.keys(mainSettings).length > 0) {
@@ -175,6 +179,15 @@ export class RepoSettingsProcessor implements IRepoSettingsProcessor {
       await this.strategy.setAutomatedSecurityFixes(
         repoInfo,
         automatedSecurityFixes,
+        options
+      );
+    }
+
+    // Handle private vulnerability reporting (separate endpoint)
+    if (privateVulnerabilityReporting !== undefined) {
+      await this.strategy.setPrivateVulnerabilityReporting(
+        repoInfo,
+        privateVulnerabilityReporting,
         options
       );
     }

--- a/src/strategies/github-repo-settings-strategy.ts
+++ b/src/strategies/github-repo-settings-strategy.ts
@@ -163,6 +163,19 @@ export class GitHubRepoSettingsStrategy implements IRepoSettingsStrategy {
     await this.ghApi(method, endpoint, undefined, options);
   }
 
+  async setPrivateVulnerabilityReporting(
+    repoInfo: RepoInfo,
+    enable: boolean,
+    options?: RepoSettingsStrategyOptions
+  ): Promise<void> {
+    this.validateGitHub(repoInfo);
+    const github = repoInfo as GitHubRepoInfo;
+
+    const endpoint = `/repos/${github.owner}/${github.repo}/private-vulnerability-reporting`;
+    const method = enable ? "PUT" : "DELETE";
+    await this.ghApi(method, endpoint, undefined, options);
+  }
+
   private async getVulnerabilityAlerts(
     github: GitHubRepoInfo,
     options?: RepoSettingsStrategyOptions

--- a/src/strategies/repo-settings-strategy.ts
+++ b/src/strategies/repo-settings-strategy.ts
@@ -76,6 +76,15 @@ export interface IRepoSettingsStrategy {
     enable: boolean,
     options?: RepoSettingsStrategyOptions
   ): Promise<void>;
+
+  /**
+   * Enables or disables private vulnerability reporting.
+   */
+  setPrivateVulnerabilityReporting(
+    repoInfo: RepoInfo,
+    enable: boolean,
+    options?: RepoSettingsStrategyOptions
+  ): Promise<void>;
 }
 
 /**
@@ -92,6 +101,7 @@ export function isRepoSettingsStrategy(
     typeof strategy.getSettings === "function" &&
     typeof strategy.updateSettings === "function" &&
     typeof strategy.setVulnerabilityAlerts === "function" &&
-    typeof strategy.setAutomatedSecurityFixes === "function"
+    typeof strategy.setAutomatedSecurityFixes === "function" &&
+    typeof strategy.setPrivateVulnerabilityReporting === "function"
   );
 }

--- a/test/unit/strategies/repo-settings-strategy.test.ts
+++ b/test/unit/strategies/repo-settings-strategy.test.ts
@@ -13,11 +13,13 @@ describe("IRepoSettingsStrategy interface", () => {
       updateSettings: async () => {},
       setVulnerabilityAlerts: async () => {},
       setAutomatedSecurityFixes: async () => {},
+      setPrivateVulnerabilityReporting: async () => {},
     };
     assert.ok(mockStrategy.getSettings);
     assert.ok(mockStrategy.updateSettings);
     assert.ok(mockStrategy.setVulnerabilityAlerts);
     assert.ok(mockStrategy.setAutomatedSecurityFixes);
+    assert.ok(mockStrategy.setPrivateVulnerabilityReporting);
   });
 });
 
@@ -28,6 +30,7 @@ describe("isRepoSettingsStrategy", () => {
       updateSettings: async () => {},
       setVulnerabilityAlerts: async () => {},
       setAutomatedSecurityFixes: async () => {},
+      setPrivateVulnerabilityReporting: async () => {},
     };
     assert.equal(isRepoSettingsStrategy(mockStrategy), true);
   });
@@ -63,6 +66,15 @@ describe("isRepoSettingsStrategy", () => {
       }),
       false
     );
+    assert.equal(
+      isRepoSettingsStrategy({
+        getSettings: async () => ({}),
+        updateSettings: async () => {},
+        setVulnerabilityAlerts: async () => {},
+        setAutomatedSecurityFixes: async () => {},
+      }),
+      false
+    );
   });
 
   test("should return false for object with non-function properties", () => {
@@ -72,6 +84,7 @@ describe("isRepoSettingsStrategy", () => {
         updateSettings: async () => {},
         setVulnerabilityAlerts: async () => {},
         setAutomatedSecurityFixes: async () => {},
+        setPrivateVulnerabilityReporting: async () => {},
       }),
       false
     );


### PR DESCRIPTION
## Summary

- Add missing setter method for private vulnerability reporting
- Update applyChanges to call the setter

## Root Cause

`privateVulnerabilityReporting` was being read from the API correctly but never applied because:
1. It was being passed to `updateSettings()` via `mainSettings`
2. But it requires a separate PUT/DELETE endpoint, not the PATCH /repos endpoint

## Changes

- Add `setPrivateVulnerabilityReporting(repoInfo, enable, options)` to `IRepoSettingsStrategy`
- Implement in `GitHubRepoSettingsStrategy` using PUT/DELETE `/repos/.../private-vulnerability-reporting`
- Extract `privateVulnerabilityReporting` in `applyChanges()` and call the setter
- Update type guard to check for the new method
- Update tests

## Test plan

- [x] Unit tests pass
- [ ] Integration tests pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)