### PR TITLE
fix: eliminate unnecessary retry delays in unit tests

### DIFF
--- a/src/settings/labels/github-labels-strategy.ts
+++ b/src/settings/labels/github-labels-strategy.ts
@@ -15,6 +15,10 @@ import type {
   LabelsStrategyOptions,
 } from "./types.js";
 
+export interface GitHubLabelsStrategyOptions {
+  retries?: number;
+}
+
 /**
  * GitHub Labels Strategy for managing repository labels via GitHub REST API.
  * Uses `gh api` CLI for authentication and API calls.
@@ -24,9 +28,14 @@ import type {
  */
 export class GitHubLabelsStrategy implements ILabelsStrategy {
   private executor: ICommandExecutor;
+  private retries: number;
 
-  constructor(executor?: ICommandExecutor) {
+  constructor(
+    executor?: ICommandExecutor,
+    options?: GitHubLabelsStrategyOptions
+  ) {
     this.executor = executor ?? defaultExecutor;
+    this.retries = options?.retries ?? 3;
   }
 
   /**
@@ -149,11 +158,15 @@ export class GitHubLabelsStrategy implements ILabelsStrategy {
     if (payload && (method === "POST" || method === "PATCH")) {
       const payloadJson = JSON.stringify(payload);
       const command = `echo ${escapeShellArg(payloadJson)} | ${tokenPrefix}${baseCommand} --input -`;
-      return await withRetry(() => this.executor.exec(command, process.cwd()));
+      return await withRetry(() => this.executor.exec(command, process.cwd()), {
+        retries: this.retries,
+      });
     }
 
     // For GET/DELETE, run command directly
     const command = `${tokenPrefix}${baseCommand}`;
-    return await withRetry(() => this.executor.exec(command, process.cwd()));
+    return await withRetry(() => this.executor.exec(command, process.cwd()), {
+      retries: this.retries,
+    });
   }
 }

--- a/src/settings/repo-settings/github-repo-settings-strategy.ts
+++ b/src/settings/repo-settings/github-repo-settings-strategy.ts
@@ -86,6 +86,10 @@ function configToGitHubPayload(
   return payload;
 }
 
+export interface GitHubRepoSettingsStrategyOptions {
+  retries?: number;
+}
+
 /**
  * GitHub Repository Settings Strategy.
  * Manages repository settings via GitHub REST API using `gh api` CLI.
@@ -94,9 +98,14 @@ function configToGitHubPayload(
  */
 export class GitHubRepoSettingsStrategy implements IRepoSettingsStrategy {
   private executor: ICommandExecutor;
+  private retries: number;
 
-  constructor(executor?: ICommandExecutor) {
+  constructor(
+    executor?: ICommandExecutor,
+    options?: GitHubRepoSettingsStrategyOptions
+  ) {
     this.executor = executor ?? defaultExecutor;
+    this.retries = options?.retries ?? 3;
   }
 
   async getSettings(
@@ -287,10 +296,14 @@ export class GitHubRepoSettingsStrategy implements IRepoSettingsStrategy {
     ) {
       const payloadJson = JSON.stringify(payload);
       const command = `echo ${escapeShellArg(payloadJson)} | ${tokenPrefix}${baseCommand} --input -`;
-      return await withRetry(() => this.executor.exec(command, process.cwd()));
+      return await withRetry(() => this.executor.exec(command, process.cwd()), {
+        retries: this.retries,
+      });
     }
 
     const command = `${tokenPrefix}${baseCommand}`;
-    return await withRetry(() => this.executor.exec(command, process.cwd()));
+    return await withRetry(() => this.executor.exec(command, process.cwd()), {
+      retries: this.retries,
+    });
   }
 }

--- a/src/settings/rulesets/github-ruleset-strategy.ts
+++ b/src/settings/rulesets/github-ruleset-strategy.ts
@@ -197,15 +197,24 @@ export interface RulesetStrategyOptions {
   host?: string;
 }
 
+export interface GitHubRulesetStrategyOptions {
+  retries?: number;
+}
+
 /**
  * GitHub Ruleset Strategy for managing repository rulesets via GitHub REST API.
  * Uses `gh api` CLI for authentication and API calls.
  */
 export class GitHubRulesetStrategy implements IRulesetStrategy {
   private executor: ICommandExecutor;
+  private retries: number;
 
-  constructor(executor?: ICommandExecutor) {
+  constructor(
+    executor?: ICommandExecutor,
+    options?: GitHubRulesetStrategyOptions
+  ) {
     this.executor = executor ?? defaultExecutor;
+    this.retries = options?.retries ?? 3;
   }
 
   /**
@@ -344,11 +353,15 @@ export class GitHubRulesetStrategy implements IRulesetStrategy {
     if (payload && (method === "POST" || method === "PUT")) {
       const payloadJson = JSON.stringify(payload);
       const command = `echo ${escapeShellArg(payloadJson)} | ${tokenPrefix}${baseCommand} --input -`;
-      return await withRetry(() => this.executor.exec(command, process.cwd()));
+      return await withRetry(() => this.executor.exec(command, process.cwd()), {
+        retries: this.retries,
+      });
     }
 
     // For GET/DELETE, run command directly
     const command = `${tokenPrefix}${baseCommand}`;
-    return await withRetry(() => this.executor.exec(command, process.cwd()));
+    return await withRetry(() => this.executor.exec(command, process.cwd()), {
+      retries: this.retries,
+    });
   }
 }

--- a/test/unit/authenticated-git-ops.test.ts
+++ b/test/unit/authenticated-git-ops.test.ts
@@ -741,6 +741,7 @@ describe("AuthenticatedGitOps", () => {
       const gitOps = new GitOps({
         workDir: "/tmp/test",
         executor: mockExecutor,
+        retries: 0,
       });
       const authOps = new AuthenticatedGitOps(gitOps, {
         token: "test-token",
@@ -773,6 +774,7 @@ describe("AuthenticatedGitOps", () => {
       const gitOps = new GitOps({
         workDir: "/tmp/test",
         executor: mockExecutor,
+        retries: 0,
       });
       const authOps = new AuthenticatedGitOps(gitOps, {
         token: "test-token",
@@ -796,6 +798,7 @@ describe("AuthenticatedGitOps", () => {
       const gitOps = new GitOps({
         workDir: "/tmp/test",
         executor: mockExecutor,
+        retries: 0,
       });
       const authOps = new AuthenticatedGitOps(gitOps, {
         token: "test-token",

--- a/test/unit/labels-github-strategy.test.ts
+++ b/test/unit/labels-github-strategy.test.ts
@@ -72,7 +72,7 @@ describe("GitHubLabelsStrategy", () => {
 
   beforeEach(() => {
     mockExecutor = new MockExecutor();
-    strategy = new GitHubLabelsStrategy(mockExecutor);
+    strategy = new GitHubLabelsStrategy(mockExecutor, { retries: 0 });
   });
 
   describe("list", () => {
@@ -451,7 +451,7 @@ describe("GitHubLabelsStrategy", () => {
         },
       };
 
-      const retryStrategy = new GitHubLabelsStrategy(executor);
+      const retryStrategy = new GitHubLabelsStrategy(executor, { retries: 1 });
       const result = await retryStrategy.list(mockGitHubRepo);
 
       assert.deepEqual(result, []);
@@ -474,7 +474,7 @@ describe("GitHubLabelsStrategy", () => {
         },
       };
 
-      const retryStrategy = new GitHubLabelsStrategy(executor);
+      const retryStrategy = new GitHubLabelsStrategy(executor, { retries: 1 });
       await assert.rejects(
         async () => retryStrategy.list(mockGitHubRepo),
         /404/
@@ -494,7 +494,7 @@ describe("GitHubLabelsStrategy", () => {
         },
       };
 
-      const errorStrategy = new GitHubLabelsStrategy(executor);
+      const errorStrategy = new GitHubLabelsStrategy(executor, { retries: 0 });
       await assert.rejects(
         async () =>
           errorStrategy.create(mockGitHubRepo, {

--- a/test/unit/settings/repo-settings/github-repo-settings-strategy.test.ts
+++ b/test/unit/settings/repo-settings/github-repo-settings-strategy.test.ts
@@ -81,7 +81,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       // 4 commands: base settings + 3 security endpoints
@@ -109,7 +111,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.owner_type, "Organization");
@@ -130,7 +134,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.owner_type, "User");
@@ -150,7 +156,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.owner_type, undefined);
@@ -170,7 +178,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.vulnerability_alerts, true);
@@ -188,7 +198,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.vulnerability_alerts, false);
@@ -204,7 +216,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         "gh: Server Error (HTTP 500)"
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
 
       await assert.rejects(
         async () => strategy.getSettings(githubRepo),
@@ -224,7 +238,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.automated_security_fixes, true);
@@ -244,7 +260,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       // Should return true based on API response, not vulnerability_alerts state
@@ -267,7 +285,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.automated_security_fixes, false);
@@ -284,7 +304,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         "gh: Unauthorized (HTTP 401)"
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
 
       await assert.rejects(
         async () => strategy.getSettings(githubRepo),
@@ -304,7 +326,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: true })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.private_vulnerability_reporting, true);
@@ -322,7 +346,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ enabled: false })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.private_vulnerability_reporting, false);
@@ -340,7 +366,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         "gh: Not Found (HTTP 404)"
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.private_vulnerability_reporting, false);
@@ -358,7 +386,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         "gh: Server Error (HTTP 500)"
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
 
       await assert.rejects(
         async () => strategy.getSettings(githubRepo),
@@ -371,7 +401,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should update repository settings via PATCH", async () => {
       mockExecutor.setResponse("/repos/test-org/test-repo", "{}");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.updateSettings(githubRepo, {
         hasIssues: false,
         allowSquashMerge: true,
@@ -385,7 +417,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should include web_commit_signoff_required in payload", async () => {
       mockExecutor.setResponse("/repos/test-org/test-repo", "{}");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.updateSettings(githubRepo, {
         webCommitSignoffRequired: true,
       });
@@ -400,7 +434,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should include default_branch in payload", async () => {
       mockExecutor.setResponse("/repos/test-org/test-repo", "{}");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.updateSettings(githubRepo, {
         defaultBranch: "develop",
       });
@@ -413,7 +449,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should include description in payload", async () => {
       mockExecutor.setResponse("/repos/test-org/test-repo", "{}");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.updateSettings(githubRepo, {
         description: "My repo description",
       });
@@ -425,7 +463,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     });
 
     test("should skip update when no settings provided", async () => {
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.updateSettings(githubRepo, {});
 
       assert.equal(mockExecutor.commands.length, 0);
@@ -436,7 +476,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should enable vulnerability alerts via PUT", async () => {
       mockExecutor.setResponse("vulnerability-alerts", "");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.setVulnerabilityAlerts(githubRepo, true);
 
       assert.equal(mockExecutor.commands.length, 1);
@@ -447,7 +489,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should disable vulnerability alerts via DELETE", async () => {
       mockExecutor.setResponse("vulnerability-alerts", "");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.setVulnerabilityAlerts(githubRepo, false);
 
       assert.equal(mockExecutor.commands.length, 1);
@@ -460,7 +504,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should enable automated security fixes via PUT", async () => {
       mockExecutor.setResponse("automated-security-fixes", "");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.setAutomatedSecurityFixes(githubRepo, true);
 
       assert.equal(mockExecutor.commands.length, 1);
@@ -471,7 +517,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should disable automated security fixes via DELETE", async () => {
       mockExecutor.setResponse("automated-security-fixes", "");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.setAutomatedSecurityFixes(githubRepo, false);
 
       assert.equal(mockExecutor.commands.length, 1);
@@ -484,7 +532,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should enable private vulnerability reporting via PUT", async () => {
       mockExecutor.setResponse("private-vulnerability-reporting", "");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.setPrivateVulnerabilityReporting(githubRepo, true);
 
       assert.equal(mockExecutor.commands.length, 1);
@@ -497,7 +547,9 @@ describe("GitHubRepoSettingsStrategy", () => {
     test("should disable private vulnerability reporting via DELETE", async () => {
       mockExecutor.setResponse("private-vulnerability-reporting", "");
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.setPrivateVulnerabilityReporting(githubRepo, false);
 
       assert.equal(mockExecutor.commands.length, 1);
@@ -519,7 +571,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         project: "project",
       };
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
 
       await assert.rejects(
         async () => strategy.getSettings(azureRepo),
@@ -543,7 +597,9 @@ describe("GitHubRepoSettingsStrategy", () => {
         JSON.stringify({ has_issues: true })
       );
 
-      const strategy = new GitHubRepoSettingsStrategy(mockExecutor);
+      const strategy = new GitHubRepoSettingsStrategy(mockExecutor, {
+        retries: 0,
+      });
       await strategy.getSettings(gheRepo, { host: "github.example.com" });
 
       assert.ok(mockExecutor.commands[0].includes("--hostname"));
@@ -571,7 +627,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         },
       };
 
-      const strategy = new GitHubRepoSettingsStrategy(executor);
+      const strategy = new GitHubRepoSettingsStrategy(executor, { retries: 1 });
       await strategy.updateSettings(githubRepo, { hasIssues: true });
 
       assert.ok(
@@ -596,7 +652,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         },
       };
 
-      const strategy = new GitHubRepoSettingsStrategy(executor);
+      const strategy = new GitHubRepoSettingsStrategy(executor, { retries: 1 });
       await assert.rejects(
         async () => strategy.updateSettings(githubRepo, { hasIssues: true }),
         /404/
@@ -631,7 +687,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         },
       };
 
-      const strategy = new GitHubRepoSettingsStrategy(executor);
+      const strategy = new GitHubRepoSettingsStrategy(executor, { retries: 1 });
       const result = await strategy.getSettings(githubRepo);
 
       assert.equal(result.vulnerability_alerts, false);

--- a/test/unit/settings/rulesets/github-ruleset-strategy.test.ts
+++ b/test/unit/settings/rulesets/github-ruleset-strategy.test.ts
@@ -66,7 +66,7 @@ describe("GitHubRulesetStrategy", () => {
 
   beforeEach(() => {
     mockExecutor = new MockExecutor();
-    strategy = new GitHubRulesetStrategy(mockExecutor);
+    strategy = new GitHubRulesetStrategy(mockExecutor, { retries: 0 });
   });
 
   describe("list", () => {
@@ -303,7 +303,7 @@ describe("GitHubRulesetStrategy", () => {
         },
       };
 
-      const retryStrategy = new GitHubRulesetStrategy(executor);
+      const retryStrategy = new GitHubRulesetStrategy(executor, { retries: 1 });
       const result = await retryStrategy.list(mockGitHubRepo);
 
       assert.deepEqual(result, []);
@@ -326,7 +326,7 @@ describe("GitHubRulesetStrategy", () => {
         },
       };
 
-      const retryStrategy = new GitHubRulesetStrategy(executor);
+      const retryStrategy = new GitHubRulesetStrategy(executor, { retries: 1 });
       await assert.rejects(
         async () => retryStrategy.list(mockGitHubRepo),
         /404/


### PR DESCRIPTION
## Summary

- Add `retries` constructor option to `GitHubRepoSettingsStrategy`, `GitHubRulesetStrategy`, and `GitHubLabelsStrategy` (following existing `GitHubLifecycleProvider` pattern)
- Use `retries: 0` in non-retry unit tests to skip exponential backoff delays
- Use `retries: 1` in explicit retry behavior tests to reduce wait time
- Pass `retries: 0` to `GitOps` constructor in `getDefaultBranch` fallback tests

Previously, tests for fallback/error logic accidentally triggered 3 retries with exponential backoff, wasting ~21+ seconds per test run. The affected tests now complete in <2ms each.

## Test plan

- [x] `npm test` — all tests pass
- [x] No "Attempt/Retrying" log messages from non-retry tests
- [x] Explicit retry behavior tests still verify retry logic with `retries: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)