### PR TITLE
ci: gate PR integration tests behind label or test file changes

### DIFF
--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -55,5 +55,8 @@ Lifecycle tests (create/fork/migrate) create and delete repos as part of their t
 
 ## CI Workflow
 
-- GitHub integration tests only run on `push` to `main` (not on PR branches)
-- All jobs run in parallel after `build` - never chain GitHub jobs with `needs`
+- Integration tests always run on `push` to `main` (when source changes detected)
+- On PRs, integration tests only run when:
+  - The `run-integration` label is added to the PR, OR
+  - Integration test files (`test/integration/`) are changed
+- GitHub integration jobs are chained via `needs` in batches to avoid API rate limits

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - "main"
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - "main"
@@ -35,6 +36,7 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           COMMIT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-integration') }}
         run: |
           set -euo pipefail
 
@@ -52,14 +54,27 @@ jobs:
             echo "No code changes, will skip build and integration tests"
           fi
 
-          # Integration tests only needed for source/test/script changes,
-          # not version-only bumps (package.json + package-lock.json)
-          if echo "$CHANGED" | grep -qE '^(src/|test/|scripts/)'; then
-            echo "integration-needed=true" >> "$GITHUB_OUTPUT"
-            echo "Source changes detected — integration tests needed"
+          # Integration tests: always on push to main (source changes),
+          # on PRs only with 'run-integration' label or integration test changes
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$HAS_LABEL" = "true" ]; then
+              echo "integration-needed=true" >> "$GITHUB_OUTPUT"
+              echo "PR has 'run-integration' label — integration tests enabled"
+            elif echo "$CHANGED" | grep -qE '^test/integration/'; then
+              echo "integration-needed=true" >> "$GITHUB_OUTPUT"
+              echo "Integration test files changed — integration tests enabled"
+            else
+              echo "integration-needed=false" >> "$GITHUB_OUTPUT"
+              echo "PR without integration label — skipping integration tests"
+            fi
           else
-            echo "integration-needed=false" >> "$GITHUB_OUTPUT"
-            echo "No source changes — skipping integration tests"
+            if echo "$CHANGED" | grep -qE '^(src/|test/|scripts/)'; then
+              echo "integration-needed=true" >> "$GITHUB_OUTPUT"
+              echo "Source changes detected — integration tests needed"
+            else
+              echo "integration-needed=false" >> "$GITHUB_OUTPUT"
+              echo "No source changes — skipping integration tests"
+            fi
           fi
 
           echo "Changed files:"


### PR DESCRIPTION
## Summary

- Integration tests on PRs now only run when the `run-integration` label is present or `test/integration/` files are changed
- Push to main retains existing behavior (run integration tests on source changes)
- Added `labeled` event type to PR trigger so adding the label re-runs CI
- Created the `run-integration` label on the repo
- Saves CI minutes on routine PRs

## Test plan

- [ ] PR without label should skip integration tests (this PR itself)
- [ ] Adding `run-integration` label should trigger integration tests
- [ ] Push to main should still run integration tests on source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)