### PR TITLE
fix: use copy alias type for mike — GitHub Pages ignores symlinks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -55,7 +55,7 @@ jobs:
           git worktree remove /tmp/v3-docs
 
       - name: Build v4 docs from main
-        run: mike deploy --update-aliases 4.x latest
+        run: mike deploy --update-aliases --alias-type copy 4.x latest
 
       - name: Set default version
         run: mike set-default latest


### PR DESCRIPTION
## Summary
- mike's default alias type is `symlink`, but GitHub Pages doesn't follow symlinks
- This caused `/latest/` to 404, so the root redirect failed and users saw stale v3 content
- Use `--alias-type copy` so the `latest` alias is a full directory copy

## Test plan
- [ ] Merge to main
- [ ] Trigger Deploy Docs
- [ ] Verify `/xfg/latest/` loads v4 docs (not 404)
- [ ] Verify `/xfg/` redirects to `/xfg/latest/`
- [ ] Verify version dropdown works

🤖 Generated with [Claude Code](https://claude.com/claude-code)