### PR TITLE
fix: pass GH_TOKEN via env var instead of shell interpolation

### DIFF
--- a/src/shared/command-executor.ts
+++ b/src/shared/command-executor.ts
@@ -2,6 +2,14 @@ import { execSync } from "node:child_process";
 import { sanitizeCredentials } from "./sanitize-utils.js";
 
 /**
+ * Options for command execution.
+ */
+export interface ExecOptions {
+  /** Additional environment variables to set for the command */
+  env?: Record<string, string>;
+}
+
+/**
  * Interface for executing shell commands.
  * Enables dependency injection for testing and alternative implementations.
  */
@@ -10,10 +18,11 @@ export interface ICommandExecutor {
    * Execute a shell command and return the output.
    * @param command The command to execute
    * @param cwd The working directory for the command
+   * @param options Optional execution options (env vars, etc.)
    * @returns Promise resolving to the trimmed stdout output
    * @throws Error if the command fails
    */
-  exec(command: string, cwd: string): Promise<string>;
+  exec(command: string, cwd: string, options?: ExecOptions): Promise<string>;
 }
 
 /**
@@ -21,12 +30,17 @@ export interface ICommandExecutor {
  * Note: Commands are escaped using escapeShellArg before being passed here.
  */
 export class ShellCommandExecutor implements ICommandExecutor {
-  async exec(command: string, cwd: string): Promise<string> {
+  async exec(
+    command: string,
+    cwd: string,
+    options?: ExecOptions
+  ): Promise<string> {
     try {
       return execSync(command, {
         cwd,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
+        env: options?.env ? { ...process.env, ...options.env } : undefined,
       }).trim();
     } catch (error) {
       // Ensure stderr is always a string for consistent error handling


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #109 (`js/shell-command-constructed-from-input`) by passing tokens via environment variables instead of shell command string interpolation.

## Changes

- Add `ExecOptions` interface to `ICommandExecutor` for env var support
- Update `ShellCommandExecutor.exec()` to merge env vars into `process.env`
- Replace `buildTokenPrefix()` with `buildTokenEnv()` in `github-pr-strategy.ts`
- Update tests to verify token passed via `options.env.GH_TOKEN`

## Test Plan

- [x] All 1724 tests pass
- [x] Linting passes
- [x] CodeQL should no longer flag the shell injection issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)