### PR TITLE
feat: add lifecycle GITHUB_STEP_SUMMARY and integration tests

### DIFF
--- a/src/output/lifecycle-report.ts
+++ b/src/output/lifecycle-report.ts
@@ -1,0 +1,231 @@
+// src/output/lifecycle-report.ts
+import { appendFileSync } from "node:fs";
+import chalk from "chalk";
+
+export interface LifecycleReport {
+  actions: LifecycleAction[];
+  totals: {
+    created: number;
+    forked: number;
+    migrated: number;
+    existed: number;
+  };
+}
+
+export interface LifecycleAction {
+  repoName: string;
+  action: "existed" | "created" | "forked" | "migrated";
+  upstream?: string;
+  source?: string;
+  settings?: {
+    visibility?: string;
+    description?: string;
+  };
+}
+
+export interface LifecycleReportInput {
+  repoName: string;
+  action: "existed" | "created" | "forked" | "migrated";
+  upstream?: string;
+  source?: string;
+  settings?: {
+    visibility?: string;
+    description?: string;
+  };
+}
+
+// =============================================================================
+// Builder
+// =============================================================================
+
+export function buildLifecycleReport(
+  results: LifecycleReportInput[]
+): LifecycleReport {
+  const actions: LifecycleAction[] = [];
+  const totals = { created: 0, forked: 0, migrated: 0, existed: 0 };
+
+  for (const result of results) {
+    actions.push({
+      repoName: result.repoName,
+      action: result.action,
+      upstream: result.upstream,
+      source: result.source,
+      settings: result.settings,
+    });
+
+    totals[result.action]++;
+  }
+
+  return { actions, totals };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function formatSummary(totals: LifecycleReport["totals"]): string {
+  const total = totals.created + totals.forked + totals.migrated;
+
+  if (total === 0) {
+    return "No changes";
+  }
+
+  const parts: string[] = [];
+  if (totals.created > 0) parts.push(`${totals.created} to create`);
+  if (totals.forked > 0) parts.push(`${totals.forked} to fork`);
+  if (totals.migrated > 0) parts.push(`${totals.migrated} to migrate`);
+
+  const repoWord = total === 1 ? "repo" : "repos";
+  return `Plan: ${total} ${repoWord} (${parts.join(", ")})`;
+}
+
+/**
+ * Returns true if the report has any non-"existed" actions worth displaying.
+ */
+export function hasLifecycleChanges(report: LifecycleReport): boolean {
+  return report.actions.some((a) => a.action !== "existed");
+}
+
+// =============================================================================
+// CLI Formatter
+// =============================================================================
+
+export function formatLifecycleReportCLI(report: LifecycleReport): string[] {
+  if (!hasLifecycleChanges(report)) {
+    return [];
+  }
+
+  const lines: string[] = [];
+
+  for (const action of report.actions) {
+    if (action.action === "existed") continue;
+
+    switch (action.action) {
+      case "created":
+        lines.push(chalk.green(`+ CREATE ${action.repoName}`));
+        break;
+
+      case "forked":
+        lines.push(
+          chalk.green(
+            `+ FORK ${action.upstream ?? "upstream"} -> ${action.repoName}`
+          )
+        );
+        break;
+
+      case "migrated":
+        lines.push(
+          chalk.green(
+            `+ MIGRATE ${action.source ?? "source"} -> ${action.repoName}`
+          )
+        );
+        break;
+    }
+
+    if (action.settings) {
+      if (action.settings.visibility) {
+        lines.push(`    visibility: ${action.settings.visibility}`);
+      }
+      if (action.settings.description) {
+        lines.push(`    description: "${action.settings.description}"`);
+      }
+    }
+  }
+
+  lines.push("");
+
+  // Summary
+  lines.push(formatSummary(report.totals));
+
+  return lines;
+}
+
+// =============================================================================
+// Markdown Formatter
+// =============================================================================
+
+export function formatLifecycleReportMarkdown(
+  report: LifecycleReport,
+  dryRun: boolean
+): string {
+  if (!hasLifecycleChanges(report)) {
+    return "";
+  }
+
+  const lines: string[] = [];
+
+  // Title
+  const titleSuffix = dryRun ? " (Dry Run)" : "";
+  lines.push(`## Lifecycle Summary${titleSuffix}`);
+  lines.push("");
+
+  // Dry-run warning
+  if (dryRun) {
+    lines.push("> [!WARNING]");
+    lines.push("> This was a dry run — no changes were applied");
+    lines.push("");
+  }
+
+  // Diff block
+  const diffLines: string[] = [];
+
+  for (const action of report.actions) {
+    if (action.action === "existed") continue;
+
+    switch (action.action) {
+      case "created":
+        diffLines.push(`+ CREATE ${action.repoName}`);
+        break;
+
+      case "forked":
+        diffLines.push(
+          `+ FORK ${action.upstream ?? "upstream"} -> ${action.repoName}`
+        );
+        break;
+
+      case "migrated":
+        diffLines.push(
+          `+ MIGRATE ${action.source ?? "source"} -> ${action.repoName}`
+        );
+        break;
+    }
+
+    if (action.settings) {
+      if (action.settings.visibility) {
+        diffLines.push(`    visibility: ${action.settings.visibility}`);
+      }
+      if (action.settings.description) {
+        diffLines.push(`    description: "${action.settings.description}"`);
+      }
+    }
+  }
+
+  if (diffLines.length > 0) {
+    lines.push("```diff");
+    lines.push(...diffLines);
+    lines.push("```");
+    lines.push("");
+  }
+
+  // Summary
+  lines.push(`**${formatSummary(report.totals)}**`);
+
+  return lines.join("\n");
+}
+
+// =============================================================================
+// File Writer
+// =============================================================================
+
+export function writeLifecycleReportSummary(
+  report: LifecycleReport,
+  dryRun: boolean
+): void {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const markdown = formatLifecycleReportMarkdown(report, dryRun);
+  if (!markdown) return;
+
+  appendFileSync(summaryPath, "\n" + markdown + "\n");
+}

--- a/test/integration/github-lifecycle.test.ts
+++ b/test/integration/github-lifecycle.test.ts
@@ -205,4 +205,188 @@ repos:
       console.log("  Migrate lifecycle test passed");
     }
   );
+
+  test("create with settings: description is applied", async () => {
+    const repoName = generateRepoName();
+    reposToDelete.push(repoName);
+
+    const configPath = writeConfig(
+      tmpDir,
+      `id: lifecycle-create-settings-test
+settings:
+  repo:
+    description: "Created by xfg lifecycle test"
+files:
+  lifecycle-test.json:
+    content:
+      created: true
+repos:
+  - git: https://github.com/${OWNER}/${repoName}.git
+`
+    );
+
+    console.log(
+      `\nCreating repo ${OWNER}/${repoName} with settings via xfg sync...`
+    );
+    const output = exec(
+      `node dist/cli.js sync --config ${configPath} --merge direct`,
+      { cwd: projectRoot }
+    );
+    console.log(output);
+
+    // Verify repo was created
+    assert.ok(
+      repoExists(OWNER, repoName),
+      `Repo ${repoName} should exist after sync`
+    );
+
+    // Verify description was applied
+    const description = exec(
+      `gh api repos/${OWNER}/${repoName} --jq '.description'`
+    );
+    assert.equal(
+      description,
+      "Created by xfg lifecycle test",
+      "Repo description should match config"
+    );
+
+    console.log("  Create with settings test passed");
+  });
+
+  test("already-existing repo: second sync shows existed", async () => {
+    const repoName = generateRepoName();
+    reposToDelete.push(repoName);
+
+    const configPath = writeConfig(
+      tmpDir,
+      `id: lifecycle-existed-test
+files:
+  lifecycle-test.json:
+    content:
+      round: 1
+repos:
+  - git: https://github.com/${OWNER}/${repoName}.git
+`
+    );
+
+    console.log(`\nFirst sync: creating ${OWNER}/${repoName}...`);
+    const firstOutput = exec(
+      `node dist/cli.js sync --config ${configPath} --merge direct`,
+      { cwd: projectRoot }
+    );
+    console.log(firstOutput);
+
+    // First run should show CREATE
+    assert.ok(
+      firstOutput.includes("CREATE"),
+      "First sync should include CREATE"
+    );
+
+    // Second run - update file content to trigger a change
+    const configPath2 = writeConfig(
+      tmpDir,
+      `id: lifecycle-existed-test
+files:
+  lifecycle-test.json:
+    content:
+      round: 2
+repos:
+  - git: https://github.com/${OWNER}/${repoName}.git
+`
+    );
+
+    console.log(`\nSecond sync: ${OWNER}/${repoName} should already exist...`);
+    const secondOutput = exec(
+      `node dist/cli.js sync --config ${configPath2} --merge direct`,
+      { cwd: projectRoot }
+    );
+    console.log(secondOutput);
+
+    // Second run should NOT show CREATE (repo already exists)
+    assert.ok(
+      !secondOutput.includes("CREATE"),
+      "Second sync should NOT include CREATE (repo already existed)"
+    );
+
+    console.log("  Already-existing repo test passed");
+  });
+
+  test("fork dry-run: shows FORK but doesn't create repo", async () => {
+    const repoName = generateRepoName();
+    // Do NOT add to reposToDelete — repo should not exist
+
+    const configPath = writeConfig(
+      tmpDir,
+      `id: lifecycle-fork-dryrun-test
+files:
+  lifecycle-fork-test.json:
+    content:
+      forked: true
+repos:
+  - git: https://github.com/${OWNER}/${repoName}.git
+    upstream: https://github.com/${FORK_SOURCE}.git
+`
+    );
+
+    console.log(`\nDry-run fork for ${OWNER}/${repoName} via xfg sync...`);
+    const output = exec(
+      `node dist/cli.js sync --config ${configPath} --dry-run`,
+      { cwd: projectRoot }
+    );
+    console.log(output);
+
+    // Verify output shows FORK
+    assert.ok(output.includes("FORK"), "Dry-run output should include FORK");
+
+    // Verify repo was NOT actually created
+    assert.ok(
+      !repoExists(OWNER, repoName),
+      `Repo ${repoName} should NOT exist after dry-run`
+    );
+
+    console.log("  Fork dry-run test passed");
+  });
+
+  test(
+    "migrate dry-run: shows MIGRATE but doesn't create repo",
+    { skip: !HAS_ADO_CREDS },
+    async () => {
+      const repoName = generateRepoName();
+      // Do NOT add to reposToDelete — repo should not exist
+
+      const configPath = writeConfig(
+        tmpDir,
+        `id: lifecycle-migrate-dryrun-test
+files:
+  lifecycle-migrate-test.json:
+    content:
+      migrated: true
+repos:
+  - git: https://github.com/${OWNER}/${repoName}.git
+    source: ${ADO_MIGRATE_SOURCE}
+`
+      );
+
+      console.log(`\nDry-run migrate for ${OWNER}/${repoName} via xfg sync...`);
+      const output = exec(
+        `node dist/cli.js sync --config ${configPath} --dry-run`,
+        { cwd: projectRoot }
+      );
+      console.log(output);
+
+      // Verify output shows MIGRATE
+      assert.ok(
+        output.includes("MIGRATE"),
+        "Dry-run output should include MIGRATE"
+      );
+
+      // Verify repo was NOT actually created
+      assert.ok(
+        !repoExists(OWNER, repoName),
+        `Repo ${repoName} should NOT exist after dry-run`
+      );
+
+      console.log("  Migrate dry-run test passed");
+    }
+  );
 });

--- a/test/unit/lifecycle-report.test.ts
+++ b/test/unit/lifecycle-report.test.ts
@@ -1,0 +1,557 @@
+// test/unit/lifecycle-report.test.ts
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  buildLifecycleReport,
+  formatLifecycleReportCLI,
+  formatLifecycleReportMarkdown,
+  writeLifecycleReportSummary,
+  hasLifecycleChanges,
+  type LifecycleReport,
+  type LifecycleReportInput,
+} from "../../src/output/lifecycle-report.js";
+
+describe("buildLifecycleReport", () => {
+  test("correctly tallies created actions", () => {
+    const inputs: LifecycleReportInput[] = [
+      { repoName: "org/repo1", action: "created" },
+      { repoName: "org/repo2", action: "created" },
+    ];
+
+    const report = buildLifecycleReport(inputs);
+
+    assert.equal(report.totals.created, 2);
+    assert.equal(report.totals.forked, 0);
+    assert.equal(report.totals.migrated, 0);
+    assert.equal(report.totals.existed, 0);
+    assert.equal(report.actions.length, 2);
+  });
+
+  test("correctly tallies mixed actions", () => {
+    const inputs: LifecycleReportInput[] = [
+      { repoName: "org/repo1", action: "created" },
+      {
+        repoName: "org/repo2",
+        action: "forked",
+        upstream: "upstream/repo",
+      },
+      {
+        repoName: "org/repo3",
+        action: "migrated",
+        source: "https://dev.azure.com/org/proj/_git/repo",
+      },
+      { repoName: "org/repo4", action: "existed" },
+      { repoName: "org/repo5", action: "existed" },
+    ];
+
+    const report = buildLifecycleReport(inputs);
+
+    assert.equal(report.totals.created, 1);
+    assert.equal(report.totals.forked, 1);
+    assert.equal(report.totals.migrated, 1);
+    assert.equal(report.totals.existed, 2);
+    assert.equal(report.actions.length, 5);
+  });
+
+  test("preserves upstream and source fields", () => {
+    const inputs: LifecycleReportInput[] = [
+      {
+        repoName: "org/my-fork",
+        action: "forked",
+        upstream: "octocat/Spoon-Knife",
+      },
+      {
+        repoName: "org/migrated",
+        action: "migrated",
+        source: "https://dev.azure.com/org/proj/_git/repo",
+      },
+    ];
+
+    const report = buildLifecycleReport(inputs);
+
+    assert.equal(report.actions[0].upstream, "octocat/Spoon-Knife");
+    assert.equal(
+      report.actions[1].source,
+      "https://dev.azure.com/org/proj/_git/repo"
+    );
+  });
+
+  test("preserves settings fields", () => {
+    const inputs: LifecycleReportInput[] = [
+      {
+        repoName: "org/repo",
+        action: "created",
+        settings: { visibility: "private", description: "My repo" },
+      },
+    ];
+
+    const report = buildLifecycleReport(inputs);
+
+    assert.deepEqual(report.actions[0].settings, {
+      visibility: "private",
+      description: "My repo",
+    });
+  });
+
+  test("handles empty input", () => {
+    const report = buildLifecycleReport([]);
+
+    assert.equal(report.actions.length, 0);
+    assert.equal(report.totals.created, 0);
+    assert.equal(report.totals.forked, 0);
+    assert.equal(report.totals.migrated, 0);
+    assert.equal(report.totals.existed, 0);
+  });
+});
+
+describe("hasLifecycleChanges", () => {
+  test("returns false when all actions are existed", () => {
+    const report: LifecycleReport = {
+      actions: [
+        { repoName: "org/repo1", action: "existed" },
+        { repoName: "org/repo2", action: "existed" },
+      ],
+      totals: { created: 0, forked: 0, migrated: 0, existed: 2 },
+    };
+
+    assert.equal(hasLifecycleChanges(report), false);
+  });
+
+  test("returns true when there is a created action", () => {
+    const report: LifecycleReport = {
+      actions: [
+        { repoName: "org/repo1", action: "existed" },
+        { repoName: "org/repo2", action: "created" },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 1 },
+    };
+
+    assert.equal(hasLifecycleChanges(report), true);
+  });
+
+  test("returns false for empty report", () => {
+    const report: LifecycleReport = {
+      actions: [],
+      totals: { created: 0, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    assert.equal(hasLifecycleChanges(report), false);
+  });
+});
+
+describe("formatLifecycleReportCLI", () => {
+  test("returns empty array when all actions are existed", () => {
+    const report: LifecycleReport = {
+      actions: [
+        { repoName: "org/repo1", action: "existed" },
+        { repoName: "org/repo2", action: "existed" },
+      ],
+      totals: { created: 0, forked: 0, migrated: 0, existed: 2 },
+    };
+
+    const lines = formatLifecycleReportCLI(report);
+
+    assert.equal(lines.length, 0);
+  });
+
+  test("renders created action with green color", () => {
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/new-repo", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const lines = formatLifecycleReportCLI(report);
+    const output = lines.join("\n");
+
+    assert.ok(output.includes("CREATE"), "should include CREATE label");
+    assert.ok(output.includes("org/new-repo"), "should include repo name");
+    assert.ok(output.includes("Plan:"), "should include summary");
+    assert.ok(output.includes("1 repo"), "should include repo count");
+    assert.ok(output.includes("1 to create"), "should include create count");
+  });
+
+  test("renders forked action with upstream", () => {
+    const report: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/my-fork",
+          action: "forked",
+          upstream: "octocat/Spoon-Knife",
+        },
+      ],
+      totals: { created: 0, forked: 1, migrated: 0, existed: 0 },
+    };
+
+    const lines = formatLifecycleReportCLI(report);
+    const output = lines.join("\n");
+
+    assert.ok(output.includes("FORK"), "should include FORK label");
+    assert.ok(
+      output.includes("octocat/Spoon-Knife"),
+      "should include upstream"
+    );
+    assert.ok(output.includes("org/my-fork"), "should include target repo");
+    assert.ok(output.includes("->"), "should include arrow");
+  });
+
+  test("renders migrated action with source", () => {
+    const report: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/migrated-repo",
+          action: "migrated",
+          source: "https://dev.azure.com/org/proj/_git/repo",
+        },
+      ],
+      totals: { created: 0, forked: 0, migrated: 1, existed: 0 },
+    };
+
+    const lines = formatLifecycleReportCLI(report);
+    const output = lines.join("\n");
+
+    assert.ok(output.includes("MIGRATE"), "should include MIGRATE label");
+    assert.ok(
+      output.includes("https://dev.azure.com/org/proj/_git/repo"),
+      "should include source"
+    );
+    assert.ok(
+      output.includes("org/migrated-repo"),
+      "should include target repo"
+    );
+  });
+
+  test("skips existed actions in output", () => {
+    const report: LifecycleReport = {
+      actions: [
+        { repoName: "org/new-repo", action: "created" },
+        { repoName: "org/existing-repo", action: "existed" },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 1 },
+    };
+
+    const lines = formatLifecycleReportCLI(report);
+    const output = lines.join("\n");
+
+    assert.ok(
+      !output.includes("org/existing-repo"),
+      "should not include existed repo"
+    );
+    assert.ok(!output.includes("existed"), "should not include existed marker");
+    assert.ok(output.includes("org/new-repo"), "should include created repo");
+  });
+
+  test("renders settings details for non-existed actions", () => {
+    const report: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/new-repo",
+          action: "created",
+          settings: { visibility: "private", description: "My new repo" },
+        },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const lines = formatLifecycleReportCLI(report);
+    const output = lines.join("\n");
+
+    assert.ok(
+      output.includes("visibility: private"),
+      "should include visibility"
+    );
+    assert.ok(
+      output.includes('description: "My new repo"'),
+      "should include description"
+    );
+  });
+
+  test("renders plural repos in summary (only counts changes)", () => {
+    const report: LifecycleReport = {
+      actions: [
+        { repoName: "org/repo1", action: "created" },
+        { repoName: "org/repo2", action: "created" },
+        { repoName: "org/repo3", action: "existed" },
+      ],
+      totals: { created: 2, forked: 0, migrated: 0, existed: 1 },
+    };
+
+    const lines = formatLifecycleReportCLI(report);
+    const output = lines.join("\n");
+
+    assert.ok(output.includes("2 repos"), "should count only changes");
+    assert.ok(output.includes("2 to create"), "should show create count");
+    assert.ok(!output.includes("existing"), "should not show existing count");
+  });
+});
+
+describe("formatLifecycleReportMarkdown", () => {
+  test("returns empty string when all actions are existed", () => {
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/repo1", action: "existed" }],
+      totals: { created: 0, forked: 0, migrated: 0, existed: 1 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, false);
+
+    assert.equal(markdown, "");
+  });
+
+  test("includes dry run warning when dryRun=true", () => {
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/repo1", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, true);
+
+    assert.ok(
+      markdown.includes("(Dry Run)"),
+      "should include dry run in title"
+    );
+    assert.ok(
+      markdown.includes("[!WARNING]"),
+      "should include warning callout"
+    );
+    assert.ok(
+      markdown.includes("no changes were applied"),
+      "should explain dry run"
+    );
+  });
+
+  test("no dry run warning when dryRun=false", () => {
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/repo1", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, false);
+
+    assert.ok(!markdown.includes("[!WARNING]"), "should not include warning");
+    assert.ok(!markdown.includes("Dry Run"), "should not mention dry run");
+  });
+
+  test("wraps output in diff code block", () => {
+    const report: LifecycleReport = {
+      actions: [
+        { repoName: "org/new-repo", action: "created" },
+        {
+          repoName: "org/my-fork",
+          action: "forked",
+          upstream: "octocat/Spoon-Knife",
+        },
+      ],
+      totals: { created: 1, forked: 1, migrated: 0, existed: 0 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, false);
+
+    assert.ok(markdown.includes("```diff"), "should have diff code block");
+    assert.ok(
+      markdown.includes("+ CREATE org/new-repo"),
+      "should include created repo"
+    );
+    assert.ok(
+      markdown.includes("+ FORK octocat/Spoon-Knife -> org/my-fork"),
+      "should include forked repo"
+    );
+  });
+
+  test("includes title as h2", () => {
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/repo1", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, false);
+
+    assert.ok(
+      markdown.includes("## Lifecycle Summary"),
+      "should include h2 title"
+    );
+  });
+
+  test("includes plan summary as bold text", () => {
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/repo1", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, false);
+
+    assert.ok(markdown.includes("**Plan:"), "should have bold plan summary");
+    assert.ok(markdown.includes("1 repo"), "should include count");
+    assert.ok(markdown.includes("1 to create"), "should include breakdown");
+  });
+
+  test("renders migrate action with source", () => {
+    const report: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/migrated",
+          action: "migrated",
+          source: "https://dev.azure.com/org/proj/_git/repo",
+        },
+      ],
+      totals: { created: 0, forked: 0, migrated: 1, existed: 0 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, false);
+
+    assert.ok(
+      markdown.includes(
+        "+ MIGRATE https://dev.azure.com/org/proj/_git/repo -> org/migrated"
+      ),
+      "should include migrate line with source and target"
+    );
+  });
+
+  test("skips existed actions in diff block", () => {
+    const report: LifecycleReport = {
+      actions: [
+        { repoName: "org/new-repo", action: "created" },
+        { repoName: "org/existing", action: "existed" },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 1 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, false);
+
+    assert.ok(
+      !markdown.includes("org/existing"),
+      "should not include existed entry"
+    );
+    assert.ok(
+      markdown.includes("+ CREATE org/new-repo"),
+      "should include created entry"
+    );
+  });
+
+  test("includes settings details in diff block", () => {
+    const report: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/new-repo",
+          action: "created",
+          settings: { visibility: "private", description: "Test repo" },
+        },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, false);
+
+    assert.ok(
+      markdown.includes("    visibility: private"),
+      "should include visibility"
+    );
+    assert.ok(
+      markdown.includes('    description: "Test repo"'),
+      "should include description"
+    );
+  });
+
+  test("renders comprehensive mixed scenario", () => {
+    const report: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/new-repo",
+          action: "created",
+          settings: { visibility: "private" },
+        },
+        {
+          repoName: "org/my-fork",
+          action: "forked",
+          upstream: "octocat/Spoon-Knife",
+        },
+        { repoName: "org/existing", action: "existed" },
+        {
+          repoName: "org/migrated",
+          action: "migrated",
+          source: "https://dev.azure.com/org/proj/_git/repo",
+        },
+      ],
+      totals: { created: 1, forked: 1, migrated: 1, existed: 1 },
+    };
+
+    const markdown = formatLifecycleReportMarkdown(report, true);
+
+    assert.ok(markdown.includes("## Lifecycle Summary (Dry Run)"));
+    assert.ok(markdown.includes("[!WARNING]"));
+    assert.ok(markdown.includes("```diff"));
+    assert.ok(markdown.includes("+ CREATE org/new-repo"));
+    assert.ok(markdown.includes("    visibility: private"));
+    assert.ok(markdown.includes("+ FORK octocat/Spoon-Knife -> org/my-fork"));
+    assert.ok(
+      !markdown.includes("org/existing"),
+      "should not include existed entry"
+    );
+    assert.ok(
+      markdown.includes(
+        "+ MIGRATE https://dev.azure.com/org/proj/_git/repo -> org/migrated"
+      )
+    );
+    assert.ok(markdown.includes("**Plan: 3 repos"));
+  });
+});
+
+describe("writeLifecycleReportSummary", () => {
+  let tempFile: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tempFile = join(tmpdir(), `lifecycle-report-test-${Date.now()}.md`);
+    originalEnv = process.env.GITHUB_STEP_SUMMARY;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.GITHUB_STEP_SUMMARY;
+    } else {
+      process.env.GITHUB_STEP_SUMMARY = originalEnv;
+    }
+    if (existsSync(tempFile)) {
+      unlinkSync(tempFile);
+    }
+  });
+
+  test("writes markdown to GITHUB_STEP_SUMMARY path", () => {
+    process.env.GITHUB_STEP_SUMMARY = tempFile;
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/repo", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    writeLifecycleReportSummary(report, false);
+
+    assert.ok(existsSync(tempFile));
+    const content = readFileSync(tempFile, "utf-8");
+    assert.ok(content.includes("Lifecycle Summary"));
+  });
+
+  test("no-ops when env var not set", () => {
+    delete process.env.GITHUB_STEP_SUMMARY;
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/repo", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    writeLifecycleReportSummary(report, false);
+
+    assert.ok(!existsSync(tempFile));
+  });
+
+  test("no-ops when all actions are existed (no changes)", () => {
+    process.env.GITHUB_STEP_SUMMARY = tempFile;
+    const report: LifecycleReport = {
+      actions: [{ repoName: "org/repo", action: "existed" }],
+      totals: { created: 0, forked: 0, migrated: 0, existed: 1 },
+    };
+
+    writeLifecycleReportSummary(report, false);
+
+    assert.ok(!existsSync(tempFile), "should not create file when all existed");
+  });
+});


### PR DESCRIPTION
## Summary
- Add terraform-style lifecycle report (create/fork/migrate) to CI job summaries via `GITHUB_STEP_SUMMARY`, displayed before the sync report
- Only shows changes — repos that already exist are omitted from output
- Add 4 new integration tests in both PAT and App test files: create with settings, already-existing repo, fork dry-run, migrate dry-run

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 1899 pass, 0 fail
- [x] `./lint.sh` — clean
- [ ] CI integration tests on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)