### PR TITLE
fix(ci): pin MkDocs to 1.x to avoid Material incompatibility

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install MkDocs Material
-        run: pip install mkdocs-material
+        run: pip install 'mkdocs<2' mkdocs-material
 
       - name: Build docs
         run: mkdocs build


### PR DESCRIPTION
Closes #568

## Summary

- Pin MkDocs to `<2` in docs CI workflow to prevent MkDocs 2.0 from being installed
- MkDocs 2.0 drops plugin support and switches config from YAML to TOML, making it incompatible with Material for MkDocs
- Zensical migration tracked in #573

## Test plan

- [ ] Verify docs CI workflow builds successfully with the pinned version


🤖 Generated with [Claude Code](https://claude.com/claude-code)