### PR TITLE
ci: enable integration tests on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,7 @@ jobs:
     needs:
       - "build"
       - "check-changes"
-    if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.integration-needed == 'true' && github.event_name == 'push' }}
+    if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.integration-needed == 'true' }}
     uses: ./.github/workflows/_integration-tests.yaml
     secrets: "inherit"
 


### PR DESCRIPTION
Closes #647

## Summary
- Remove the `github.event_name == 'push'` gate from the integration tests job
- Integration tests now run on both PRs and pushes to main (when source changes are detected)
- Safe to enable thanks to the concurrency group and wave-based pacing added in #652

## Test plan
- [ ] Integration tests run on this PR itself (self-validating)
- [ ] Verify concurrency group prevents parallel workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)