### PR TITLE
fix: enable diff syntax colors in GITHUB_STEP_SUMMARY reports

### DIFF
--- a/src/output/sync-report.ts
+++ b/src/output/sync-report.ts
@@ -100,20 +100,20 @@ export function formatSyncReportMarkdown(
       continue;
     }
 
-    diffLines.push(`~ ${repo.repoName}`);
+    diffLines.push(`@@ ${repo.repoName} @@`);
 
     for (const file of repo.files) {
       if (file.action === "create") {
-        diffLines.push(`    + ${file.path}`);
+        diffLines.push(`+ ${file.path}`);
       } else if (file.action === "update") {
-        diffLines.push(`    ~ ${file.path}`);
+        diffLines.push(`! ${file.path}`);
       } else if (file.action === "delete") {
-        diffLines.push(`    - ${file.path}`);
+        diffLines.push(`- ${file.path}`);
       }
     }
 
     if (repo.error) {
-      diffLines.push(`    ! Error: ${repo.error}`);
+      diffLines.push(`- Error: ${repo.error}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Move `+`/`-`/`!` prefixes to column 0 in sync and settings report markdown diff blocks so GitHub's syntax highlighting applies
- `+` lines render green (creates/adds), `-` lines render red (deletes), `!` lines render orange (updates/changes)
- Use `@@ repo-name @@` for section headers (renders blue)
- Previously all diff block content was uncolored because prefixes were indented

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 1899 pass, 0 fail
- [x] `./lint.sh` — clean
- [ ] Visual verification on next CI run with settings/sync changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)