### PR TITLE
fix(ci): pass app token via input to gh-release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,5 +154,4 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Fix GitHub Release creation failing with 403 "Resource not accessible by integration"
- Pass app token via `token` input instead of `GITHUB_TOKEN` env var
- The `softprops/action-gh-release` action defaults to `github.token` (workflow token with `contents: read`), ignoring the env var

## Root cause

The v4.0.4 release published to npm but failed to create a GitHub Release. The `softprops/action-gh-release@v2` action uses its `token` input (defaulting to `github.token`) rather than the `GITHUB_TOKEN` env var. Since the workflow has `contents: read`, the default token lacks release creation permission. Previous releases likely worked because `softprops/action-gh-release` previously honored the env var.

## Test plan

- [ ] Verify next release creates a GitHub Release successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)