### PR TITLE
fix: revert broken HTML summary, restore diff code blocks

### DIFF
--- a/src/output/lifecycle-report.ts
+++ b/src/output/lifecycle-report.ts
@@ -2,13 +2,6 @@
 import { appendFileSync } from "node:fs";
 import chalk from "chalk";
 
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
 export interface LifecycleReport {
   actions: LifecycleAction[];
   totals: {
@@ -173,7 +166,7 @@ export function formatLifecycleReportMarkdown(
     lines.push("");
   }
 
-  // Colored diff output using HTML <pre> with inline styles
+  // Diff block
   const diffLines: string[] = [];
 
   for (const action of report.actions) {
@@ -181,42 +174,36 @@ export function formatLifecycleReportMarkdown(
 
     switch (action.action) {
       case "created":
-        diffLines.push(
-          `<span style="color:#3fb950">+ CREATE ${escapeHtml(action.repoName)}</span>`
-        );
+        diffLines.push(`+ CREATE ${action.repoName}`);
         break;
 
       case "forked":
         diffLines.push(
-          `<span style="color:#3fb950">+ FORK ${escapeHtml(action.upstream ?? "upstream")} -&gt; ${escapeHtml(action.repoName)}</span>`
+          `+ FORK ${action.upstream ?? "upstream"} -> ${action.repoName}`
         );
         break;
 
       case "migrated":
         diffLines.push(
-          `<span style="color:#3fb950">+ MIGRATE ${escapeHtml(action.source ?? "source")} -&gt; ${escapeHtml(action.repoName)}</span>`
+          `+ MIGRATE ${action.source ?? "source"} -> ${action.repoName}`
         );
         break;
     }
 
     if (action.settings) {
       if (action.settings.visibility) {
-        diffLines.push(
-          `<span style="color:#3fb950">    visibility: ${escapeHtml(action.settings.visibility)}</span>`
-        );
+        diffLines.push(`    visibility: ${action.settings.visibility}`);
       }
       if (action.settings.description) {
-        diffLines.push(
-          `<span style="color:#3fb950">    description: "${escapeHtml(action.settings.description)}"</span>`
-        );
+        diffLines.push(`    description: "${action.settings.description}"`);
       }
     }
   }
 
   if (diffLines.length > 0) {
-    lines.push("<pre>");
+    lines.push("```diff");
     lines.push(...diffLines);
-    lines.push("</pre>");
+    lines.push("```");
     lines.push("");
   }
 

--- a/src/output/sync-report.ts
+++ b/src/output/sync-report.ts
@@ -2,13 +2,6 @@
 import { appendFileSync } from "node:fs";
 import chalk from "chalk";
 
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
 export interface SyncReport {
   repos: RepoFileChanges[];
   totals: {
@@ -99,8 +92,7 @@ export function formatSyncReportMarkdown(
     lines.push("");
   }
 
-  // Colored diff output using HTML <pre> with inline styles
-  // Colors: green (#3fb950) for creates, yellow (#d29922) for changes, red (#f85149) for deletes
+  // Diff block
   const diffLines: string[] = [];
 
   for (const repo of report.repos) {
@@ -108,37 +100,27 @@ export function formatSyncReportMarkdown(
       continue;
     }
 
-    diffLines.push(
-      `<span style="color:#d29922">~ ${escapeHtml(repo.repoName)}</span>`
-    );
+    diffLines.push(`@@ ${repo.repoName} @@`);
 
     for (const file of repo.files) {
       if (file.action === "create") {
-        diffLines.push(
-          `<span style="color:#3fb950">    + ${escapeHtml(file.path)}</span>`
-        );
+        diffLines.push(`+ ${file.path}`);
       } else if (file.action === "update") {
-        diffLines.push(
-          `<span style="color:#d29922">    ~ ${escapeHtml(file.path)}</span>`
-        );
+        diffLines.push(`! ${file.path}`);
       } else if (file.action === "delete") {
-        diffLines.push(
-          `<span style="color:#f85149">    - ${escapeHtml(file.path)}</span>`
-        );
+        diffLines.push(`- ${file.path}`);
       }
     }
 
     if (repo.error) {
-      diffLines.push(
-        `<span style="color:#f85149">    ! Error: ${escapeHtml(repo.error)}</span>`
-      );
+      diffLines.push(`- Error: ${repo.error}`);
     }
   }
 
   if (diffLines.length > 0) {
-    lines.push("<pre>");
+    lines.push("```diff");
     lines.push(...diffLines);
-    lines.push("</pre>");
+    lines.push("```");
     lines.push("");
   }
 

--- a/test/unit/lifecycle-report.test.ts
+++ b/test/unit/lifecycle-report.test.ts
@@ -333,7 +333,7 @@ describe("formatLifecycleReportMarkdown", () => {
     assert.ok(!markdown.includes("Dry Run"), "should not mention dry run");
   });
 
-  test("wraps output in HTML pre block with colored spans", () => {
+  test("wraps output in diff code block", () => {
     const report: LifecycleReport = {
       actions: [
         { repoName: "org/new-repo", action: "created" },
@@ -348,14 +348,14 @@ describe("formatLifecycleReportMarkdown", () => {
 
     const markdown = formatLifecycleReportMarkdown(report, false);
 
-    assert.ok(markdown.includes("<pre>"), "should have HTML pre block");
+    assert.ok(markdown.includes("```diff"), "should have diff code block");
     assert.ok(
       markdown.includes("+ CREATE org/new-repo"),
       "should include created repo"
     );
     assert.ok(
-      markdown.includes("+ FORK octocat/Spoon-Knife -&gt; org/my-fork"),
-      "should include forked repo with HTML entity arrow"
+      markdown.includes("+ FORK octocat/Spoon-Knife -> org/my-fork"),
+      "should include forked repo"
     );
   });
 
@@ -402,9 +402,9 @@ describe("formatLifecycleReportMarkdown", () => {
 
     assert.ok(
       markdown.includes(
-        "+ MIGRATE https://dev.azure.com/org/proj/_git/repo -&gt; org/migrated"
+        "+ MIGRATE https://dev.azure.com/org/proj/_git/repo -> org/migrated"
       ),
-      "should include migrate line with source and target (HTML entity arrow)"
+      "should include migrate line with source and target"
     );
   });
 
@@ -480,19 +480,17 @@ describe("formatLifecycleReportMarkdown", () => {
 
     assert.ok(markdown.includes("## Lifecycle Summary (Dry Run)"));
     assert.ok(markdown.includes("[!WARNING]"));
-    assert.ok(markdown.includes("<pre>"));
+    assert.ok(markdown.includes("```diff"));
     assert.ok(markdown.includes("+ CREATE org/new-repo"));
     assert.ok(markdown.includes("    visibility: private"));
-    assert.ok(
-      markdown.includes("+ FORK octocat/Spoon-Knife -&gt; org/my-fork")
-    );
+    assert.ok(markdown.includes("+ FORK octocat/Spoon-Knife -> org/my-fork"));
     assert.ok(
       !markdown.includes("org/existing"),
       "should not include existed entry"
     );
     assert.ok(
       markdown.includes(
-        "+ MIGRATE https://dev.azure.com/org/proj/_git/repo -&gt; org/migrated"
+        "+ MIGRATE https://dev.azure.com/org/proj/_git/repo -> org/migrated"
       )
     );
     assert.ok(markdown.includes("**Plan: 3 repos"));

--- a/test/unit/settings-report-formatter.test.ts
+++ b/test/unit/settings-report-formatter.test.ts
@@ -499,7 +499,7 @@ describe("formatSettingsReportMarkdown", () => {
     );
   });
 
-  test("wraps output in HTML pre block with colored spans", () => {
+  test("wraps output in diff code block", () => {
     const report: SettingsReport = {
       repos: [
         {
@@ -523,7 +523,7 @@ describe("formatSettingsReportMarkdown", () => {
 
     const markdown = formatSettingsReportMarkdown(report, false);
 
-    assert.ok(markdown.includes("<pre>"), "should have HTML pre block");
+    assert.ok(markdown.includes("```diff"), "should have diff code block");
     assert.ok(markdown.includes("org/repo"), "should include repo name");
     assert.ok(
       markdown.includes("deleteBranchOnMerge"),

--- a/test/unit/sync-report-formatter.test.ts
+++ b/test/unit/sync-report-formatter.test.ts
@@ -195,7 +195,7 @@ describe("formatSyncReportMarkdown", () => {
     );
   });
 
-  test("wraps output in HTML pre block with colored spans", () => {
+  test("wraps output in diff code block", () => {
     const report: SyncReport = {
       repos: [
         {
@@ -213,7 +213,7 @@ describe("formatSyncReportMarkdown", () => {
 
     const markdown = formatSyncReportMarkdown(report, false);
 
-    assert.ok(markdown.includes("<pre>"), "should have HTML pre block");
+    assert.ok(markdown.includes("```diff"), "should have diff code block");
     assert.ok(markdown.includes("org/repo"), "should include repo name");
     assert.ok(markdown.includes("ci.yml"), "should include file");
   });


### PR DESCRIPTION
## Summary
- Reverts #488 which used `<pre>` with `<span style="color:...">` for GITHUB_STEP_SUMMARY
- GitHub strips inline `style` attributes, so colors didn't render and indentation broke
- Restores ```diff code blocks from #487 which provide green/red/blue coloring

## Test plan
- [x] All 1899 unit tests pass
- [x] Build passes
- [ ] CI checks pass
- [ ] Verify diff colors render in step summary on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)