### PR TITLE
chore: add exports, sideEffects, and funding to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,18 @@
   "description": "Manage files, settings, and repositories across GitHub, Azure DevOps, and GitLab — declaratively, from a single YAML config",
   "type": "module",
   "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "bin": {
     "xfg": "./dist/cli.js"
   },
+  "sideEffects": [
+    "./dist/cli.js"
+  ],
   "files": [
     "dist",
     "PR.md"
@@ -57,6 +66,9 @@
   ],
   "author": "Anthony Spruyt",
   "license": "MIT",
+  "funding": {
+    "url": "https://github.com/sponsors/anthony-spruyt"
+  },
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^14.0.2",


### PR DESCRIPTION
## Summary

Improve Socket.dev supply chain score by adding modern package metadata:

- **`exports`** — explicit ESM entry point with types condition, signals well-maintained package
- **`sideEffects`** — marks only `cli.js` as having side effects, enables tree-shaking analysis
- **`funding`** — transparency signal that Socket.dev scores positively

No behavioral changes — metadata only.

## Test plan

- [x] `npm run build` passes
- [x] All 2364 unit tests pass
- [x] `package.json` parses correctly with new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)