### PR TITLE
fix(ci): use spruyt-labs org for lifecycle integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -696,7 +696,7 @@ jobs:
       cancel-in-progress: false
 
     env:
-      OWNER: anthony-spruyt
+      OWNER: spruyt-labs
 
     steps:
       - uses: actions/checkout@v6
@@ -770,7 +770,7 @@ jobs:
       cancel-in-progress: false
 
     env:
-      OWNER: anthony-spruyt
+      OWNER: spruyt-labs
 
     steps:
       - uses: actions/checkout@v6

--- a/test/integration/github-lifecycle-app.test.ts
+++ b/test/integration/github-lifecycle-app.test.ts
@@ -13,7 +13,7 @@ import {
   writeConfig,
 } from "./test-helpers.js";
 
-const OWNER = "anthony-spruyt";
+const OWNER = "spruyt-labs";
 const FORK_SOURCE = "octocat/Spoon-Knife";
 const ADO_MIGRATE_SOURCE = "https://dev.azure.com/aspruyt/fxg/_git/fxg-test";
 const HAS_ADO_CREDS = !!process.env.AZURE_DEVOPS_EXT_PAT;

--- a/test/integration/github-lifecycle.test.ts
+++ b/test/integration/github-lifecycle.test.ts
@@ -13,7 +13,7 @@ import {
   writeConfig,
 } from "./test-helpers.js";
 
-const OWNER = "anthony-spruyt";
+const OWNER = "spruyt-labs";
 const FORK_SOURCE = "octocat/Spoon-Knife";
 const ADO_MIGRATE_SOURCE = "https://dev.azure.com/aspruyt/fxg/_git/fxg-test";
 const HAS_ADO_CREDS = !!process.env.AZURE_DEVOPS_EXT_PAT;


### PR DESCRIPTION
## Summary
- Switch lifecycle test target from `anthony-spruyt` (personal account) to `spruyt-labs` org
- Fixes fine-grained PAT access propagation issues with newly created repos on personal accounts
- Fixes GitHub App `createRepository` permission limitations on personal accounts

## Prerequisites
Before merging, ensure:
- [ ] XFG Test App is installed on `spruyt-labs` org with "All repositories" + `administration:write`
- [ ] Fine-grained PAT is configured with resource owner `spruyt-labs` (or covers the org)

## Test plan
- [x] All 1867 unit tests pass
- [x] Lint passes
- [ ] CI lifecycle jobs pass on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)