### PR TITLE
fix: create ephemeral test repos as public

### DIFF
--- a/.github/scripts/create-ephemeral-repo-config.sh
+++ b/.github/scripts/create-ephemeral-repo-config.sh
@@ -21,7 +21,7 @@ if [ "${1:-}" = "--fixture" ]; then
   echo "Generated repo name: ${REPO_NAME}"
 
   # Create the ephemeral repo (action jobs sync TO an existing repo)
-  gh repo create "${OWNER}/${REPO_NAME}" --private --add-readme
+  gh repo create "${OWNER}/${REPO_NAME}" --public --add-readme
 
   # Substitute placeholder in fixture template
   sed "s|OWNER/REPO_PLACEHOLDER|${OWNER}/${REPO_NAME}|g" "${FIXTURE_PATH}" >"${CONFIG_PATH}"

--- a/test/integration/test-helpers.ts
+++ b/test/integration/test-helpers.ts
@@ -260,7 +260,7 @@ export function deleteRepo(
 }
 
 /**
- * Create an ephemeral private repo under the given owner.
+ * Create an ephemeral public repo under the given owner.
  */
 export function createRepo(
   owner: string,
@@ -270,7 +270,7 @@ export function createRepo(
   console.log(`  Creating ephemeral repo ${owner}/${repoName}...`);
   // owner and repoName are controlled test constants (from generateRepoName),
   // not user input — safe to use with exec()
-  const cmd = `gh repo create ${owner}/${repoName} --private --add-readme`;
+  const cmd = `gh repo create ${owner}/${repoName} --public --add-readme`;
   exec(cmd, envOptions);
   console.log(`  Created ${owner}/${repoName}`);
 }


### PR DESCRIPTION
Closes #558

## Summary

- Change `--private` to `--public` in `gh repo create` calls for ephemeral test repos
- Fixes all 9 integration test CI failures on main after ephemeral repo migration
- Old static test repos were public; private repos on free org plan lack rulesets API, privateVulnerabilityReporting, and have different PAT permission behavior

## Test plan

- [x] `npm test` — unit tests pass
- [x] `./lint.sh` — linting passes
- [ ] Integration tests will validate on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)