### PR TITLE
fix: handle (unknown) branch in AuthenticatedGitOps.getDefaultBranch

### DIFF
--- a/src/vcs/authenticated-git-ops.ts
+++ b/src/vcs/authenticated-git-ops.ts
@@ -142,7 +142,7 @@ export class AuthenticatedGitOps implements IAuthenticatedGitOps {
     try {
       const remoteInfo = await this.execWithRetry(`git remote show origin`);
       const match = remoteInfo.match(/HEAD branch: (\S+)/);
-      if (match) {
+      if (match && match[1] !== "(unknown)") {
         return { branch: match[1], method: "remote HEAD" };
       }
     } catch {


### PR DESCRIPTION
## Summary
- Apply the same `(unknown)` branch name skip to `AuthenticatedGitOps.getDefaultBranch()` — the code path used when auth is set (CI)
- PR #481 only fixed `GitOps.getDefaultBranch()`, but `AuthenticatedGitOps` has its own duplicate implementation that runs in CI

## Context
CI still showed `Default branch: (unknown) (detected via remote HEAD)` because the authenticated code path wasn't fixed. This is the actual code path used in CI since auth tokens are always present.

## Test plan
- [x] New unit test for `AuthenticatedGitOps.getDefaultBranch` with `(unknown)` HEAD
- [x] All 1869 unit tests pass
- [x] Lint passes (lychee failure is transient network issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)