### PR TITLE
fix: propagate diffLines through SyncResultEntry to report output

### DIFF
--- a/src/cli/sync-command.ts
+++ b/src/cli/sync-command.ts
@@ -542,6 +542,7 @@ async function runFileSyncPhase(
       fileChanges: (result.fileChanges ?? []).map((f) => ({
         path: f.path,
         action: f.action,
+        ...(f.diffLines ? { diffLines: f.diffLines } : {}),
       })),
       prUrl: result.prUrl,
       mergeOutcome,

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -49,7 +49,11 @@ export interface SyncOptions extends SharedOptions {
 export interface SyncResultEntry {
   repoName: string;
   success: boolean;
-  fileChanges: Array<{ path: string; action: "create" | "update" | "delete" }>;
+  fileChanges: Array<{
+    path: string;
+    action: "create" | "update" | "delete";
+    diffLines?: string[];
+  }>;
   prUrl?: string;
   mergeOutcome?: "manual" | "auto" | "force" | "direct";
   error?: string;

--- a/test/unit/sync-command.test.ts
+++ b/test/unit/sync-command.test.ts
@@ -1130,6 +1130,50 @@ ${VALID_RULESET}
     });
   });
 
+  describe("diffLines propagation", () => {
+    test("propagates diffLines from processor result to CLI output", async () => {
+      writeFileSync(
+        testConfigPath,
+        `id: test-config
+${MINIMAL_FILES}
+repos:
+  - git: https://github.com/test/repo
+`
+      );
+
+      const diffLines = ["@@ -1,1 +1,1 @@", "-old", "+new"];
+      const mockProcessor = createMockProcessor({
+        success: true,
+        message: "PR created",
+        fileChanges: [
+          {
+            path: "config.json",
+            action: "update" as const,
+            diffLines,
+          },
+        ],
+      });
+
+      await runSync(
+        { config: testConfigPath, dryRun: true, workDir: testDir },
+        {
+          processorFactory: () => mockProcessor,
+          lifecycleManager: noopLifecycleManager,
+        }
+      );
+
+      const output = consoleOutput.join("\n");
+      assert.ok(
+        output.includes("-old"),
+        "Should include diff removal line in CLI output"
+      );
+      assert.ok(
+        output.includes("+new"),
+        "Should include diff addition line in CLI output"
+      );
+    });
+  });
+
   describe("merge mode warnings", () => {
     test("warns when mergeStrategy is set with direct merge mode", async () => {
       writeFileSync(


### PR DESCRIPTION
Closes #627

## Summary

- **Bug:** `runFileSyncPhase` in `sync-command.ts` mapped `fileChanges` into `SyncResultEntry` copying only `path` and `action`, silently dropping `diffLines`. Content diffs were computed correctly upstream but never reached the GitHub summary or CLI output.
- **Fix:** Propagate `diffLines` through the mapping and add the field to `SyncResultEntry` type.
- **Test:** Added integration test covering the full path from `ProcessorResult` → `reportResults` → CLI output (the gap existing unit tests missed).

## Test plan

- [x] New test: `propagates diffLines from processor result to CLI output`
- [x] All 2364 existing tests pass
- [x] `npm run test:typecheck` clean
- [ ] CI passes
- [ ] Verify content diffs appear in GitHub summary on next sync run

🤖 Generated with [Claude Code](https://claude.com/claude-code)