### PR TITLE
fix(ci): rename APP_ID vars to CLIENT_ID and use client-id input

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,8 +7,8 @@
 self-hosted-runner:
   labels: []
 config-variables:
-  - RELEASE_APP_ID
-  - TEST_APP_ID
+  - RELEASE_CLIENT_ID
+  - TEST_CLIENT_ID
 paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Act — run GitHub App integration tests
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_ORG }}
-          XFG_GITHUB_APP_ID: ${{ vars.TEST_APP_ID }}
+          XFG_GITHUB_APP_ID: ${{ vars.TEST_CLIENT_ID }}
           XFG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
         run: npm run test:integration:github-app
 
@@ -257,7 +257,7 @@ jobs:
           # Include github-token to simulate real usage where both are set
           # This tests that GitHub App credentials take precedence over PAT
           github-token: ${{ github.token }}
-          github-app-id: ${{ vars.TEST_APP_ID }}
+          github-app-id: ${{ vars.TEST_CLIENT_ID }}
           github-app-private-key: ${{ secrets.TEST_APP_PRIVATE_KEY }}
           xfg-package: "./${{ env.XFG_PACKAGE }}"
 
@@ -388,7 +388,7 @@ jobs:
       - name: Run lifecycle integration tests (GitHub App)
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_ORG }}
-          XFG_GITHUB_APP_ID: ${{ vars.TEST_APP_ID }}
+          XFG_GITHUB_APP_ID: ${{ vars.TEST_CLIENT_ID }}
           XFG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
           AZURE_DEVOPS_EXT_PAT: ${{ secrets.AZURE_DEVOPS_EXT_PAT }}
         run: npm run test:integration:github-lifecycle-app
@@ -487,7 +487,7 @@ jobs:
           config: /tmp/lifecycle-action-app-config.yaml
           merge: direct
           github-token: ${{ github.token }}
-          github-app-id: ${{ vars.TEST_APP_ID }}
+          github-app-id: ${{ vars.TEST_CLIENT_ID }}
           github-app-private-key: ${{ secrets.TEST_APP_PRIVATE_KEY }}
           xfg-package: "./${{ env.XFG_PACKAGE }}"
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Setup Node.js


### PR DESCRIPTION
## Summary

- Repo variables `RELEASE_APP_ID`/`TEST_APP_ID` were renamed on GitHub to `RELEASE_CLIENT_ID`/`TEST_CLIENT_ID` (they already held Client IDs). Update workflow references.
- Switch `actions/create-github-app-token` from deprecated `app-id` input to `client-id` in `release.yaml` and `docs.yaml`.
- Update `actionlint.yaml` config-variables list to match.

xfg-internal env var `XFG_GITHUB_APP_ID` and the `github-app-id` action input on this repo's own action are **not** changed here — tracked as a follow-up issue.

## Test plan

- [ ] CI green on this PR
- [ ] Release workflow succeeds after merge (next release)
- [ ] Docs deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)