### PR TITLE
docs: update documentation for settings command and add action no-delete input

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ settings:
       enforcement: active
       conditions:
         refName:
-          include: ["refs/heads/main"]
+          include: [refs/heads/main]
           exclude: []
       rules:
         - type: pull_request

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "xfg - Repo as Code"
-description: "Sync files and manage repositories as code"
+description: "Sync files and manage settings across GitHub, Azure DevOps, and GitLab"
 author: "Anthony Spruyt"
 
 branding:
@@ -55,6 +55,10 @@ inputs:
   github-app-private-key:
     description: "GitHub App private key (PEM format) for JWT signing"
     required: false
+  no-delete:
+    description: "Skip deletion of orphaned resources even if deleteOrphaned is configured"
+    required: false
+    default: "false"
   xfg-package:
     description: "Override xfg package to install (npm package name, local .tgz path, or 'skip' to use pre-installed). Defaults to the version matching this action release."
     required: false
@@ -140,6 +144,10 @@ runs:
         # Add optional flags (shared)
         if [ "${{ inputs.dry-run }}" = "true" ]; then
           CMD="$CMD --dry-run"
+        fi
+
+        if [ "${{ inputs.no-delete }}" = "true" ]; then
+          CMD="$CMD --no-delete"
         fi
 
         # Add sync-only flags

--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -31,6 +31,7 @@ The simplest way to use xfg in GitHub Actions is with the official action:
 | `github-app-private-key` | No       | -                     | GitHub App private key (PEM) for JWT signing               |
 | `azure-devops-token`     | No       | -                     | Azure DevOps Personal Access Token                         |
 | `gitlab-token`           | No       | -                     | GitLab token for authentication                            |
+| `no-delete`              | No       | `false`               | Skip deletion of orphaned resources                        |
 
 ### Multi-Platform Example
 

--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -36,7 +36,11 @@ Add to `.vscode/settings.json`:
 
 This enables:
 
-- Autocomplete for `files`, `repos`, `content`, `mergeStrategy`, `git`, `override`
-- Enum suggestions for `mergeStrategy` values (`replace`, `append`, `prepend`)
-- Validation of required fields
+- Autocomplete for all config fields:
+  - Root level: `id`, `files`, `repos`, `settings`, `prOptions`, `prTemplate`, `githubHosts`, `deleteOrphaned`
+  - File config: `content`, `mergeStrategy`, `createOnly`, `executable`, `header`, `schemaUrl`, `template`, `vars`, `deleteOrphaned`
+  - Repo config: `git`, `files`, `settings`, `prOptions`
+  - Settings: `repo`, `rulesets` with full ruleset configuration
+- Enum suggestions for `mergeStrategy` (`replace`, `append`, `prepend`), `merge` mode (`manual`, `auto`, `force`, `direct`), etc.
+- Validation of required fields (`id`, `repos`)
 - Hover documentation for each field

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ settings:
       conditions:
         refName:
           include: [refs/heads/main]
+          exclude: []
       rules:
         - type: pull_request
           parameters:

--- a/docs/reference/cli-options.md
+++ b/docs/reference/cli-options.md
@@ -1,13 +1,13 @@
 # CLI Options Reference
 
-xfg uses subcommands to separate file sync (`sync`) from ruleset management (`settings`).
+xfg uses subcommands to separate file sync (`sync`) from repository settings management (`settings`).
 
 ## Subcommands
 
-| Command        | Description                                  |
-| -------------- | -------------------------------------------- |
-| `xfg sync`     | Sync configuration files across repositories |
-| `xfg settings` | Manage GitHub Rulesets for repositories      |
+| Command        | Description                                      |
+| -------------- | ------------------------------------------------ |
+| `xfg sync`     | Sync configuration files across repositories     |
+| `xfg settings` | Manage GitHub repository settings and rulesets   |
 
 ## Sync Command
 
@@ -57,7 +57,7 @@ xfg sync --config ./config.yaml --no-delete
 
 ## Settings Command
 
-Manage GitHub Rulesets for repositories. Creates, updates, or deletes rulesets to match your config.
+Manage GitHub repository settings and rulesets. Updates repository configuration and creates, updates, or deletes rulesets to match your config.
 
 ```bash
 xfg settings --config <path> [options]

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,13 +1,13 @@
 # Usage
 
-xfg uses subcommands to separate file sync from ruleset management.
+xfg uses subcommands to separate file sync from repository settings management.
 
 ## Commands
 
-| Command        | Description                                  |
-| -------------- | -------------------------------------------- |
-| `xfg sync`     | Sync configuration files across repositories |
-| `xfg settings` | Manage GitHub Rulesets for repositories      |
+| Command        | Description                                      |
+| -------------- | ------------------------------------------------ |
+| `xfg sync`     | Sync configuration files across repositories     |
+| `xfg settings` | Manage GitHub repository settings and rulesets   |
 
 ## Basic Usage
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aspruyt/xfg",
   "version": "3.8.1",
-  "description": "CLI tool for repository-as-code",
+  "description": "CLI tool for repository-as-code: sync files and manage settings across GitHub, Azure DevOps, and GitLab",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -92,9 +92,9 @@ const syncCommand = new Command("sync")
 addSharedOptions(syncCommand);
 program.addCommand(syncCommand);
 
-// Settings command (ruleset management)
+// Settings command (repository settings and rulesets)
 const settingsCommand = new Command("settings")
-  .description("Manage GitHub Rulesets for repositories")
+  .description("Manage GitHub repository settings and rulesets")
   .action((opts) => {
     runSettings(opts as SettingsOptions).catch((error) => {
       console.error("Fatal error:", error);


### PR DESCRIPTION
## Summary

- Update settings command description from "Manage GitHub Rulesets" to "Manage GitHub repository settings and rulesets" across CLI, docs, and usage pages
- Expand npm package description to include platform support details
- Add `no-delete` input to GitHub Action for skipping orphan deletion
- Update IDE integration page with comprehensive list of all config fields
- Add required `exclude: []` to rulesets examples in quick start guides
- Fix action.yml description to be more specific about platform support

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (1735 tests)
- [x] `./lint.sh` passes
- [x] CLI help shows updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)