### PR TITLE
fix: fetchBranch rejects non-fast-forward updates on reused PR branches

### DIFF
--- a/src/vcs/authenticated-git-ops.ts
+++ b/src/vcs/authenticated-git-ops.ts
@@ -216,7 +216,7 @@ export class AuthenticatedGitOps implements IAuthenticatedGitOps {
     // Remote URL already has auth from clone
     const safeBranch = escapeShellArg(branchName);
     await this.execWithRetry(
-      `git fetch origin ${safeBranch}:refs/remotes/origin/${safeBranch}`
+      `git fetch origin +${safeBranch}:refs/remotes/origin/${safeBranch}`
     );
   }
 

--- a/src/vcs/graphql-commit-strategy.ts
+++ b/src/vcs/graphql-commit-strategy.ts
@@ -159,7 +159,7 @@ export class GraphQLCommitStrategy implements ICommitStrategy {
           await gitOps.fetchBranch(branchName);
         } else {
           await this.executor.exec(
-            `git fetch origin ${safeBranch}:refs/remotes/origin/${safeBranch}`,
+            `git fetch origin +${safeBranch}:refs/remotes/origin/${safeBranch}`,
             workDir
           );
         }

--- a/test/unit/authenticated-git-ops.test.ts
+++ b/test/unit/authenticated-git-ops.test.ts
@@ -526,6 +526,40 @@ describe("AuthenticatedGitOps", () => {
       assert.ok(commands[0].includes("feature-branch"));
       assert.ok(commands[0].includes("refs/remotes/origin/"));
       assert.ok(!commands[0].includes("insteadOf"), "Should not have -c flag");
+      assert.ok(
+        commands[0].includes("+"),
+        "Should use + prefix in refspec to allow non-fast-forward updates"
+      );
+    });
+
+    it("fetchBranch uses + refspec prefix to allow non-fast-forward updates", async () => {
+      const commands: string[] = [];
+      const mockExecutor = {
+        exec: async (cmd: string) => {
+          commands.push(cmd);
+          return "";
+        },
+      };
+      const gitOps = new GitOps({
+        workDir: "/tmp/test",
+        executor: mockExecutor,
+      });
+      const authOps = new AuthenticatedGitOps(gitOps, {
+        token: "test-token",
+        host: "github.com",
+        owner: "owner",
+        repo: "repo",
+      });
+
+      await authOps.fetchBranch("chore/sync-config");
+
+      // Regression: without +, git fetch rejects non-fast-forward updates
+      // when a PR branch (e.g. chore/sync-config) has been rebased or force-pushed
+      assert.match(
+        commands[0],
+        /\+.*chore\/sync-config.*:refs\/remotes\/origin/,
+        "Refspec must have + prefix to allow non-fast-forward updates"
+      );
     });
 
     it("lsRemote without auth uses plain git command", async () => {


### PR DESCRIPTION
## Summary

- Add `+` prefix to git fetch refspec in `fetchBranch()` and its fallback in `GraphQLCommitStrategy` so non-fast-forward updates are allowed when a PR branch (e.g. `chore/sync-config`) has been rebased or force-pushed between runs
- Add regression test asserting the `+` prefix is present in the refspec

## Test plan

- [x] Existing unit tests pass (`npm test`)
- [x] Lint passes (`./lint.sh`)
- [ ] CI passes
- [ ] Integration tests pass on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)