### PR TITLE
fix: CI failures from ephemeral repo migration

### DIFF
--- a/.github/scripts/create-ephemeral-repo-config.sh
+++ b/.github/scripts/create-ephemeral-repo-config.sh
@@ -51,6 +51,24 @@ ENDCONFIG
   echo "Wrote config to ${CONFIG_PATH}"
 fi
 
+# Wait for fine-grained PAT permissions to propagate to the new repo.
+# When a PAT is scoped to "All repositories", issues:write and pull_requests:write
+# may take seconds to propagate to dynamically created repos.
+echo "Waiting for PAT permissions to propagate to ${OWNER}/${REPO_NAME}..."
+TIMEOUT=30
+ELAPSED=0
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  if gh api "repos/${OWNER}/${REPO_NAME}/labels" --jq '.[0].name' >/dev/null 2>&1; then
+    echo "Repo permissions ready after ${ELAPSED}s"
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+done
+if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+  echo "WARNING: Repo permissions not ready after ${TIMEOUT}s — PAT may lack issues:write scope"
+fi
+
 # Output for GitHub Actions
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "repo_name=${REPO_NAME}" >>"$GITHUB_OUTPUT"

--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -36,7 +36,7 @@ const GITHUB_DEFAULTS = {
   delete_branch_on_merge: false,
 };
 
-const SYNC_BRANCH = "chore/sync-github-app-test";
+const SYNC_BRANCH = "chore/sync-my-config";
 const DIRECT_FILE = "github-app-direct-test.json";
 
 let repoName: string;
@@ -69,8 +69,6 @@ files:
   my.config.json:
     content:
       prop1: main
-prOptions:
-  branch: ${SYNC_BRANCH}
 repos:
   - git: https://github.com/${testRepo}.git
 `
@@ -332,8 +330,6 @@ files:
   my.config.json:
     content:
       prop1: main
-prOptions:
-  branch: ${SYNC_BRANCH}
 repos:
   - git: https://github.com/${signedTestRepo}.git
 `

--- a/test/integration/test-helpers.ts
+++ b/test/integration/test-helpers.ts
@@ -261,6 +261,7 @@ export function deleteRepo(
 
 /**
  * Create an ephemeral public repo under the given owner.
+ * Waits for PAT permissions to propagate to the new repo before returning.
  */
 export function createRepo(
   owner: string,
@@ -273,6 +274,41 @@ export function createRepo(
   const cmd = `gh repo create ${owner}/${repoName} --public --add-readme`;
   exec(cmd, envOptions);
   console.log(`  Created ${owner}/${repoName}`);
+  waitForRepoReady(`${owner}/${repoName}`, envOptions);
+}
+
+/**
+ * Polls until fine-grained PAT permissions have propagated to a newly created repo.
+ * When a fine-grained PAT is scoped to "All repositories", permissions like
+ * issues:write and pull_requests:write may take seconds to propagate to
+ * dynamically created repos, even though administration and contents scopes
+ * are available immediately.
+ */
+function waitForRepoReady(
+  repo: string,
+  envOptions?: { env: Record<string, string | undefined> },
+  timeoutMs = 30000,
+  pollMs = 2000
+): void {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      // The labels endpoint requires issues:write — if this succeeds,
+      // all permission scopes have propagated to the new repo
+      exec(`gh api repos/${repo}/labels --jq '.[0].name'`, envOptions);
+      console.log(`  Repo permissions ready after ${Date.now() - startTime}ms`);
+      return;
+    } catch {
+      // Permission not yet propagated, continue polling
+    }
+    // Synchronous sleep — Atomics.wait on a dummy SharedArrayBuffer
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, pollMs);
+  }
+
+  throw new Error(
+    `Repo ${repo} permissions not ready after ${timeoutMs}ms — check PAT repository scope`
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #561 follow-up

## Summary

- Fix branch name mismatch in `github-app.test.ts`: `SYNC_BRANCH` was `"chore/sync-github-app-test"` but xfg generates `"chore/sync-my-config"` from filename `my.config.json`. Removed silently-ignored `prOptions.branch` from inline YAML configs (see #563).
- Add `waitForRepoReady` poll in `createRepo()` (test-helpers.ts) and `create-ephemeral-repo-config.sh` — fine-grained PAT permissions (`issues:write`, `pull_requests:write`) may take seconds to propagate to dynamically created repos.

## Test plan

- [ ] `integration-test-cli-sync-github-app` passes (branch name fix)
- [ ] `integration-test-cli-sync-github-pat` passes (PAT propagation wait)
- [ ] `integration-test-action-sync-pat` passes (shell script wait)
- [ ] `integration-test-cli-settings-labels-pat` passes (PAT propagation wait)

🤖 Generated with [Claude Code](https://claude.com/claude-code)