### PR TITLE
chore: make release CI wait timeout configurable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,11 @@ on:
           - patch
           - minor
           - major
+      ci_timeout:
+        description: "Seconds to wait for CI after version bump"
+        required: false
+        type: number
+        default: 1200
 
 permissions:
   contents: read
@@ -68,7 +73,7 @@ jobs:
           COMMIT_SHA=$(gh api "repos/$REPO/git/ref/heads/main" --jq '.object.sha')
           echo "Waiting for CI on commit $COMMIT_SHA..."
 
-          TIMEOUT=600
+          TIMEOUT=${{ inputs.ci_timeout }}
           ELAPSED=0
           while [ $ELAPSED -lt $TIMEOUT ]; do
             # Get all check runs for this commit


### PR DESCRIPTION
## Summary

- Add `ci_timeout` workflow_dispatch input to release workflow (default 1200s)
- Replaces hard-coded 600s timeout that was too short when integration tests queue slowly

## Test plan

- [ ] CI passes
- [ ] Next release run uses the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)