### PR TITLE
feat: unified GITHUB_STEP_SUMMARY for lifecycle + sync

### DIFF
--- a/src/cli/sync-command.ts
+++ b/src/cli/sync-command.ts
@@ -24,17 +24,14 @@ import { generateWorkspaceName } from "../shared/workspace-utils.js";
 import { RepoInfo } from "../shared/repo-detector.js";
 import { ProcessorFactory, defaultProcessorFactory } from "./types.js";
 import { buildSyncReport } from "./sync-report-builder.js";
-import {
-  formatSyncReportCLI,
-  writeSyncReportSummary,
-} from "../output/sync-report.js";
+import { formatSyncReportCLI } from "../output/sync-report.js";
 import {
   buildLifecycleReport,
   formatLifecycleReportCLI,
-  writeLifecycleReportSummary,
   hasLifecycleChanges,
   type LifecycleReportInput,
 } from "../output/lifecycle-report.js";
+import { writeUnifiedSummary } from "../output/unified-summary.js";
 import type { ProcessorResult } from "../sync/index.js";
 import {
   RepoLifecycleManager,
@@ -343,7 +340,6 @@ export async function runSync(
       console.log(line);
     }
   }
-  writeLifecycleReportSummary(lifecycleReport, options.dryRun ?? false);
 
   // Build and display sync report
   const report = buildSyncReport(reportResults);
@@ -351,7 +347,9 @@ export async function runSync(
   for (const line of formatSyncReportCLI(report)) {
     console.log(line);
   }
-  writeSyncReportSummary(report, options.dryRun ?? false);
+
+  // Write unified summary to GITHUB_STEP_SUMMARY
+  writeUnifiedSummary(lifecycleReport, report, options.dryRun ?? false);
 
   // Exit with error if any failures
   const hasErrors = reportResults.some((r) => r.error);

--- a/src/output/unified-summary.ts
+++ b/src/output/unified-summary.ts
@@ -1,0 +1,194 @@
+// src/output/unified-summary.ts
+import { appendFileSync } from "node:fs";
+import type { LifecycleReport } from "./lifecycle-report.js";
+import { hasLifecycleChanges } from "./lifecycle-report.js";
+import type { SyncReport } from "./sync-report.js";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function formatCombinedSummary(
+  lifecycleTotals: LifecycleReport["totals"],
+  syncTotals: SyncReport["totals"]
+): string {
+  const parts: string[] = [];
+
+  // Lifecycle totals
+  const repoTotal =
+    lifecycleTotals.created + lifecycleTotals.forked + lifecycleTotals.migrated;
+  if (repoTotal > 0) {
+    const repoParts: string[] = [];
+    if (lifecycleTotals.created > 0)
+      repoParts.push(`${lifecycleTotals.created} to create`);
+    if (lifecycleTotals.forked > 0)
+      repoParts.push(`${lifecycleTotals.forked} to fork`);
+    if (lifecycleTotals.migrated > 0)
+      repoParts.push(`${lifecycleTotals.migrated} to migrate`);
+    const repoWord = repoTotal === 1 ? "repo" : "repos";
+    parts.push(`${repoTotal} ${repoWord} (${repoParts.join(", ")})`);
+  }
+
+  // Sync totals
+  const fileTotal =
+    syncTotals.files.create + syncTotals.files.update + syncTotals.files.delete;
+  if (fileTotal > 0) {
+    const fileParts: string[] = [];
+    if (syncTotals.files.create > 0)
+      fileParts.push(`${syncTotals.files.create} to create`);
+    if (syncTotals.files.update > 0)
+      fileParts.push(`${syncTotals.files.update} to update`);
+    if (syncTotals.files.delete > 0)
+      fileParts.push(`${syncTotals.files.delete} to delete`);
+    const fileWord = fileTotal === 1 ? "file" : "files";
+    parts.push(`${fileTotal} ${fileWord} (${fileParts.join(", ")})`);
+  }
+
+  if (parts.length === 0) {
+    return "No changes";
+  }
+
+  return `Plan: ${parts.join(", ")}`;
+}
+
+// =============================================================================
+// Markdown Formatter
+// =============================================================================
+
+export function formatUnifiedSummaryMarkdown(
+  lifecycle: LifecycleReport,
+  sync: SyncReport,
+  dryRun: boolean
+): string {
+  const hasLifecycle = hasLifecycleChanges(lifecycle);
+  const hasSync = sync.repos.some((r) => r.files.length > 0 || r.error);
+
+  if (!hasLifecycle && !hasSync) {
+    return "";
+  }
+
+  const lines: string[] = [];
+
+  // Title
+  const titleSuffix = dryRun ? " (Dry Run)" : "";
+  lines.push(`## xfg Sync Summary${titleSuffix}`);
+  lines.push("");
+
+  // Dry-run warning
+  if (dryRun) {
+    lines.push("> [!WARNING]");
+    lines.push("> This was a dry run — no changes were applied");
+    lines.push("");
+  }
+
+  // Build lookup maps by repoName
+  const lifecycleByRepo = new Map(
+    lifecycle.actions.map((a) => [a.repoName, a])
+  );
+  const syncByRepo = new Map(sync.repos.map((r) => [r.repoName, r]));
+
+  // Collect all repo names in order (lifecycle first, then sync-only)
+  const allRepos: string[] = [];
+  for (const action of lifecycle.actions) {
+    if (!allRepos.includes(action.repoName)) {
+      allRepos.push(action.repoName);
+    }
+  }
+  for (const repo of sync.repos) {
+    if (!allRepos.includes(repo.repoName)) {
+      allRepos.push(repo.repoName);
+    }
+  }
+
+  // Diff block
+  const diffLines: string[] = [];
+
+  for (const repoName of allRepos) {
+    const lcAction = lifecycleByRepo.get(repoName);
+    const syncRepo = syncByRepo.get(repoName);
+
+    const hasLcChange = lcAction && lcAction.action !== "existed";
+    const hasSyncChanges =
+      syncRepo && (syncRepo.files.length > 0 || syncRepo.error);
+
+    if (!hasLcChange && !hasSyncChanges) continue;
+
+    // Repo header
+    diffLines.push(`@@ ${repoName} @@`);
+
+    // Lifecycle action
+    if (lcAction && lcAction.action !== "existed") {
+      switch (lcAction.action) {
+        case "created":
+          diffLines.push(`+ CREATE`);
+          break;
+        case "forked":
+          diffLines.push(
+            `+ FORK ${lcAction.upstream ?? "upstream"} -> ${repoName}`
+          );
+          break;
+        case "migrated":
+          diffLines.push(
+            `+ MIGRATE ${lcAction.source ?? "source"} -> ${repoName}`
+          );
+          break;
+      }
+
+      if (lcAction.settings) {
+        if (lcAction.settings.visibility) {
+          diffLines.push(`+   visibility: ${lcAction.settings.visibility}`);
+        }
+        if (lcAction.settings.description) {
+          diffLines.push(`+   description: "${lcAction.settings.description}"`);
+        }
+      }
+    }
+
+    // File changes
+    if (syncRepo) {
+      for (const file of syncRepo.files) {
+        if (file.action === "create") {
+          diffLines.push(`+ ${file.path}`);
+        } else if (file.action === "update") {
+          diffLines.push(`! ${file.path}`);
+        } else if (file.action === "delete") {
+          diffLines.push(`- ${file.path}`);
+        }
+      }
+
+      if (syncRepo.error) {
+        diffLines.push(`- Error: ${syncRepo.error}`);
+      }
+    }
+  }
+
+  if (diffLines.length > 0) {
+    lines.push("```diff");
+    lines.push(...diffLines);
+    lines.push("```");
+    lines.push("");
+  }
+
+  // Combined summary
+  lines.push(`**${formatCombinedSummary(lifecycle.totals, sync.totals)}**`);
+
+  return lines.join("\n");
+}
+
+// =============================================================================
+// File Writer
+// =============================================================================
+
+export function writeUnifiedSummary(
+  lifecycle: LifecycleReport,
+  sync: SyncReport,
+  dryRun: boolean
+): void {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const markdown = formatUnifiedSummaryMarkdown(lifecycle, sync, dryRun);
+  if (!markdown) return;
+
+  appendFileSync(summaryPath, "\n" + markdown + "\n");
+}

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -836,9 +836,9 @@ repos:
 
       const summary = readFileSync(summaryPath, "utf-8");
 
-      // Verify summary content - new repo-grouped format
+      // Verify summary content - unified summary format
       assert.ok(
-        summary.includes("## Config Sync Summary"),
+        summary.includes("## xfg Sync Summary"),
         "Should have summary header"
       );
       // The summary uses **Plan: or **No changes**

--- a/test/unit/unified-summary.test.ts
+++ b/test/unit/unified-summary.test.ts
@@ -1,0 +1,368 @@
+// test/unit/unified-summary.test.ts
+import { test, describe, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  formatUnifiedSummaryMarkdown,
+  writeUnifiedSummary,
+} from "../../src/output/unified-summary.js";
+import type { LifecycleReport } from "../../src/output/lifecycle-report.js";
+import type { SyncReport } from "../../src/output/sync-report.js";
+
+function emptyLifecycle(): LifecycleReport {
+  return {
+    actions: [],
+    totals: { created: 0, forked: 0, migrated: 0, existed: 0 },
+  };
+}
+
+function emptySync(): SyncReport {
+  return {
+    repos: [],
+    totals: { files: { create: 0, update: 0, delete: 0 } },
+  };
+}
+
+describe("formatUnifiedSummaryMarkdown", () => {
+  test("returns empty string when no changes at all", () => {
+    const markdown = formatUnifiedSummaryMarkdown(
+      emptyLifecycle(),
+      emptySync(),
+      false
+    );
+    assert.equal(markdown, "");
+  });
+
+  test("returns empty string when all repos existed and no file changes", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [{ repoName: "org/repo", action: "existed" }],
+      totals: { created: 0, forked: 0, migrated: 0, existed: 1 },
+    };
+    const markdown = formatUnifiedSummaryMarkdown(
+      lifecycle,
+      emptySync(),
+      false
+    );
+    assert.equal(markdown, "");
+  });
+
+  test("renders lifecycle-only changes (no file sync)", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/new-repo",
+          action: "created",
+          settings: { visibility: "private" },
+        },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+    const markdown = formatUnifiedSummaryMarkdown(
+      lifecycle,
+      emptySync(),
+      false
+    );
+
+    assert.ok(markdown.includes("## xfg Sync Summary"));
+    assert.ok(markdown.includes("```diff"));
+    assert.ok(markdown.includes("@@ org/new-repo @@"));
+    assert.ok(markdown.includes("+ CREATE"));
+    assert.ok(markdown.includes("+   visibility: private"));
+    assert.ok(markdown.includes("**Plan: 1 repo (1 to create)**"));
+  });
+
+  test("renders sync-only changes (no lifecycle)", () => {
+    const sync: SyncReport = {
+      repos: [
+        {
+          repoName: "org/repo",
+          files: [
+            { path: ".github/ci.yml", action: "create" },
+            { path: "README.md", action: "update" },
+          ],
+        },
+      ],
+      totals: { files: { create: 1, update: 1, delete: 0 } },
+    };
+    const markdown = formatUnifiedSummaryMarkdown(
+      emptyLifecycle(),
+      sync,
+      false
+    );
+
+    assert.ok(markdown.includes("@@ org/repo @@"));
+    assert.ok(markdown.includes("+ .github/ci.yml"));
+    assert.ok(markdown.includes("! README.md"));
+    assert.ok(
+      markdown.includes("**Plan: 2 files (1 to create, 1 to update)**")
+    );
+  });
+
+  test("renders combined lifecycle + sync for same repo", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/new-repo",
+          action: "created",
+          settings: { visibility: "private" },
+        },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+    const sync: SyncReport = {
+      repos: [
+        {
+          repoName: "org/new-repo",
+          files: [{ path: ".github/ci.yml", action: "create" }],
+        },
+      ],
+      totals: { files: { create: 1, update: 0, delete: 0 } },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(lifecycle, sync, false);
+
+    // Should be one section for the repo
+    const headerMatches = markdown.match(/@@ org\/new-repo @@/g);
+    assert.equal(headerMatches?.length, 1, "should have one header per repo");
+    assert.ok(markdown.includes("+ CREATE"));
+    assert.ok(markdown.includes("+   visibility: private"));
+    assert.ok(markdown.includes("+ .github/ci.yml"));
+    assert.ok(
+      markdown.includes("**Plan: 1 repo (1 to create), 1 file (1 to create)**")
+    );
+  });
+
+  test("renders fork with file changes", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/my-fork",
+          action: "forked",
+          upstream: "octocat/Spoon-Knife",
+        },
+      ],
+      totals: { created: 0, forked: 1, migrated: 0, existed: 0 },
+    };
+    const sync: SyncReport = {
+      repos: [
+        {
+          repoName: "org/my-fork",
+          files: [{ path: ".github/ci.yml", action: "create" }],
+        },
+      ],
+      totals: { files: { create: 1, update: 0, delete: 0 } },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(lifecycle, sync, false);
+
+    assert.ok(markdown.includes("@@ org/my-fork @@"));
+    assert.ok(markdown.includes("+ FORK octocat/Spoon-Knife -> org/my-fork"));
+    assert.ok(markdown.includes("+ .github/ci.yml"));
+  });
+
+  test("renders migrate with file changes", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [
+        {
+          repoName: "org/migrated",
+          action: "migrated",
+          source: "https://dev.azure.com/org/proj/_git/repo",
+        },
+      ],
+      totals: { created: 0, forked: 0, migrated: 1, existed: 0 },
+    };
+    const sync: SyncReport = {
+      repos: [
+        {
+          repoName: "org/migrated",
+          files: [{ path: "README.md", action: "update" }],
+        },
+      ],
+      totals: { files: { create: 0, update: 1, delete: 0 } },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(lifecycle, sync, false);
+
+    assert.ok(markdown.includes("+ MIGRATE"));
+    assert.ok(markdown.includes("! README.md"));
+  });
+
+  test("skips existed repos with no file changes", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [
+        { repoName: "org/new-repo", action: "created" },
+        { repoName: "org/existing", action: "existed" },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 1 },
+    };
+    const sync: SyncReport = {
+      repos: [
+        { repoName: "org/new-repo", files: [] },
+        { repoName: "org/existing", files: [] },
+      ],
+      totals: { files: { create: 0, update: 0, delete: 0 } },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(lifecycle, sync, false);
+
+    assert.ok(markdown.includes("org/new-repo"));
+    assert.ok(
+      !markdown.includes("org/existing"),
+      "should not show existed repo with no changes"
+    );
+  });
+
+  test("shows existed repo if it has file changes", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [{ repoName: "org/repo", action: "existed" }],
+      totals: { created: 0, forked: 0, migrated: 0, existed: 1 },
+    };
+    const sync: SyncReport = {
+      repos: [
+        {
+          repoName: "org/repo",
+          files: [{ path: ".github/ci.yml", action: "create" }],
+        },
+      ],
+      totals: { files: { create: 1, update: 0, delete: 0 } },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(lifecycle, sync, false);
+
+    assert.ok(markdown.includes("@@ org/repo @@"));
+    assert.ok(markdown.includes("+ .github/ci.yml"));
+    assert.ok(!markdown.includes("CREATE"), "should not show lifecycle action");
+  });
+
+  test("renders dry run warning", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [{ repoName: "org/repo", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(lifecycle, emptySync(), true);
+
+    assert.ok(markdown.includes("(Dry Run)"));
+    assert.ok(markdown.includes("[!WARNING]"));
+    assert.ok(markdown.includes("no changes were applied"));
+  });
+
+  test("no dry run warning when dryRun=false", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [{ repoName: "org/repo", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(
+      lifecycle,
+      emptySync(),
+      false
+    );
+
+    assert.ok(!markdown.includes("[!WARNING]"));
+    assert.ok(!markdown.includes("Dry Run"));
+  });
+
+  test("renders error from sync report", () => {
+    const sync: SyncReport = {
+      repos: [
+        {
+          repoName: "org/failed-repo",
+          files: [],
+          error: "Connection refused",
+        },
+      ],
+      totals: { files: { create: 0, update: 0, delete: 0 } },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(
+      emptyLifecycle(),
+      sync,
+      false
+    );
+
+    assert.ok(markdown.includes("org/failed-repo"));
+    assert.ok(markdown.includes("Error: Connection refused"));
+  });
+
+  test("renders multiple repos in order", () => {
+    const lifecycle: LifecycleReport = {
+      actions: [
+        { repoName: "org/repo-a", action: "created" },
+        { repoName: "org/repo-b", action: "existed" },
+      ],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 1 },
+    };
+    const sync: SyncReport = {
+      repos: [
+        {
+          repoName: "org/repo-a",
+          files: [{ path: "file-a.txt", action: "create" }],
+        },
+        {
+          repoName: "org/repo-b",
+          files: [{ path: "file-b.txt", action: "update" }],
+        },
+      ],
+      totals: { files: { create: 1, update: 1, delete: 0 } },
+    };
+
+    const markdown = formatUnifiedSummaryMarkdown(lifecycle, sync, false);
+
+    const indexA = markdown.indexOf("org/repo-a");
+    const indexB = markdown.indexOf("org/repo-b");
+    assert.ok(indexA < indexB, "repo-a should appear before repo-b");
+    assert.ok(markdown.includes("+ CREATE"));
+    assert.ok(markdown.includes("+ file-a.txt"));
+    assert.ok(markdown.includes("! file-b.txt"));
+  });
+});
+
+describe("writeUnifiedSummary", () => {
+  let tempFile: string;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    tempFile = join(tmpdir(), `unified-summary-test-${Date.now()}.md`);
+    originalEnv = process.env.GITHUB_STEP_SUMMARY;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.GITHUB_STEP_SUMMARY;
+    } else {
+      process.env.GITHUB_STEP_SUMMARY = originalEnv;
+    }
+    if (existsSync(tempFile)) {
+      unlinkSync(tempFile);
+    }
+  });
+
+  test("writes markdown to GITHUB_STEP_SUMMARY path", () => {
+    process.env.GITHUB_STEP_SUMMARY = tempFile;
+    const lifecycle: LifecycleReport = {
+      actions: [{ repoName: "org/repo", action: "created" }],
+      totals: { created: 1, forked: 0, migrated: 0, existed: 0 },
+    };
+
+    writeUnifiedSummary(lifecycle, emptySync(), false);
+
+    assert.ok(existsSync(tempFile));
+    const content = readFileSync(tempFile, "utf-8");
+    assert.ok(content.includes("xfg Sync Summary"));
+  });
+
+  test("no-ops when env var not set", () => {
+    delete process.env.GITHUB_STEP_SUMMARY;
+    writeUnifiedSummary(emptyLifecycle(), emptySync(), false);
+    assert.ok(!existsSync(tempFile));
+  });
+
+  test("no-ops when no changes", () => {
+    process.env.GITHUB_STEP_SUMMARY = tempFile;
+    writeUnifiedSummary(emptyLifecycle(), emptySync(), false);
+    assert.ok(!existsSync(tempFile));
+  });
+});


### PR DESCRIPTION
## Summary
- Merge lifecycle (create/fork/migrate) and file sync reports into a single diff block grouped by repo
- Each repo shows lifecycle action first, then file changes, under one `@@` header
- Combined summary line: `Plan: 1 repo (1 to create), 2 files (1 to create, 1 to update)`
- 16 new unit tests for unified summary formatter

## Test plan
- [x] All 1915 unit tests pass
- [x] Lint passes
- [ ] CI checks pass
- [ ] Verify unified output renders in step summary on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)