### PR TITLE
fix: parse JSON in integration test + add missing coverage

### DIFF
--- a/test/integration/github-repo-settings.test.ts
+++ b/test/integration/github-repo-settings.test.ts
@@ -55,11 +55,14 @@ function getSecuritySettings(): {
     vulnerabilityAlerts = false;
   }
 
-  // Check automated security fixes (204 = enabled, 404 = disabled)
+  // Check automated security fixes (JSON response with {enabled: boolean})
   let automatedSecurityFixes = false;
   try {
-    exec(`gh api repos/${TEST_REPO}/automated-security-fixes`);
-    automatedSecurityFixes = true;
+    const asfResult = exec(
+      `gh api repos/${TEST_REPO}/automated-security-fixes`
+    );
+    const asfData = JSON.parse(asfResult);
+    automatedSecurityFixes = asfData.enabled === true;
   } catch {
     automatedSecurityFixes = false;
   }


### PR DESCRIPTION
## Summary
- Fix `getSecuritySettings()` in integration test to parse JSON from `automated-security-fixes` endpoint
- Add unit test for `setPrivateVulnerabilityReporting` to cover missing lines
- Add `privateVulnerabilityReportingCalls` tracking to MockStrategy

## Root Cause
The integration test had the same bug as the main code - assumed 204/404 status codes for `automated-security-fixes`, but GitHub returns HTTP 200 with JSON `{"enabled": boolean}`.

## Coverage
Added test for `privateVulnerabilityReporting` path in `applyChanges()` that was missing coverage.

## Test Plan
- [x] Unit tests pass (1611 tests)
- [x] Linting passes
- [ ] Integration tests on main
- [ ] Codecov at 95%+

**NO AUTOMERGE** - waiting for Codecov report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)