### PR TITLE
fix(ci): revert repo-operator workflow pins to @main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
 
   lint:
     if: github.event_name == 'pull_request'
-    uses: "anthony-spruyt/repo-operator/.github/workflows/_lint.yaml@605fcdfab864797e519666120966a1e2b999eb0b" # main
+    uses: "anthony-spruyt/repo-operator/.github/workflows/_lint.yaml@main"
     secrets: "inherit"
 
   build:
@@ -139,4 +139,4 @@ jobs:
       - "build"
       - "integration-tests"
     if: "always()"
-    uses: "anthony-spruyt/repo-operator/.github/workflows/_summary.yaml@605fcdfab864797e519666120966a1e2b999eb0b" # main
+    uses: "anthony-spruyt/repo-operator/.github/workflows/_summary.yaml@main"

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -12,4 +12,4 @@ permissions:
   issues: "write"
 jobs:
   scan:
-    uses: "anthony-spruyt/repo-operator/.github/workflows/_trivy-scan.yaml@605fcdfab864797e519666120966a1e2b999eb0b" # main
+    uses: "anthony-spruyt/repo-operator/.github/workflows/_trivy-scan.yaml@main"


### PR DESCRIPTION
## Summary

- Reverts digest-pinned references to `anthony-spruyt/repo-operator` reusable workflows back to `@main` in `ci.yaml` and `trivy-scan.yaml`
- Digest pinning on these internal workflows adds renovation churn with no security benefit, since repo-operator already has write access via xfg sync

## Test plan

- [ ] Verify CI workflow runs successfully with `@main` references
- [ ] Verify Trivy scan workflow triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)