### PR TITLE
fix(test): use merge: direct for delete-orphaned labels test

### DIFF
--- a/test/integration/github-labels.test.ts
+++ b/test/integration/github-labels.test.ts
@@ -297,6 +297,9 @@ settings:
     xfg-test-feature:
       color: a2eeef
       description: "New feature or request"
+prOptions:
+  merge: direct
+  deleteBranch: true
 repos:
   - git: https://github.com/anthony-spruyt/xfg-test-8.git
     files:
@@ -333,6 +336,9 @@ settings:
     xfg-test-bug:
       color: d73a4a
       description: "Something isn't working"
+prOptions:
+  merge: direct
+  deleteBranch: true
 repos:
   - git: https://github.com/anthony-spruyt/xfg-test-8.git
     files:


### PR DESCRIPTION
## Summary
- Fix failing `delete-orphaned` labels integration test by adding `prOptions: merge: direct` to both phase configs
- Without this, the manifest PR isn't merged so phase 2 can't detect orphans

## Test Plan
- [ ] `npm test` - unit tests pass (2121/2121)
- [ ] `npm run test:integration:github-labels` - all 6 scenarios pass on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)