### PR TITLE
Fix ssh-keygen to specify explicit output path

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,7 @@ This repository uses a VS Code devcontainer for a consistent development experie
 5. Generate an SSH key if you don't have one:
 
    ```bash
-   ssh-keygen -t ed25519 -C "you@example.com"
+   ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519
    ```
 
 6. Add your public key to GitHub: copy the output of `cat ~/.ssh/id_ed25519.pub` and add it at [GitHub Settings > SSH and GPG keys](https://github.com/settings/keys).
@@ -54,7 +54,7 @@ This repository uses a VS Code devcontainer for a consistent development experie
 4. All development happens inside WSL. Open a WSL terminal to clone the repo and generate your SSH key:
 
    ```bash
-   ssh-keygen -t ed25519 -C "you@example.com"
+   ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519
    ```
 
 5. Add your public key to GitHub: copy the output of `cat ~/.ssh/id_ed25519.pub` and add it at [GitHub Settings > SSH and GPG keys](https://github.com/settings/keys).
@@ -78,7 +78,7 @@ This repository uses a VS Code devcontainer for a consistent development experie
 3. Generate an SSH key if you don't have one and add it to GitHub:
 
    ```bash
-   ssh-keygen -t ed25519 -C "you@example.com"
+   ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519
    cat ~/.ssh/id_ed25519.pub
    ```
 


### PR DESCRIPTION
## Summary

- Add `-f ~/.ssh/id_ed25519` to all `ssh-keygen` commands to ensure keys are saved in the correct location instead of relying on the interactive prompt default

## Test plan

- [ ] Verify `ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519` creates the key in `~/.ssh/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)