### PR TITLE
fix: use + symbol for array items in create context

### DIFF
--- a/src/ruleset-plan-formatter.ts
+++ b/src/ruleset-plan-formatter.ts
@@ -509,9 +509,9 @@ function formatFullConfig(ruleset: Ruleset, indent: number = 2): string[] {
         lines.push(style.color(`${pad}+ ${key}:`));
         for (const item of value) {
           if (typeof item === "object" && item !== null) {
-            lines.push(style.color(`${pad}    - ${JSON.stringify(item)}`));
+            lines.push(style.color(`${pad}    + ${JSON.stringify(item)}`));
           } else {
-            lines.push(style.color(`${pad}    - ${formatValue(item)}`));
+            lines.push(style.color(`${pad}    + ${formatValue(item)}`));
           }
         }
       }


### PR DESCRIPTION
## Summary

The ruleset plan formatter was using hardcoded `-` symbol for array items even when creating new rulesets. Changed to use `+` to correctly indicate items being added.

Before:
```
+ rules:
    - {"type":"pull_request",...}  # WRONG - looks like removing
```

After:
```
+ rules:
    + {"type":"pull_request",...}  # CORRECT - adding
```

## Test plan

- [x] Unit tests pass
- [ ] Integration tests verify correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)