### PR TITLE
fix(lifecycle): review findings — fork guard, ref cleanup, init, docs

### DIFF
--- a/docs/configuration/lifecycle.md
+++ b/docs/configuration/lifecycle.md
@@ -121,6 +121,14 @@ The following settings apply during repo creation:
 | `hasIssues`   | Enable/disable Issues (default: enabled)         |
 | `hasWiki`     | Enable/disable Wiki (default: enabled)           |
 
+### Empty Repository Initialization
+
+When creating a new repository, xfg uses `--add-readme` to establish the default branch with an initial commit, then immediately deletes the README to leave the repo in a clean state. This ensures subsequent clone and push operations work correctly, since empty repositories without any commits have no resolvable `HEAD`.
+
+### Mirror Clone Cleanup
+
+When migrating with `source`, the mirror clone may include platform-specific refs that GitHub rejects on push (such as `refs/pull/*` from GitHub, `refs/merge-requests/*` from GitLab, or other internal refs). xfg automatically strips all refs except branches (`refs/heads/*`) and tags (`refs/tags/*`) before pushing to the target repository.
+
 ## Dry Run
 
 In dry-run mode (`--dry-run`), lifecycle operations are reported but not executed:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - PR Options: configuration/pr-options.md
       - PR Templates: configuration/pr-templates.md
       - Repo Lifecycle: configuration/lifecycle.md
+      - Repository Settings: configuration/repo-settings.md
       - GitHub Rulesets: configuration/rulesets.md
   - Examples:
       - Overview: examples/index.md


### PR DESCRIPTION
## Summary
- Case-insensitive fork same-owner guard (GitHub usernames are case-insensitive)
- Broader mirror ref cleanup: strip all non-`refs/heads/*` and non-`refs/tags/*` refs, not just `refs/pull/*` (fixes GitLab `refs/merge-requests/*` rejection on push to GitHub)
- Replace `.gitkeep` Contents API init with `--add-readme` + delete `README.md` (cleaner: repo gets default branch with zero leftover files)
- Add `repo-settings.md` to mkdocs.yml navigation (was a broken link)
- Document empty repo initialization and mirror clone cleanup in `lifecycle.md`

## Test plan
- [x] `npm test` — 1871 tests pass (+1 new case-insensitive fork test)
- [x] `./lint.sh` — clean
- [ ] CI lifecycle integration tests on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)