### PR TITLE
test(coverage): add error-path tests for git-ops, fix codecov ignore

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,7 @@ ignore:
   - "src/cli/types.ts"
   - "src/config/types.ts"
   - "src/lifecycle/types.ts"
+  - "src/output/types.ts"
   - "src/sync/types.ts"
   - "src/vcs/types.ts"
   - "src/settings/rulesets/types.ts"

--- a/test/unit/git-ops.test.ts
+++ b/test/unit/git-ops.test.ts
@@ -16,6 +16,7 @@ import {
   validateBranchName,
 } from "../../src/shared/branch-utils.js";
 import { ICommandExecutor } from "../../src/shared/command-executor.js";
+import { SyncError } from "../../src/shared/errors.js";
 
 const stubExecutor: ICommandExecutor = { exec: async () => "" };
 
@@ -284,6 +285,24 @@ describe("GitOps", () => {
       assert.ok(existsSync(workDir));
       assert.ok(!existsSync(join(workDir, "nested")));
     });
+
+    test("wraps filesystem errors in SyncError", () => {
+      // Use a path through a file (not a directory) to trigger ENOTDIR
+      const blockingFile = join(testDir, "blocking-file");
+      writeFileSync(blockingFile, "I am a file");
+      const badWorkDir = join(blockingFile, "impossible");
+
+      const gitOps = new GitOps({
+        workDir: badWorkDir,
+        executor: stubExecutor,
+      });
+      assert.throws(
+        () => gitOps.cleanWorkspace(),
+        (err: unknown) =>
+          err instanceof SyncError &&
+          err.message.includes("Failed to clean workspace")
+      );
+    });
   });
 
   describe("writeFile", () => {
@@ -318,6 +337,18 @@ describe("GitOps", () => {
       gitOps.writeFile("test.json", "content");
 
       assert.ok(!existsSync(join(workDir, "test.json")));
+    });
+
+    test("wraps filesystem errors in SyncError", () => {
+      // Place a file where writeFile expects to create a directory
+      writeFileSync(join(workDir, "blocker"), "I am a file");
+      const gitOps = new GitOps({ workDir, executor: stubExecutor });
+      assert.throws(
+        () => gitOps.writeFile("blocker/sub/test.json", "content"),
+        (err: unknown) =>
+          err instanceof SyncError &&
+          err.message.includes("Failed to write file")
+      );
     });
   });
 
@@ -656,6 +687,17 @@ describe("GitOps", () => {
         "File should not be executable in dry-run mode"
       );
     });
+
+    test("wraps chmod errors in SyncError", async () => {
+      const gitOps = new GitOps({ workDir, executor: stubExecutor });
+      // File doesn't exist, so chmodSync will throw ENOENT
+      await assert.rejects(
+        async () => gitOps.setExecutable("nonexistent.sh"),
+        (err: unknown) =>
+          err instanceof SyncError &&
+          err.message.includes("Failed to set executable permissions")
+      );
+    });
   });
 
   describe("commit", () => {
@@ -928,6 +970,22 @@ describe("GitOps", () => {
       gitOps.deleteFile("subdir/nested.json");
 
       assert.ok(!existsSync(filePath));
+    });
+
+    test("wraps filesystem errors in SyncError", () => {
+      // Create a directory where deleteFile expects a file — rmSync on a
+      // non-empty directory without { recursive: true } throws ENOTEMPTY/EISDIR
+      const dirPath = join(workDir, "actually-a-dir");
+      mkdirSync(dirPath, { recursive: true });
+      writeFileSync(join(dirPath, "child.txt"), "content");
+
+      const gitOps = new GitOps({ workDir, executor: stubExecutor });
+      assert.throws(
+        () => gitOps.deleteFile("actually-a-dir"),
+        (err: unknown) =>
+          err instanceof SyncError &&
+          err.message.includes("Failed to delete file")
+      );
     });
   });
 


### PR DESCRIPTION
Closes #616

## Summary
- Add `SyncError` error-path tests for `cleanWorkspace`, `writeFile`, `setExecutable`, and `deleteFile` catch blocks in `git-ops.ts` (covers 20 previously uncovered lines)
- Add `src/output/types.ts` to codecov ignore list — pure type definitions with zero runtime code

## Test Plan
- [x] `npm test` — 2320/2320 pass (4 new)
- [x] `npm run test:typecheck` — clean
- [x] `./lint.sh` — all linters pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)