### PR TITLE
fix: add detailed plan output to CLI and GitHub summary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -458,6 +458,15 @@ export async function runSettings(
         noDelete: options.noDelete,
       });
 
+      // Print detailed ruleset plan output
+      if (result.planOutput && result.planOutput.lines.length > 0) {
+        logger.info("");
+        logger.info(chalk.bold(`${repoName} - Rulesets:`));
+        for (const line of result.planOutput.lines) {
+          logger.info(line);
+        }
+      }
+
       if (result.skipped) {
         logger.skip(i + 1, repoName, result.message);
       } else if (result.success) {

--- a/src/resource-converters.ts
+++ b/src/resource-converters.ts
@@ -5,15 +5,18 @@ import type { RepoConfig } from "./config.js";
 
 /**
  * Convert RulesetProcessorResult planOutput entries to Resource objects.
+ * Includes the detailed plan lines in the first resource's details for display.
  */
 export function rulesetResultToResources(
   repoName: string,
   result: RulesetProcessorResult
 ): Resource[] {
   const resources: Resource[] = [];
+  const planLines = result.planOutput?.lines ?? [];
 
   if (result.planOutput?.entries) {
-    for (const entry of result.planOutput.entries) {
+    for (let i = 0; i < result.planOutput.entries.length; i++) {
+      const entry = result.planOutput.entries[i];
       let action: ResourceAction;
       switch (entry.action) {
         case "create":
@@ -29,11 +32,16 @@ export function rulesetResultToResources(
           action = "unchanged";
       }
 
+      // Attach all plan lines to first resource for GitHub summary display
+      const details =
+        i === 0 && planLines.length > 0 ? { diff: planLines } : undefined;
+
       resources.push({
         type: "ruleset",
         repo: repoName,
         name: entry.name,
         action,
+        details,
       });
     }
   }
@@ -99,22 +107,34 @@ export function syncResultToResources(
 
 /**
  * Convert repo settings processor planOutput entries to Resource objects.
+ * Includes the detailed plan lines in the first resource's details for display.
  */
 export function repoSettingsResultToResources(
   repoName: string,
   result: {
-    planOutput?: { entries?: Array<{ property: string; action: string }> };
+    planOutput?: {
+      entries?: Array<{ property: string; action: string }>;
+      lines?: string[];
+    };
   }
 ): Resource[] {
   const resources: Resource[] = [];
+  const planLines = result.planOutput?.lines ?? [];
 
   if (result.planOutput?.entries) {
-    for (const entry of result.planOutput.entries) {
+    for (let i = 0; i < result.planOutput.entries.length; i++) {
+      const entry = result.planOutput.entries[i];
+
+      // Attach all plan lines to first resource for GitHub summary display
+      const details =
+        i === 0 && planLines.length > 0 ? { diff: planLines } : undefined;
+
       resources.push({
         type: "setting",
         repo: repoName,
         name: entry.property,
         action: entry.action === "add" ? "create" : "update",
+        details,
       });
     }
   }


### PR DESCRIPTION
## Summary

- Print detailed ruleset plan lines using logger.info instead of console.log
- Include plan lines in Resource details for GitHub summary display
- Update resource converters to attach plan lines to first resource

This fixes the missing detailed output in the Terraform-style plan, showing the actual property changes being made.

## Test plan

- [x] Unit tests pass (1654 tests)
- [x] Coverage at 97.5%
- [ ] Integration tests pass on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)