### PR TITLE
fix: add group configuration to JSON schema and docs

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -18,6 +18,11 @@
       "required": [
         "settings"
       ]
+    },
+    {
+      "required": [
+        "groups"
+      ]
     }
   ],
   "properties": {
@@ -34,6 +39,13 @@
       "minProperties": 1,
       "additionalProperties": {
         "$ref": "#/definitions/fileConfig"
+      }
+    },
+    "groups": {
+      "type": "object",
+      "description": "Named configuration groups that repos can reference via 'groups: [...]'. Groups create a merge chain: root → group1 → group2 → repo overrides. Each group can define files, prOptions, and settings.",
+      "additionalProperties": {
+        "$ref": "#/definitions/groupConfig"
       }
     },
     "repos": {
@@ -200,6 +212,13 @@
             ]
           }
         },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of group names to apply to this repo. Groups are merged in order: root → group1 → group2 → repo overrides. Group names must reference groups defined in the root 'groups' object."
+        },
         "prOptions": {
           "$ref": "#/definitions/prOptions",
           "description": "Per-repo PR merge options. Overrides global prOptions."
@@ -347,6 +366,45 @@
         "deleteOrphaned": {
           "type": "boolean",
           "description": "Override the file-level or global deleteOrphaned setting for this specific repo. Set to true to enable orphan tracking, or false to disable it for this repo."
+        }
+      }
+    },
+    "groupConfig": {
+      "type": "object",
+      "description": "Configuration group that can define files, prOptions, and settings. Referenced by repos via 'groups: [groupName]'.",
+      "properties": {
+        "files": {
+          "type": "object",
+          "description": "Files defined or overridden by this group. Keys are filenames. Set to false to remove an inherited file. Set inherit: false to discard all accumulated files from prior layers.",
+          "properties": {
+            "inherit": {
+              "type": "boolean",
+              "description": "Set to false to discard all files accumulated from root and earlier groups. Default: true"
+            }
+          },
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "boolean",
+                "const": false,
+                "description": "Set to false to remove this file from the group's output"
+              },
+              {
+                "$ref": "#/definitions/fileConfig"
+              },
+              {
+                "$ref": "#/definitions/repoFileOverride"
+              }
+            ]
+          }
+        },
+        "prOptions": {
+          "$ref": "#/definitions/prOptions",
+          "description": "PR merge options for repos using this group. Overrides root prOptions, can be overridden by repo prOptions."
+        },
+        "settings": {
+          "$ref": "#/definitions/repoSettings",
+          "description": "Settings for repos using this group. Supports inherit: false on rulesets/labels sub-sections. Merged between root and repo settings."
         }
       }
     },

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -41,6 +41,7 @@ Or configure in `.vscode/settings.json`:
 | ---------------- | ----------- | -------- | ------------------------------------------------- |
 | `id`             | `string`    | Yes      | Unique config identifier (alphanumeric, `-`, `_`) |
 | `files`          | `object`    | *        | Map of filenames to file configs                  |
+| `groups`         | `object`    | *        | Named config groups referenced by repos           |
 | `repos`          | `array`     | Yes      | List of repository configurations                 |
 | `settings`       | `object`    | *        | Repository settings (rulesets, labels, etc.)      |
 | `prOptions`      | `PROptions` | No       | Global PR merge options                           |
@@ -48,8 +49,8 @@ Or configure in `.vscode/settings.json`:
 | `githubHosts`    | `array`     | No       | GitHub Enterprise Server hostnames                |
 | `deleteOrphaned` | `boolean`   | No       | Global default for orphan file deletion           |
 
-!!! note "files/settings requirement"
-    At least one of `files` or `settings` must be present. The `sync` command requires `files`, while the `settings` command requires `settings`.
+!!! note "files/settings/groups requirement"
+    At least one of `files`, `settings`, or `groups` must be present. The `sync` command requires files defined in root `files` or in at least one group. The `settings` command requires `settings` at root, repo, or group level.
 
 ### File Config
 
@@ -65,12 +66,23 @@ Or configure in `.vscode/settings.json`:
 | `vars`           | `object`              | No       | Custom template variables            |
 | `deleteOrphaned` | `boolean`             | No       | Track file for orphan deletion       |
 
+### Group Config
+
+| Field       | Type        | Required | Description                                                  |
+| ----------- | ----------- | -------- | ------------------------------------------------------------ |
+| `files`     | `object`    | No       | Files defined or overridden by this group                    |
+| `prOptions` | `PROptions` | No       | PR options for repos using this group                        |
+| `settings`  | `object`    | No       | Settings for repos using this group (supports `inherit`)     |
+
+Group files support `inherit: false` (discard accumulated files), `file: false` (remove a file), and full file config or override objects.
+
 ### Repo Config
 
 | Field       | Type           | Required | Description                                                 |
 | ----------- | -------------- | -------- | ----------------------------------------------------------- |
 | `git`       | `string/array` | Yes      | Git URL(s)                                                  |
 | `files`     | `object`       | No       | Per-repo file overrides                                     |
+| `groups`    | `string[]`     | No       | Group names to apply (merged in order)                      |
 | `prOptions` | `PROptions`    | No       | Per-repo PR options                                         |
 | `upstream`  | `string`       | No       | Fork from this URL if target doesn't exist                  |
 | `source`    | `string`       | No       | Migrate from this URL if target doesn't exist               |
@@ -105,7 +117,7 @@ Or configure in `.vscode/settings.json`:
 
 The schema validates:
 
-- Required fields (`id`, `repos`, at least one of `files` or `settings`)
+- Required fields (`id`, `repos`, at least one of `files`, `settings`, or `groups`)
 - Command-specific requirements (see below)
 - Enum values (`mergeStrategy`, `merge`, etc.)
 - Content types (object for JSON/YAML, string/array for text files)
@@ -113,19 +125,19 @@ The schema validates:
 
 ### Command-Specific Requirements
 
-| Command        | Required Fields                                              |
-| -------------- | ------------------------------------------------------------ |
-| `xfg sync`     | `files` with at least one file defined                       |
-| `xfg settings` | `settings` with actionable config (e.g., rulesets, labels)   |
+| Command        | Required Fields                                                    |
+| -------------- | ------------------------------------------------------------------ |
+| `xfg sync`     | Files defined in root `files` or in at least one group             |
+| `xfg settings` | `settings` at root, repo, or group level with actionable config    |
 
 If you run the wrong command for your config, you'll see a helpful error:
 
 ```text
 # Running sync with a settings-only config:
-The 'sync' command requires a 'files' section with at least one file defined.
+The 'sync' command requires files defined in root 'files' or in at least one group.
 To manage repository settings instead, use 'xfg settings'.
 
 # Running settings with a files-only config:
-The 'settings' command requires a 'settings' section at root level or in at least one repo.
+The 'settings' command requires a 'settings' section at root level, in at least one repo, or in at least one group.
 To sync files instead, use 'xfg sync'.
 ```


### PR DESCRIPTION
Closes #567 (follow-up)

## Summary
- Add `groupConfig` definition to `config-schema.json` with `files`, `prOptions`, and `settings` properties
- Add root-level `groups` property (map of named group configs)
- Add repo-level `groups` property (`string[]` referencing defined groups)
- Update `anyOf` constraint so configs with only `groups` (no root `files`) are valid
- Update `docs/reference/config-schema.md` with Group Config table, updated Root/Repo tables, and revised validation notes

## Test plan
- [x] JSON schema validates (`node -e "JSON.parse(...)"`)
- [x] 2256 unit tests pass (`npm test`)
- [x] Lint passes clean (`./lint.sh`)
- [ ] CI checks on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)