### PR TITLE
fix(schema): use anyOf for group file entries to resolve IDE validation warning

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -383,7 +383,7 @@
             }
           },
           "additionalProperties": {
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "boolean",
                 "const": false,


### PR DESCRIPTION
## Summary

- Fix IDE schema warning "Matches multiple schemas when only one must validate" when configuring group files with `content`
- Change `oneOf` to `anyOf` for `groupConfig.files.additionalProperties` since `fileConfig` and `repoFileOverride` have overlapping optional properties and any valid entry matches both

## Test plan

- [x] All 2256 unit tests pass
- [ ] Verify IDE no longer shows schema warning on group file `content` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)