### PR TITLE
fix(settings): use desired visibility when validating security settings

### DIFF
--- a/src/settings/repo-settings/processor.ts
+++ b/src/settings/repo-settings/processor.ts
@@ -183,7 +183,11 @@ export class RepoSettingsProcessor implements IRepoSettingsProcessor {
     currentSettings: CurrentRepoSettings
   ): string[] {
     const errors: string[] = [];
-    const isPublic = currentSettings.visibility === "public";
+    // Use desired visibility if specified (repo may be transitioning to public),
+    // otherwise fall back to current visibility
+    const effectiveVisibility =
+      desiredSettings.visibility ?? currentSettings.visibility;
+    const isPublic = effectiveVisibility === "public";
 
     // privateVulnerabilityReporting is only available on public repos
     if (desiredSettings.privateVulnerabilityReporting === true && !isPublic) {

--- a/test/unit/repo-settings-processor.test.ts
+++ b/test/unit/repo-settings-processor.test.ts
@@ -801,5 +801,87 @@ describe("RepoSettingsProcessor", () => {
       assert.ok(result.message.includes("secretScanningPushProtection"));
       assert.ok(result.message.includes("privateVulnerabilityReporting"));
     });
+
+    test("should allow security settings when visibility is transitioning from private to public", async () => {
+      mockStrategy.getSettingsResult = {
+        visibility: "private",
+        owner_type: "User",
+        private_vulnerability_reporting: false,
+      };
+
+      const processor = new RepoSettingsProcessor(mockStrategy);
+      const repoConfig: RepoConfig = {
+        git: githubRepo.gitUrl,
+        files: [],
+        settings: {
+          repo: {
+            visibility: "public",
+            secretScanning: true,
+            secretScanningPushProtection: true,
+            privateVulnerabilityReporting: true,
+          },
+        },
+      };
+
+      const result = await processor.process(repoConfig, githubRepo, {
+        dryRun: true,
+      });
+
+      assert.equal(result.success, true);
+    });
+
+    test("should allow security settings when visibility is transitioning from internal to public", async () => {
+      mockStrategy.getSettingsResult = {
+        visibility: "internal",
+        owner_type: "Organization",
+      };
+
+      const processor = new RepoSettingsProcessor(mockStrategy);
+      const repoConfig: RepoConfig = {
+        git: githubRepo.gitUrl,
+        files: [],
+        settings: {
+          repo: {
+            visibility: "public",
+            secretScanning: true,
+            privateVulnerabilityReporting: true,
+          },
+        },
+      };
+
+      const result = await processor.process(repoConfig, githubRepo, {
+        dryRun: true,
+      });
+
+      assert.equal(result.success, true);
+    });
+
+    test("should still fail when desired visibility is also private", async () => {
+      mockStrategy.getSettingsResult = {
+        visibility: "private",
+        owner_type: "User",
+      };
+
+      const processor = new RepoSettingsProcessor(mockStrategy);
+      const repoConfig: RepoConfig = {
+        git: githubRepo.gitUrl,
+        files: [],
+        settings: {
+          repo: {
+            visibility: "private",
+            secretScanning: true,
+            privateVulnerabilityReporting: true,
+          },
+        },
+      };
+
+      const result = await processor.process(repoConfig, githubRepo, {
+        dryRun: false,
+      });
+
+      assert.equal(result.success, false);
+      assert.ok(result.message.includes("secretScanning"));
+      assert.ok(result.message.includes("privateVulnerabilityReporting"));
+    });
   });
 });


### PR DESCRIPTION
Closes #641

## Summary

- Use the desired visibility (from config) instead of only the current repo visibility when validating security settings compatibility
- When a config sets `visibility: public` alongside `secretScanning`, `secretScanningPushProtection`, or `privateVulnerabilityReporting`, the sync now correctly allows these settings for repos transitioning from private to public
- Repos that remain private (no visibility change or `visibility: private` in config) still correctly fail validation

## Test plan

- [x] Unit tests pass (`npm test` — 2312 passing)
- [x] Test typecheck passes (`npm run test:typecheck`)
- [x] Build passes (`npm run build`)
- [ ] CI passes
- [ ] Integration tests: `npm run test:integration:github`

🤖 Generated with [Claude Code](https://claude.com/claude-code)