### PR TITLE
fix: resolve file references in conditional group files

### DIFF
--- a/src/config/file-reference-resolver.ts
+++ b/src/config/file-reference-resolver.ts
@@ -189,6 +189,26 @@ export function resolveFileReferencesInConfig(
     }
   }
 
+  // Resolve conditional group file content
+  if (result.conditionalGroups) {
+    for (const cg of result.conditionalGroups) {
+      if (cg.files) {
+        for (const [fileName, fileConfig] of Object.entries(cg.files)) {
+          if (
+            fileConfig &&
+            typeof fileConfig === "object" &&
+            "content" in fileConfig
+          ) {
+            const resolved = resolveContentValue(fileConfig.content, configDir);
+            if (resolved !== undefined) {
+              cg.files[fileName] = { ...fileConfig, content: resolved };
+            }
+          }
+        }
+      }
+    }
+  }
+
   // Resolve per-repo file content
   if (result.repos) {
     for (const repo of result.repos) {

--- a/test/unit/file-reference-resolver.test.ts
+++ b/test/unit/file-reference-resolver.test.ts
@@ -548,4 +548,109 @@ describe("File Reference Resolver", () => {
       assert.deepStrictEqual(groupFile.content, { fromGroup: true });
     });
   });
+
+  describe("conditional group file references", () => {
+    test("resolves @file refs in conditional group file content", () => {
+      const yamlPath = join(testDir, "templates", "trivy.yaml");
+      writeFileSync(yamlPath, "severity: HIGH\n", "utf-8");
+
+      const raw: RawConfig = {
+        id: "test",
+        files: {},
+        groups: {
+          a: { files: { "a.txt": { content: "a" } } },
+        },
+        conditionalGroups: [
+          {
+            when: { anyOf: ["a"] },
+            files: {
+              "trivy.yaml": { content: "@templates/trivy.yaml" },
+            },
+          },
+        ],
+        repos: [{ git: "git@github.com:org/repo.git", groups: ["a"] }],
+      };
+
+      const result = resolveFileReferencesInConfig(raw, { configDir: testDir });
+      const condFile = result.conditionalGroups![0].files![
+        "trivy.yaml"
+      ] as RawFileConfig;
+      assert.deepStrictEqual(condFile.content, { severity: "HIGH" });
+    });
+
+    test("resolves @file refs for text files in conditional groups", () => {
+      const txtPath = join(testDir, "templates", "ignore.txt");
+      writeFileSync(txtPath, "ignore this\n", "utf-8");
+
+      const raw: RawConfig = {
+        id: "test",
+        files: {},
+        groups: {
+          a: { files: { "a.txt": { content: "a" } } },
+        },
+        conditionalGroups: [
+          {
+            when: { anyOf: ["a"] },
+            files: {
+              "ignore.txt": { content: "@templates/ignore.txt" },
+            },
+          },
+        ],
+        repos: [{ git: "git@github.com:org/repo.git", groups: ["a"] }],
+      };
+
+      const result = resolveFileReferencesInConfig(raw, { configDir: testDir });
+      const condFile = result.conditionalGroups![0].files![
+        "ignore.txt"
+      ] as RawFileConfig;
+      assert.strictEqual(condFile.content, "ignore this\n");
+    });
+
+    test("preserves non-reference content in conditional groups", () => {
+      const raw: RawConfig = {
+        id: "test",
+        files: {},
+        groups: {
+          a: { files: { "a.txt": { content: "a" } } },
+        },
+        conditionalGroups: [
+          {
+            when: { anyOf: ["a"] },
+            files: {
+              "readme.txt": { content: "plain string" },
+            },
+          },
+        ],
+        repos: [{ git: "git@github.com:org/repo.git", groups: ["a"] }],
+      };
+
+      const result = resolveFileReferencesInConfig(raw, { configDir: testDir });
+      const condFile = result.conditionalGroups![0].files![
+        "readme.txt"
+      ] as RawFileConfig;
+      assert.strictEqual(condFile.content, "plain string");
+    });
+
+    test("preserves file exclusions in conditional groups", () => {
+      const raw: RawConfig = {
+        id: "test",
+        files: {},
+        groups: {
+          a: { files: { "a.txt": { content: "a" } } },
+        },
+        conditionalGroups: [
+          {
+            when: { anyOf: ["a"] },
+            files: {
+              "a.txt": false,
+            },
+          },
+        ],
+        repos: [{ git: "git@github.com:org/repo.git", groups: ["a"] }],
+      };
+
+      const result = resolveFileReferencesInConfig(raw, { configDir: testDir });
+      assert.strictEqual(result.conditionalGroups![0].files!["a.txt"], false);
+    });
+  });
 });


### PR DESCRIPTION
Closes #666

## Summary

- `resolveFileReferencesInConfig` was missing the `conditionalGroups` case, so `@file` references (e.g. `content: "@templates/trivy.yaml"`) in conditional group files were passed through as literal strings
- This caused validation to reject structured files with "has JSON/YAML extension but string content"
- Added the missing resolution loop for conditional group files, matching the existing pattern for root/group/repo files

## Test plan

- [x] Added 4 regression tests for conditional group file references (YAML, text, non-reference, exclusions)
- [x] All 2448 unit tests pass
- [x] `npm run test:typecheck` passes
- [x] `./lint.sh` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)