### PR TITLE
test: add coverage for flaky test race condition fixes

### DIFF
--- a/test/unit/lifecycle/github-lifecycle-provider.test.ts
+++ b/test/unit/lifecycle/github-lifecycle-provider.test.ts
@@ -395,6 +395,41 @@ describe("GitHubLifecycleProvider", () => {
         assert.ok(!calls.some((c) => c.command.includes("default_branch")));
       });
 
+      test("waitForDefaultBranch handles API errors during polling", async () => {
+        // Poll throws errors intermittently, then succeeds
+        let defaultBranchCallCount = 0;
+        const calls: Array<{ command: string; cwd: string }> = [];
+        const executor = {
+          async exec(command: string, cwd: string): Promise<string> {
+            calls.push({ command, cwd });
+            if (command.includes("--jq '.default_branch'")) {
+              defaultBranchCallCount++;
+              if (defaultBranchCallCount === 1) return "master";
+              if (defaultBranchCallCount === 2)
+                throw new Error("HTTP 500: Internal Server Error");
+              return "main"; // Third call succeeds
+            }
+            if (command.includes("gh repo create")) return "";
+            if (command.includes("branches/'master'/rename")) return "";
+            if (command.includes("contents/README.md --jq")) return "abc123def";
+            if (command.includes("--method DELETE")) return "";
+            return "";
+          },
+        };
+
+        const provider = new GitHubLifecycleProvider({ executor, retries: 0 });
+        await provider.create(mockRepoInfo, { defaultBranch: "main" });
+
+        // Should have recovered from the error and continued polling
+        const pollCalls = calls.filter((c) =>
+          c.command.includes("--jq '.default_branch'")
+        );
+        assert.ok(
+          pollCalls.length >= 3,
+          `Expected at least 3 default_branch calls (initial + error + success), got ${pollCalls.length}`
+        );
+      });
+
       test("error propagates from rename API and deleteReadme is not reached", async () => {
         const { mock: executor, calls } = createMockExecutor({
           responses: new Map([

--- a/test/unit/vcs/graphql-commit-strategy.test.ts
+++ b/test/unit/vcs/graphql-commit-strategy.test.ts
@@ -1395,6 +1395,75 @@ describe("GraphQLCommitStrategy", () => {
       );
     });
 
+    test("succeeds when createRef fails with 'already exists' (fork race condition)", async () => {
+      // Simulates: queryRemoteRef returns null (fork not propagated),
+      // createRef fails with "already exists" — should succeed, not throw
+      const queryResponse = JSON.stringify({
+        data: { repository: { id: "R_fork123", ref: null } },
+      });
+      const commitResponse = JSON.stringify({
+        data: { createCommitOnBranch: { commit: { oid: "forkcommitsha" } } },
+      });
+
+      let graphqlCallCount = 0;
+      mockExecutor.responses.set("git rev-parse HEAD", "headsha");
+      mockExecutor.responses.set("git fetch", "");
+      mockExecutor.responses.set("git rev-parse origin/", "headsha");
+      mockExecutor.responses.set("gh api graphql", () => {
+        graphqlCallCount++;
+        if (graphqlCallCount === 1) return queryResponse;
+        if (graphqlCallCount === 2) {
+          // createRef fails — branch appeared between query and create
+          throw new Error(
+            'A ref named "refs/heads/main" already exists in the repository.'
+          );
+        }
+        return commitResponse;
+      });
+
+      const strategy = new GraphQLCommitStrategy(mockExecutor);
+      const result = await strategy.commit({
+        repoInfo: githubRepoInfo,
+        branchName: "main",
+        message: "Test fork sync",
+        fileChanges: [{ path: "f.txt", content: "content" }],
+        workDir: testDir,
+        token: "ghs_token",
+      });
+
+      // Should succeed — "already exists" is treated as the branch being ready
+      assert.equal(result.sha, "forkcommitsha");
+    });
+
+    test("re-throws non-'already exists' errors from createRef", async () => {
+      const queryResponse = JSON.stringify({
+        data: { repository: { id: "R_repo123", ref: null } },
+      });
+
+      let graphqlCallCount = 0;
+      mockExecutor.responses.set("git rev-parse HEAD", "headsha");
+      mockExecutor.responses.set("gh api graphql", () => {
+        graphqlCallCount++;
+        if (graphqlCallCount === 1) return queryResponse;
+        throw new Error("Internal server error");
+      });
+
+      const strategy = new GraphQLCommitStrategy(mockExecutor);
+      await assert.rejects(
+        () =>
+          strategy.commit({
+            repoInfo: githubRepoInfo,
+            branchName: "feature",
+            message: "Test",
+            fileChanges: [{ path: "f.txt", content: "c" }],
+            workDir: testDir,
+            token: "ghs_token",
+          }),
+        /Internal server error/,
+        "Should re-throw non-'already exists' errors"
+      );
+    });
+
     test("deleteRemoteRef uses --hostname for GitHub Enterprise", async () => {
       // force=true with existing branch triggers deleteRef + createRef
       const queryResponse = JSON.stringify({


### PR DESCRIPTION
Closes #588

## Summary
- Add unit tests for "already exists" race condition handling in `ensureBranchExistsOnRemote` (succeeds on race, re-throws other errors)
- Add unit test for `waitForDefaultBranch` API error resilience during polling
- Improves coverage for changes introduced in #588

## Test plan
- [x] `npm test` — 2204 tests pass
- [x] `./lint.sh` — clean
- [x] `npm run build` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)