### PR TITLE
chore: add cclsp MCP server for LSP diagnostics

### DIFF
--- a/.claude/cclsp.json
+++ b/.claude/cclsp.json
@@ -1,74 +1,9 @@
 {
   "servers": [
     {
-      "extensions": [
-        "js",
-        "ts",
-        "jsx",
-        "tsx"
-      ],
-      "command": [
-        "npx",
-        "--",
-        "typescript-language-server",
-        "--stdio"
-      ],
+      "extensions": ["js", "ts", "jsx", "tsx"],
+      "command": ["npx", "--", "typescript-language-server", "--stdio"],
       "rootDir": "."
-    },
-    {
-      "extensions": [
-        "py",
-        "pyi"
-      ],
-      "command": [
-        "uvx",
-        "--from",
-        "python-lsp-server",
-        "pylsp"
-      ],
-      "rootDir": ".",
-      "restartInterval": 5,
-      "initializationOptions": {
-        "settings": {
-          "pylsp": {
-            "plugins": {
-              "jedi_completion": {
-                "enabled": true
-              },
-              "jedi_definition": {
-                "enabled": true
-              },
-              "jedi_hover": {
-                "enabled": true
-              },
-              "jedi_references": {
-                "enabled": true
-              },
-              "jedi_signature_help": {
-                "enabled": true
-              },
-              "jedi_symbols": {
-                "enabled": true
-              },
-              "pylint": {
-                "enabled": false
-              },
-              "pycodestyle": {
-                "enabled": false
-              },
-              "pyflakes": {
-                "enabled": false
-              },
-              "yapf": {
-                "enabled": false
-              },
-              "rope_completion": {
-                "enabled": false
-              }
-            }
-          }
-        }
-      }
     }
   ]
 }

--- a/.devcontainer/setup-devcontainer.sh
+++ b/.devcontainer/setup-devcontainer.sh
@@ -21,6 +21,12 @@ curl -sL -o /tmp/gcm.deb https://github.com/git-ecosystem/git-credential-manager
 sudo dpkg -i /tmp/gcm.deb
 rm /tmp/gcm.deb
 
+# renovate: depName=cclsp datasource=npm
+CCLSP_VERSION="0.7.0"
+
+echo "Installing cclsp ${CCLSP_VERSION}..."
+npm install -g "cclsp@${CCLSP_VERSION}"
+
 # Install and build the project
 echo "Installing project dependencies..."
 cd "/workspaces/xfg"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "cclsp": {
+      "type": "stdio",
+      "command": "cclsp",
+      "env": {
+        "CCLSP_CONFIG_PATH": "/workspaces/xfg/.claude/cclsp.json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #N/A

## Summary
- Add `.mcp.json` with cclsp stdio server config for Claude Code LSP integration
- Simplify `.claude/cclsp.json` to TypeScript/JavaScript only (remove unused Python server)
- Install `cclsp@0.7.0` in devcontainer setup with renovate-managed versioning

## Test plan
- [x] Verified cclsp MCP connects and `get_diagnostics` returns results
- [ ] Rebuild devcontainer and verify cclsp installs automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)