### PR TITLE
fix(ci): gate lifecycle tests behind ENABLE_LIFECYCLE_TESTS variable

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,6 +7,7 @@
 self-hosted-runner:
   labels: []
 config-variables:
+  - ENABLE_LIFECYCLE_TESTS
   - RELEASE_APP_ID
   - TEST_APP_ID
 paths:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -602,10 +602,9 @@ jobs:
   integration-test-cli-lifecycle-github-pat:
     needs:
       - "build"
-    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
+    # Requires ENABLE_LIFECYCLE_TESTS=true repo variable + GH_PAT with repo scope for new repos
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && vars.ENABLE_LIFECYCLE_TESTS == 'true' }}
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once GH_PAT has repo scope for newly-created repos
-    continue-on-error: true
 
     concurrency:
       group: integration-github-8
@@ -646,10 +645,9 @@ jobs:
   integration-test-cli-lifecycle-github-app:
     needs:
       - "build"
-    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
+    # Requires ENABLE_LIFECYCLE_TESTS=true repo variable + GitHub App with administration:write
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && vars.ENABLE_LIFECYCLE_TESTS == 'true' }}
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once GitHub App has administration:write permission
-    continue-on-error: true
 
     concurrency:
       group: integration-github-9
@@ -692,10 +690,9 @@ jobs:
   integration-test-action-lifecycle-pat:
     needs:
       - "build"
-    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
+    # Requires ENABLE_LIFECYCLE_TESTS=true repo variable + GH_PAT with repo scope for new repos
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && vars.ENABLE_LIFECYCLE_TESTS == 'true' }}
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once GH_PAT has repo scope for newly-created repos
-    continue-on-error: true
 
     concurrency:
       group: integration-github-10
@@ -768,10 +765,9 @@ jobs:
   integration-test-action-lifecycle-app:
     needs:
       - "build"
-    if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
+    # Requires ENABLE_LIFECYCLE_TESTS=true repo variable + GitHub App with administration:write
+    if: ${{ !failure() && !cancelled() && github.event_name == 'push' && vars.ENABLE_LIFECYCLE_TESTS == 'true' }}
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once GitHub App has administration:write permission
-    continue-on-error: true
 
     concurrency:
       group: integration-github-11


### PR DESCRIPTION
## Summary

Follow-up to #475. The `continue-on-error: true` approach didn't work because the summary workflow (`_summary.yaml`) queries all jobs via the GitHub API and checks their `conclusion` field directly. With `continue-on-error`, the conclusion is still `failure` — only the `outcome` for dependent jobs changes.

**Fix:** Gate all 4 lifecycle CI jobs behind `vars.ENABLE_LIFECYCLE_TESTS == 'true'`. When the variable isn't configured, the jobs are `skipped` (not `failure`), which the summary treats correctly.

Also adds `ENABLE_LIFECYCLE_TESTS` to `.github/actionlint.yaml` config-variables to pass actionlint validation.

## Prerequisites before enabling
- [ ] `GH_PAT` with repo scope for newly-created private repos
- [ ] GitHub App with `administration:write` permission
- [ ] Cross-owner fork source repo for fork tests
- [ ] Add `ENABLE_LIFECYCLE_TESTS=true` as a repo variable

## Test plan
- [x] Lint passes (all linters green including actionlint)
- [x] Unit tests pass (1867/1867)
- [x] Lifecycle jobs will be skipped when variable is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)