### PR TITLE
ci: skip integration tests on PRs and version-only bumps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,8 @@ jobs:
   check-changes:
     runs-on: ubuntu-latest
     outputs:
-      code-changed: ${{ steps.filter.outputs.code-changed }}
+      build-needed: ${{ steps.filter.outputs.build-needed }}
+      integration-needed: ${{ steps.filter.outputs.integration-needed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -44,12 +45,23 @@ jobs:
           fi
 
           if echo "$CHANGED" | grep -qE '^(src/|test/|scripts/|package\.json$|package-lock\.json$)'; then
-            echo "code-changed=true" >> "$GITHUB_OUTPUT"
+            echo "build-needed=true" >> "$GITHUB_OUTPUT"
             echo "Code changes detected"
           else
-            echo "code-changed=false" >> "$GITHUB_OUTPUT"
+            echo "build-needed=false" >> "$GITHUB_OUTPUT"
             echo "No code changes, will skip build and integration tests"
           fi
+
+          # Integration tests only needed for source/test/script changes,
+          # not version-only bumps (package.json + package-lock.json)
+          if echo "$CHANGED" | grep -qE '^(src/|test/|scripts/)'; then
+            echo "integration-needed=true" >> "$GITHUB_OUTPUT"
+            echo "Source changes detected — integration tests needed"
+          else
+            echo "integration-needed=false" >> "$GITHUB_OUTPUT"
+            echo "No source changes — skipping integration tests"
+          fi
+
           echo "Changed files:"
           echo "$CHANGED"
 
@@ -62,7 +74,7 @@ jobs:
     needs:
       - "lint"
       - "check-changes"
-    if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.code-changed == 'true' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.build-needed == 'true' }}
     runs-on: ubuntu-latest
 
     concurrency:
@@ -115,7 +127,7 @@ jobs:
     needs:
       - "build"
       - "check-changes"
-    if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.code-changed == 'true' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.integration-needed == 'true' && github.event_name == 'push' }}
     uses: ./.github/workflows/_integration-tests.yaml
     secrets: "inherit"
 


### PR DESCRIPTION
## Summary
- Integration tests now only run on pushes to main with actual source changes (`src/`, `test/`, `scripts/`)
- PRs get lint, build, and unit tests only — integration tests run after merge
- Version bump commits (package.json/package-lock.json only) skip integration tests, so releases aren't blocked by rate limits

## Why
Integration test polling hammers the GitHub API, hitting secondary rate limits (HTTP 403) that block releases and other operations.

## Test plan
- [ ] PR CI runs lint + build + unit tests (no integration tests)
- [ ] After merge, push to main with src/ changes triggers integration tests
- [ ] Release workflow version bump (package.json only) skips integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)