### PR TITLE
fix: use GitHub App token for docs deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,9 +22,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-python@v6
         with:
@@ -35,8 +43,8 @@ jobs:
 
       - name: Configure git for mike
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "xfg-release[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Deploy docs with mike
         run: mike deploy --push --update-aliases 4.x latest


### PR DESCRIPTION
## Summary

Closes the deploy-docs regression introduced by the `branch-signatures` ruleset from #544.

- `mike deploy --push` creates commits on `gh-pages` using the default `GITHUB_TOKEN`, which are unsigned
- The `required_signatures` ruleset targets `refs/heads/**` (including `gh-pages`), rejecting unsigned commits
- Fix: use the release GitHub App token (same as `release.yaml`) so commits are signed and verified

Changes:
- Generate App token via `actions/create-github-app-token@v2`
- Pass token to `actions/checkout` so the remote URL has App auth embedded
- Configure git identity as the App's bot user for signature recognition

## Test plan

- [ ] Merge this PR
- [ ] Trigger `Deploy Docs` workflow on main (manually or via docs change)
- [ ] Verify `mike deploy --push` succeeds and the gh-pages commit is verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)