### PR TITLE
fix(ci): add repo readiness polling and fix lifecycle tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -604,8 +604,6 @@ jobs:
       - "build"
     if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once GH_PAT has repo scope for newly-created repos
-    continue-on-error: true
 
     concurrency:
       group: integration-github-8
@@ -648,8 +646,6 @@ jobs:
       - "build"
     if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once GitHub App has administration:write permission
-    continue-on-error: true
 
     concurrency:
       group: integration-github-9
@@ -694,8 +690,6 @@ jobs:
       - "build"
     if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once GH_PAT has repo scope for newly-created repos
-    continue-on-error: true
 
     concurrency:
       group: integration-github-10
@@ -770,8 +764,6 @@ jobs:
       - "build"
     if: ${{ !failure() && !cancelled() && github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once GitHub App has administration:write permission
-    continue-on-error: true
 
     concurrency:
       group: integration-github-11

--- a/test/integration/github-lifecycle-app.test.ts
+++ b/test/integration/github-lifecycle-app.test.ts
@@ -14,12 +14,9 @@ import {
 } from "./test-helpers.js";
 
 const OWNER = "anthony-spruyt";
-const FORK_SOURCE = "anthony-spruyt/xfg-fork-source";
-const FORK_SOURCE_OWNER = FORK_SOURCE.split("/")[0];
+const FORK_SOURCE = "octocat/Spoon-Knife";
 const ADO_MIGRATE_SOURCE = "https://dev.azure.com/aspruyt/fxg/_git/fxg-test";
 const HAS_ADO_CREDS = !!process.env.AZURE_DEVOPS_EXT_PAT;
-// Fork requires different owner — skip if upstream and target share the same owner
-const CAN_FORK = FORK_SOURCE_OWNER !== OWNER;
 
 // Skip all tests if GitHub App credentials are not set
 const SKIP_TESTS =
@@ -104,16 +101,13 @@ repos:
       console.log("  Create lifecycle test (App) passed");
     });
 
-    test(
-      "fork: sync forks upstream when repo doesn't exist (App auth)",
-      { skip: !CAN_FORK },
-      async () => {
-        const repoName = generateRepoName();
-        reposToDelete.push(repoName);
+    test("fork: sync forks upstream when repo doesn't exist (App auth)", async () => {
+      const repoName = generateRepoName();
+      reposToDelete.push(repoName);
 
-        const configPath = writeConfig(
-          tmpDir,
-          `id: lifecycle-fork-app-test
+      const configPath = writeConfig(
+        tmpDir,
+        `id: lifecycle-fork-app-test
 files:
   lifecycle-fork-test.json:
     content:
@@ -122,32 +116,31 @@ repos:
   - git: https://github.com/${OWNER}/${repoName}.git
     upstream: https://github.com/${FORK_SOURCE}.git
 `
-        );
+      );
 
-        console.log(
-          `\nForking ${FORK_SOURCE} as ${OWNER}/${repoName} via xfg sync (App)...`
-        );
-        const output = exec(
-          `node dist/cli.js sync --config ${configPath} --merge direct`,
-          xfgEnv
-        );
-        console.log(output);
+      console.log(
+        `\nForking ${FORK_SOURCE} as ${OWNER}/${repoName} via xfg sync (App)...`
+      );
+      const output = exec(
+        `node dist/cli.js sync --config ${configPath} --merge direct`,
+        xfgEnv
+      );
+      console.log(output);
 
-        // Verify repo was created
-        assert.ok(
-          repoExists(OWNER, repoName),
-          `Repo ${repoName} should exist after sync`
-        );
+      // Verify repo was created
+      assert.ok(
+        repoExists(OWNER, repoName),
+        `Repo ${repoName} should exist after sync`
+      );
 
-        // Verify it's a fork of the source
-        assert.ok(
-          isForkedFrom(OWNER, repoName, FORK_SOURCE),
-          `Repo ${repoName} should be a fork of ${FORK_SOURCE}`
-        );
+      // Verify it's a fork of the source
+      assert.ok(
+        isForkedFrom(OWNER, repoName, FORK_SOURCE),
+        `Repo ${repoName} should be a fork of ${FORK_SOURCE}`
+      );
 
-        console.log("  Fork lifecycle test (App) passed");
-      }
-    );
+      console.log("  Fork lifecycle test (App) passed");
+    });
 
     test("create dry-run: shows CREATE but doesn't actually create repo (App auth)", async () => {
       const repoName = generateRepoName();

--- a/test/integration/github-lifecycle.test.ts
+++ b/test/integration/github-lifecycle.test.ts
@@ -14,12 +14,9 @@ import {
 } from "./test-helpers.js";
 
 const OWNER = "anthony-spruyt";
-const FORK_SOURCE = "anthony-spruyt/xfg-fork-source";
-const FORK_SOURCE_OWNER = FORK_SOURCE.split("/")[0];
+const FORK_SOURCE = "octocat/Spoon-Knife";
 const ADO_MIGRATE_SOURCE = "https://dev.azure.com/aspruyt/fxg/_git/fxg-test";
 const HAS_ADO_CREDS = !!process.env.AZURE_DEVOPS_EXT_PAT;
-// Fork requires different owner — skip if upstream and target share the same owner
-const CAN_FORK = FORK_SOURCE_OWNER !== OWNER;
 
 describe("Lifecycle Integration Test (PAT)", () => {
   const reposToDelete: string[] = [];
@@ -83,16 +80,13 @@ repos:
     console.log("  Create lifecycle test passed");
   });
 
-  test(
-    "fork: sync forks upstream when repo doesn't exist",
-    { skip: !CAN_FORK },
-    async () => {
-      const repoName = generateRepoName();
-      reposToDelete.push(repoName);
+  test("fork: sync forks upstream when repo doesn't exist", async () => {
+    const repoName = generateRepoName();
+    reposToDelete.push(repoName);
 
-      const configPath = writeConfig(
-        tmpDir,
-        `id: lifecycle-fork-test
+    const configPath = writeConfig(
+      tmpDir,
+      `id: lifecycle-fork-test
 files:
   lifecycle-fork-test.json:
     content:
@@ -101,32 +95,31 @@ repos:
   - git: https://github.com/${OWNER}/${repoName}.git
     upstream: https://github.com/${FORK_SOURCE}.git
 `
-      );
+    );
 
-      console.log(
-        `\nForking ${FORK_SOURCE} as ${OWNER}/${repoName} via xfg sync...`
-      );
-      const output = exec(
-        `node dist/cli.js sync --config ${configPath} --merge direct`,
-        { cwd: projectRoot }
-      );
-      console.log(output);
+    console.log(
+      `\nForking ${FORK_SOURCE} as ${OWNER}/${repoName} via xfg sync...`
+    );
+    const output = exec(
+      `node dist/cli.js sync --config ${configPath} --merge direct`,
+      { cwd: projectRoot }
+    );
+    console.log(output);
 
-      // Verify repo was created
-      assert.ok(
-        repoExists(OWNER, repoName),
-        `Repo ${repoName} should exist after sync`
-      );
+    // Verify repo was created
+    assert.ok(
+      repoExists(OWNER, repoName),
+      `Repo ${repoName} should exist after sync`
+    );
 
-      // Verify it's a fork of the source
-      assert.ok(
-        isForkedFrom(OWNER, repoName, FORK_SOURCE),
-        `Repo ${repoName} should be a fork of ${FORK_SOURCE}`
-      );
+    // Verify it's a fork of the source
+    assert.ok(
+      isForkedFrom(OWNER, repoName, FORK_SOURCE),
+      `Repo ${repoName} should be a fork of ${FORK_SOURCE}`
+    );
 
-      console.log("  Fork lifecycle test passed");
-    }
-  );
+    console.log("  Fork lifecycle test passed");
+  });
 
   test("create dry-run: shows CREATE but doesn't actually create repo", async () => {
     const repoName = generateRepoName();

--- a/test/unit/lifecycle/repo-lifecycle-manager.test.ts
+++ b/test/unit/lifecycle/repo-lifecycle-manager.test.ts
@@ -40,19 +40,26 @@ describe("RepoLifecycleManager", () => {
     migrateCalled?: () => void;
     cloneCalled?: () => void;
   }): IRepoLifecycleFactory {
+    // Track whether a lifecycle operation has been performed so
+    // waitForRepoReady() sees the repo as ready immediately.
+    let repoCreated = false;
+
     const provider: IRepoLifecycleProvider = {
       platform: "github",
       async exists() {
-        return options.exists ?? false;
+        return repoCreated || (options.exists ?? false);
       },
       async create() {
         options.createCalled?.();
+        repoCreated = true;
       },
       async fork() {
         options.forkCalled?.();
+        repoCreated = true;
       },
       async receiveMigration() {
         options.migrateCalled?.();
+        repoCreated = true;
       },
     };
 


### PR DESCRIPTION
## Summary
- Add `waitForRepoReady()` polling after create/fork/migrate to handle GitHub's eventual consistency (avoids 403 on immediate clone)
- Switch fork test source to `octocat/Spoon-Knife` (cross-owner, avoids "Cannot fork to same owner" error)
- Remove `continue-on-error: true` from all 4 lifecycle CI jobs so failures are properly reported

## Test plan
- [x] All 1867 unit tests pass (21s, down from 83s after fixing mock to track repo creation state)
- [x] Lint passes (actionlint, eslint, shellcheck, yamllint, etc.)
- [ ] CI lifecycle jobs should pass on main after merge (requires PAT/App permissions to be configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)