### PR TITLE
docs: fix v4 references and remove stale action command input

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: anthony-spruyt/xfg@v3
+      - uses: anthony-spruyt/xfg@v4
         with:
-          command: sync
           config: ./sync-config.yaml
           github-token: ${{ secrets.GH_PAT }} # PAT with repo scope for cross-repo access
 ```

--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -7,7 +7,7 @@ The simplest way to use xfg in GitHub Actions is with the official action:
 ```yaml
 - uses: actions/checkout@v4
 
-- uses: anthony-spruyt/xfg@v3
+- uses: anthony-spruyt/xfg@v4
   with:
     config: ./sync-config.yml
     github-token: ${{ secrets.GH_PAT }} # PAT with repo scope for cross-repo access
@@ -17,7 +17,6 @@ The simplest way to use xfg in GitHub Actions is with the official action:
 
 | Input                    | Required | Default               | Description                                                |
 | ------------------------ | -------- | --------------------- | ---------------------------------------------------------- |
-| `command`                | No       | `sync`                | Command to run (`sync` or `settings`)                      |
 | `config`                 | Yes      | -                     | Path to YAML config file                                   |
 | `dry-run`                | No       | `false`               | Preview mode - show what would change without creating PRs |
 | `work-dir`               | No       | `./tmp`               | Directory for cloning repositories                         |
@@ -38,7 +37,7 @@ The simplest way to use xfg in GitHub Actions is with the official action:
 Sync configs across GitHub, Azure DevOps, and GitLab repositories:
 
 ```yaml
-- uses: anthony-spruyt/xfg@v3
+- uses: anthony-spruyt/xfg@v4
   with:
     config: ./sync-config.yml
     github-token: ${{ secrets.GH_PAT }}
@@ -54,7 +53,7 @@ Sync configs across GitHub, Azure DevOps, and GitLab repositories:
 Automatically merge PRs when CI passes:
 
 ```yaml
-- uses: anthony-spruyt/xfg@v3
+- uses: anthony-spruyt/xfg@v4
   with:
     config: ./sync-config.yml
     github-token: ${{ secrets.GH_PAT }}
@@ -66,7 +65,7 @@ Automatically merge PRs when CI passes:
 Push directly to the default branch without creating PRs:
 
 ```yaml
-- uses: anthony-spruyt/xfg@v3
+- uses: anthony-spruyt/xfg@v4
   with:
     config: ./sync-config.yml
     github-token: ${{ secrets.GH_PAT }}
@@ -97,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: anthony-spruyt/xfg@v3
+      - uses: anthony-spruyt/xfg@v4
         with:
           config: ./sync-config.yml
           github-app-id: ${{ vars.APP_ID }}

--- a/docs/configuration/labels.md
+++ b/docs/configuration/labels.md
@@ -1,6 +1,6 @@
 # GitHub Labels
 
-xfg can manage GitHub labels declaratively using the `settings` command. Define labels in your config file, and xfg will create, update, rename, or delete them to match your desired state.
+xfg can manage GitHub labels declaratively using the `sync` command. Define labels in your config file, and xfg will create, update, rename, or delete them to match your desired state.
 
 !!! note "GitHub-Only Feature"
     Labels are only available for GitHub repositories. Azure DevOps and GitLab repos will be skipped when running `xfg sync`.
@@ -128,7 +128,7 @@ repos:
 
 ## How It Works
 
-The `settings` command:
+The `xfg sync` command:
 
 1. Fetches current labels from the GitHub API
 2. Compares them against the desired state in config (case-insensitive matching)

--- a/docs/configuration/repo-settings.md
+++ b/docs/configuration/repo-settings.md
@@ -1,6 +1,6 @@
 # Repository Settings
 
-xfg can manage GitHub repository settings declaratively using the `settings` command. Configure features, merge options, and security settings in your config file, and xfg will update repositories to match your desired state.
+xfg can manage GitHub repository settings declaratively using the `sync` command. Configure features, merge options, and security settings in your config file, and xfg will update repositories to match your desired state.
 
 !!! note "GitHub-Only Feature"
     Repository settings are only available for GitHub repositories. Azure DevOps and GitLab repos will be skipped when running `xfg sync`.

--- a/docs/configuration/rulesets.md
+++ b/docs/configuration/rulesets.md
@@ -1,6 +1,6 @@
 # GitHub Rulesets
 
-xfg can manage GitHub Rulesets declaratively using the `settings` command. Define rulesets in your config file, and xfg will create, update, or delete them to match your desired state.
+xfg can manage GitHub Rulesets declaratively using the `sync` command. Define rulesets in your config file, and xfg will create, update, or delete them to match your desired state.
 
 !!! note "GitHub-Only Feature"
     Rulesets are only available for GitHub repositories. Azure DevOps and GitLab repos will be skipped when running `xfg sync`.
@@ -422,14 +422,13 @@ Found 2 repositories with rulesets
 
 ## Combining with File Sync
 
-The `sync` and `settings` commands are independent. Run them together or separately:
+File sync and settings are handled together by a single command:
 
 ```bash
-# Sync files and apply rulesets
-xfg sync -c config.yaml && xfg sync -c config.yaml
-
-# Or run separately
+# Sync files and apply rulesets in one run
 xfg sync -c config.yaml
+
+# Preview first, then apply
 xfg sync -c config.yaml --dry-run  # Preview first
 xfg sync -c config.yaml            # Apply
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,7 +185,7 @@ Customize PR descriptions with [PR templates](configuration/pr-templates.md) usi
 
 - **[GitHub App Authentication](platforms/github-app.md)** - No user-tied credentials, fine-grained permissions, and verified commits with the "Verified" badge
 - **GitHub Enterprise Server** - Configure custom hostnames via `githubHosts` in config
-- **[GitHub Actions](ci-cd/github-actions.md)** - Official action (`anthony-spruyt/xfg@v3`) with all options as inputs
+- **[GitHub Actions](ci-cd/github-actions.md)** - Official action (`anthony-spruyt/xfg@v4`) with all options as inputs
 - **[Azure Pipelines](ci-cd/azure-pipelines.md)** - Run xfg in Azure DevOps pipelines
 - **CI Summary Output** - Rich `GITHUB_STEP_SUMMARY` with diff-style change reports:
 

--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -30,7 +30,7 @@ The `command` input has been removed from the GitHub Action. The action always r
 **Before (v3):**
 
 ```yaml
-- uses: anthony-spruyt/xfg@v3
+- uses: anthony-spruyt/xfg@v4
   with:
     command: settings
     config: ./config.yaml

--- a/docs/platforms/github-app.md
+++ b/docs/platforms/github-app.md
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: anthony-spruyt/xfg@v3
+      - uses: anthony-spruyt/xfg@v4
         with:
           config: sync-config.yaml
           github-app-id: ${{ vars.APP_ID }}


### PR DESCRIPTION
## Summary

- Remove `command: sync` from GitHub Action usage examples — the `command` input was removed in v4 but docs still showed it, causing `Unexpected input(s) 'command'` errors
- Remove `command` row from action inputs table in `github-actions.md`
- Update action version references from `v3` to `v4` in `docs/index.md`, migration guide, and `github-app.md`
- Fix remaining references to the removed `settings` CLI command → `sync` in rulesets, labels, and repo-settings docs

## Test plan

- [ ] Verify no `command:` in any action usage examples
- [ ] Verify all action version references show `v4`
- [ ] Verify all CLI command references say `xfg sync` (not `xfg settings`)