### PR TITLE
fix(output): filter undefined settings in builder not formatter

### DIFF
--- a/src/cli/settings-report-builder.ts
+++ b/src/cli/settings-report-builder.ts
@@ -41,6 +41,10 @@ export function buildSettingsReport(
     // Convert settings processor output
     if (result.settingsResult?.planOutput?.entries) {
       for (const entry of result.settingsResult.planOutput.entries) {
+        // Skip settings where both values are undefined (no actual change)
+        if (entry.oldValue === undefined && entry.newValue === undefined) {
+          continue;
+        }
         const settingChange: SettingChange = {
           name: entry.property,
           action: entry.action,

--- a/test/unit/settings-report-builder.test.ts
+++ b/test/unit/settings-report-builder.test.ts
@@ -120,4 +120,38 @@ describe("buildSettingsReport", () => {
     assert.equal(report.totals.rulesets.create, 1);
     assert.equal(report.totals.rulesets.delete, 1);
   });
+
+  test("skips settings where both oldValue and newValue are undefined", () => {
+    const results = [
+      {
+        repoName: "org/repo",
+        settingsResult: {
+          planOutput: {
+            entries: [
+              {
+                property: "has_issues",
+                action: "change" as const,
+                oldValue: undefined,
+                newValue: undefined,
+              },
+              {
+                property: "deleteBranchOnMerge",
+                action: "change" as const,
+                oldValue: false,
+                newValue: true,
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const report = buildSettingsReport(results);
+
+    // Should only include the valid setting, not the undefined one
+    assert.equal(report.repos[0].settings.length, 1);
+    assert.equal(report.repos[0].settings[0].name, "deleteBranchOnMerge");
+    // Totals should only count the valid setting
+    assert.equal(report.totals.settings.change, 1);
+  });
 });


### PR DESCRIPTION
## Summary
- Move the filtering of settings with both `oldValue` and `newValue` undefined from the formatters to the builder
- This ensures totals are accurate and repos don't appear in output without any changes

The previous fix filtered in the formatter which caused a mismatch: totals counted the settings but they weren't displayed.

## Test plan
- [x] Unit tests pass (`npm test`)
- [x] Linting passes (`./lint.sh`)
- [ ] Integration tests pass on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)