### PR TITLE
fix(sync): ManifestStrategy should not save manifest in dry-run mode

### DIFF
--- a/src/sync/manifest-strategy.ts
+++ b/src/sync/manifest-strategy.ts
@@ -61,9 +61,9 @@ export class ManifestStrategy implements IWorkStrategy {
 
     if (dryRun) {
       this.log.info(`Would update ${MANIFEST_FILENAME} with rulesets`);
+    } else {
+      saveManifest(workDir, newManifest);
     }
-
-    saveManifest(workDir, newManifest);
 
     const fileChanges = new Map<string, FileWriteResult>([
       [


### PR DESCRIPTION
## Summary

- Fixed bug where ManifestStrategy saved the manifest file even in dry-run mode
- Dry-run should only report what would happen without making changes

## Test plan

- [x] All 1749 existing tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)