### PR TITLE
refactor(cli): extract helpers from settings-command for SOLID compliance

### DIFF
--- a/src/cli/settings-report-builder.ts
+++ b/src/cli/settings-report-builder.ts
@@ -7,7 +7,11 @@ import type {
 import type { RepoSettingsPlanEntry } from "../settings/repo-settings/formatter.js";
 import type { RulesetPlanEntry } from "../settings/rulesets/formatter.js";
 
-interface ProcessorResults {
+/**
+ * Result from processing a repository's settings and rulesets.
+ * Used to collect results during settings command execution.
+ */
+export interface ProcessorResults {
   repoName: string;
   settingsResult?: {
     planOutput?: {


### PR DESCRIPTION
## Summary

- Export `ProcessorResults` interface from `settings-report-builder.ts` to eliminate duplicate interface definition (DRY violation)
- Extract `ResultsCollector` class to manage processing results collection
- Extract `processRulesets()` function for ruleset processing loop
- Extract `processRepoSettings()` function for repo settings processing loop
- Reduce `runSettings()` from 284 lines to 91 lines

## Motivation

Code review identified two SOLID violations in the post-refactor changes:

1. **DRY violation**: `ProcessorResults` interface was duplicated in both `settings-report-builder.ts` and `settings-command.ts`
2. **SRP violation**: `runSettings()` was 284 lines with mixed responsibilities

## Changes

| Component | Lines | Responsibility |
|-----------|-------|----------------|
| `ResultsCollector` class | 47-72 | Manage processing results collection |
| `processRulesets()` | 77-187 | Process rulesets for all repos |
| `processRepoSettings()` | 192-271 | Process repo settings for all repos |
| `runSettings()` | 276-367 | Orchestrate the workflow |

## Test plan

- [x] `npm run build` - TypeScript compiles
- [x] `npm test` - All 1735 unit tests pass
- [x] `./lint.sh` - All linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)