### PR TITLE
fix: deploy both v3 and v4 docs with mike versioning

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -46,8 +46,19 @@ jobs:
           git config user.name "xfg-release[bot]"
           git config user.email "xfg-release[bot]@users.noreply.github.com"
 
-      - name: Build docs locally (no push)
+      - name: Build v3 docs from tag
+        run: |
+          # Check out v3 docs sources into a temp directory
+          git worktree add /tmp/v3-docs v3
+          # Build v3 docs using v3's mkdocs.yml
+          mike deploy --config-file /tmp/v3-docs/mkdocs.yml 3.x
+          git worktree remove /tmp/v3-docs
+
+      - name: Build v4 docs from main
         run: mike deploy --update-aliases 4.x latest
+
+      - name: Set default version
+        run: mike set-default latest
 
       - name: Push git objects to remote
         run: |


### PR DESCRIPTION
## Summary
- Build v3 docs from the `v3` tag via git worktree
- Build v4 docs from main with `latest` alias
- Set default version to `latest` so root URL (`/xfg/`) redirects to `/xfg/latest/`
- Fixes missing version dropdown and stale content at root

## Test plan
- [ ] Merge to main
- [ ] Trigger Deploy Docs workflow
- [ ] Verify root URL redirects to `/latest/`
- [ ] Verify version dropdown shows both 3.x and 4.x
- [ ] Verify v3 docs accessible at `/xfg/3.x/`
- [ ] Verify v4 docs accessible at `/xfg/4.x/` and `/xfg/latest/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)