### PR TITLE
feat!: rename github-app-id to github-client-id (v6.0.0)

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Act — run GitHub App integration tests
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_ORG }}
-          XFG_GITHUB_APP_ID: ${{ vars.TEST_CLIENT_ID }}
+          XFG_GITHUB_CLIENT_ID: ${{ vars.TEST_CLIENT_ID }}
           XFG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
         run: npm run test:integration:github-app
 
@@ -257,7 +257,7 @@ jobs:
           # Include github-token to simulate real usage where both are set
           # This tests that GitHub App credentials take precedence over PAT
           github-token: ${{ github.token }}
-          github-app-id: ${{ vars.TEST_CLIENT_ID }}
+          github-client-id: ${{ vars.TEST_CLIENT_ID }}
           github-app-private-key: ${{ secrets.TEST_APP_PRIVATE_KEY }}
           xfg-package: "./${{ env.XFG_PACKAGE }}"
 
@@ -388,7 +388,7 @@ jobs:
       - name: Run lifecycle integration tests (GitHub App)
         env:
           GH_TOKEN: ${{ secrets.GH_PAT_ORG }}
-          XFG_GITHUB_APP_ID: ${{ vars.TEST_CLIENT_ID }}
+          XFG_GITHUB_CLIENT_ID: ${{ vars.TEST_CLIENT_ID }}
           XFG_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
           AZURE_DEVOPS_EXT_PAT: ${{ secrets.AZURE_DEVOPS_EXT_PAT }}
         run: npm run test:integration:github-lifecycle-app
@@ -487,7 +487,7 @@ jobs:
           config: /tmp/lifecycle-action-app-config.yaml
           merge: direct
           github-token: ${{ github.token }}
-          github-app-id: ${{ vars.TEST_CLIENT_ID }}
+          github-client-id: ${{ vars.TEST_CLIENT_ID }}
           github-app-private-key: ${{ secrets.TEST_APP_PRIVATE_KEY }}
           xfg-package: "./${{ env.XFG_PACKAGE }}"
 

--- a/action.yml
+++ b/action.yml
@@ -45,8 +45,8 @@ inputs:
   gitlab-token:
     description: "GitLab token for authentication"
     required: false
-  github-app-id:
-    description: "GitHub App ID (generates installation tokens automatically)"
+  github-client-id:
+    description: "GitHub App Client ID (generates installation tokens automatically)"
     required: false
   github-app-private-key:
     description: "GitHub App private key (PEM format) for JWT signing"
@@ -126,7 +126,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
-        XFG_GITHUB_APP_ID: ${{ inputs.github-app-id }}
+        XFG_GITHUB_CLIENT_ID: ${{ inputs.github-client-id }}
         XFG_GITHUB_APP_PRIVATE_KEY: ${{ inputs.github-app-private-key }}
         AZURE_DEVOPS_EXT_PAT: ${{ inputs.azure-devops-token }}
         GITLAB_TOKEN: ${{ inputs.gitlab-token }}

--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -26,7 +26,7 @@ The simplest way to use xfg in GitHub Actions is with the official action:
 | `merge-strategy`         | No       | -                     | Merge strategy (`merge`/`squash`/`rebase`)                 |
 | `delete-branch`          | No       | `false`               | Delete branch after merge                                  |
 | `github-token`           | No       | `${{ github.token }}` | GitHub token for authentication                            |
-| `github-app-id`          | No       | -                     | GitHub App ID for installation token generation            |
+| `github-client-id`       | No       | -                     | GitHub App Client ID for installation token generation     |
 | `github-app-private-key` | No       | -                     | GitHub App private key (PEM) for JWT signing               |
 | `azure-devops-token`     | No       | -                     | Azure DevOps Personal Access Token                         |
 | `gitlab-token`           | No       | -                     | GitLab token for authentication                            |
@@ -99,7 +99,7 @@ jobs:
       - uses: anthony-spruyt/xfg@v5
         with:
           config: ./sync-config.yml
-          github-app-id: ${{ vars.APP_ID }}
+          github-client-id: ${{ vars.CLIENT_ID }}
           github-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
 ```
 

--- a/docs/platforms/github-app.md
+++ b/docs/platforms/github-app.md
@@ -36,7 +36,7 @@ For enterprises that prefer GitHub Apps over personal access tokens (PATs).
 
 In your GitHub repository:
 
-- **Variables:** `APP_ID` (the numeric app ID)
+- **Variables:** `CLIENT_ID` (the GitHub App Client ID, starts with `Iv23`)
 - **Secrets:** `APP_PRIVATE_KEY` (contents of the .pem file)
 
 ### 4. Update Your Workflow
@@ -51,7 +51,7 @@ jobs:
       - uses: anthony-spruyt/xfg@v5
         with:
           config: sync-config.yaml
-          github-app-id: ${{ vars.APP_ID }}
+          github-client-id: ${{ vars.CLIENT_ID }}
           github-app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
 ```
 
@@ -79,13 +79,13 @@ This uses GitHub's `createCommitOnBranch` mutation instead of git commands, whic
 
 ## Environment Variables
 
-| Variable                     | Auth Type  | Description                              |
-| ---------------------------- | ---------- | ---------------------------------------- |
-| `XFG_GITHUB_APP_ID`          | GitHub App | App ID for installation token generation |
-| `XFG_GITHUB_APP_PRIVATE_KEY` | GitHub App | Private key (PEM) for JWT signing        |
-| `GH_TOKEN`                   | PAT        | Personal Access Token for GitHub API     |
+| Variable                     | Auth Type  | Description                                            |
+| ---------------------------- | ---------- | ------------------------------------------------------ |
+| `XFG_GITHUB_CLIENT_ID`       | GitHub App | GitHub App Client ID for installation token generation |
+| `XFG_GITHUB_APP_PRIVATE_KEY` | GitHub App | Private key (PEM) for JWT signing                      |
+| `GH_TOKEN`                   | PAT        | Personal Access Token for GitHub API                   |
 
-When `XFG_GITHUB_APP_ID` and `XFG_GITHUB_APP_PRIVATE_KEY` are set, xfg uses GitHub App authentication with automatic per-installation token generation. For repositories without app access, xfg will skip processing with a warning.
+When `XFG_GITHUB_CLIENT_ID` and `XFG_GITHUB_APP_PRIVATE_KEY` are set, xfg uses GitHub App authentication with automatic per-installation token generation. For repositories without app access, xfg will skip processing with a warning.
 
 > **Note:** You can also get verified commits with PATs by [configuring GPG signing](https://docs.github.com/en/authentication/managing-commit-signature-verification). GitHub App authentication is an alternative that doesn't require GPG key management.
 
@@ -111,7 +111,7 @@ The app lacks required permissions. Check that:
 
 ### Commits not showing as verified
 
-Ensure you're using GitHub App authentication (`github-app-id` and `github-app-private-key` inputs). Only installation tokens from GitHub Apps trigger the GraphQL verified commit flow.
+Ensure you're using GitHub App authentication (`github-client-id` and `github-app-private-key` inputs). Only installation tokens from GitHub Apps trigger the GraphQL verified commit flow.
 
 ### Payload too large
 

--- a/docs/platforms/github-app.md
+++ b/docs/platforms/github-app.md
@@ -23,7 +23,7 @@ For enterprises that prefer GitHub Apps over personal access tokens (PATs).
      - Pull requests: Read and write
      - Workflows: Read and write _(required if syncing `.github/workflows/` files)_
    - **Where can this GitHub App be installed?** Any account
-4. Create the app and note the **App ID**
+4. Create the app and note the **Client ID** (starts with `Iv23`)
 5. Generate a **private key** (downloads a .pem file)
 
 ### 2. Install the App
@@ -66,7 +66,7 @@ This approach:
 
 When GitHub App credentials are provided, xfg:
 
-1. **Generates a JWT** using your App ID and private key
+1. **Generates a JWT** using your Client ID and private key
 2. **Discovers installations** by calling GitHub's API to list all installations
 3. **Generates installation tokens** per-installation (tokens are cached for 55 minutes)
 4. **Uses GraphQL API** for commits with the installation token, creating verified commits

--- a/plans/superpowers/plans/2026-04-15-rename-app-id-to-client-id.md
+++ b/plans/superpowers/plans/2026-04-15-rename-app-id-to-client-id.md
@@ -157,14 +157,14 @@ git commit -m "refactor(vcs)!: rename GitHubAppTokenManager appId to clientId"
 
 ---
 
-## Task 3: Rename `AppCredentials` in `commit-strategy-selector.ts`
+## Task 3: Rename `GitHubAppCredentials` in `commit-strategy-selector.ts`
 
 **Files:**
 - Modify: `src/vcs/commit-strategy-selector.ts:10-23`
 
 - [ ] **Step 1: Rename the type field and the constructor argument**
 
-In `src/vcs/commit-strategy-selector.ts`, change line 10 from `appId: string;` to `clientId: string;`, and change line 23 from `new GitHubAppTokenManager(credentials.appId, credentials.privateKey)` to `new GitHubAppTokenManager(credentials.clientId, credentials.privateKey)`.
+In `src/vcs/commit-strategy-selector.ts` (in the `GitHubAppCredentials` interface and the `createTokenManager` function), change line 10 from `appId: string;` to `clientId: string;`, and change line 23 from `new GitHubAppTokenManager(credentials.appId, credentials.privateKey)` to `new GitHubAppTokenManager(credentials.clientId, credentials.privateKey)`.
 
 - [ ] **Step 2: Verify**
 
@@ -441,7 +441,7 @@ git commit -m "ci!: rename github-app-id to github-client-id in integration work
 
 - [ ] **Step 1: Update `docs/platforms/github-app.md`**
 
-- Line 39: `**Variables:** \`APP_ID\` (the numeric app ID)` → `**Variables:** \`CLIENT_ID\` (the GitHub App Client ID, starts with \`Iv23\`)`
+- Line 39: `- **Variables:** \`APP_ID\` (the numeric app ID)` → `- **Variables:** \`CLIENT_ID\` (the GitHub App Client ID, starts with \`Iv23\`)`
 - Line 54: `github-app-id: ${{ vars.APP_ID }}` → `github-client-id: ${{ vars.CLIENT_ID }}`
 - Line 84: in the env var table, `XFG_GITHUB_APP_ID` → `XFG_GITHUB_CLIENT_ID` and description `App ID for installation token generation` → `GitHub App Client ID for installation token generation`
 - Line 88: `When \`XFG_GITHUB_APP_ID\` and \`XFG_GITHUB_APP_PRIVATE_KEY\` are set` → `When \`XFG_GITHUB_CLIENT_ID\` and \`XFG_GITHUB_APP_PRIVATE_KEY\` are set`

--- a/plans/superpowers/plans/2026-04-15-rename-app-id-to-client-id.md
+++ b/plans/superpowers/plans/2026-04-15-rename-app-id-to-client-id.md
@@ -1,0 +1,569 @@
+# Rename `appId` → `clientId` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename all xfg-owned `appId` / `XFG_GITHUB_APP_ID` / `github-app-id` names to `clientId` / `XFG_GITHUB_CLIENT_ID` / `github-client-id` (breaking, v6.0.0). Closes #700.
+
+**Architecture:** Pure rename with no behavior change. External surface (action input + env var) renames without backwards-compatible alias. Internal TypeScript identifiers (`appId` param/field, `TEST_APP_ID` fixture, test variables) renamed end-to-end. Octokit's `createAppAuth({ appId })` parameter name is third-party and not touched; it already accepts Client IDs.
+
+**Tech Stack:** TypeScript, Node.js, GitHub Actions (composite action), Vitest unit tests, integration tests against real platforms.
+
+**Spec:** `plans/superpowers/specs/2026-04-15-rename-app-id-to-client-id-design.md`
+
+---
+
+## File Map
+
+**Production code (modify):**
+- `action.yml` — input key + env var passthrough
+- `src/vcs/github-app-token-manager.ts` — constructor param, private field, JWT iss
+- `src/vcs/commit-strategy-selector.ts` — `AppCredentials.appId` type field + usage
+- `src/cli/sync-command.ts` — `process.env.XFG_GITHUB_APP_ID` reads + factory options key
+
+**Tests (modify):**
+- `test/fixtures/test-fixtures.ts` — `TEST_APP_ID` export
+- `test/unit/github-app-token-manager.test.ts` — all references (21 call sites + `creates instance with appId` test name + `JWT payload has correct issuer (appId)` test name)
+- `test/unit/vcs/commit-strategy-selector.test.ts` — fixture key
+- `test/unit/repository-processor.test.ts` — `process.env.XFG_GITHUB_APP_ID` (many sites), `originalAppId` locals, `TEST_APP_ID` import/usage, `appId: "12345"` fixture
+- `test/integration/github-app.test.ts` — env var checks + skip message + unset block
+- `test/integration/github-lifecycle-app.test.ts` — env var checks + skip message
+
+**Docs (modify):**
+- `docs/platforms/github-app.md`
+- `docs/ci-cd/github-actions.md`
+- `README.md` — grep first (likely mentions input name)
+
+**Workflow (modify):**
+- `.github/workflows/_integration-tests.yaml` — 2 × `XFG_GITHUB_APP_ID` env keys (lines 107, 391). (Lines 260 and 490 already use `github-app-id` input → update to `github-client-id`.)
+
+**Out of scope:**
+- `plans/2026-03-29-file-mode-fixup-commit-plan.md` — historical plan; do not edit
+- `.desloppify/**` — scanner state; will re-scan after merge
+- `docs/superpowers/**` and `plans/superpowers/**` spec/plan references — historical
+
+---
+
+## Task 1: Rename external surface (`action.yml`)
+
+**Files:**
+- Modify: `action.yml`
+
+- [ ] **Step 1: Update input key and env passthrough**
+
+Replace the input definition around line 48:
+
+```yaml
+  github-client-id:
+    description: "GitHub App Client ID (generates installation tokens automatically)"
+    required: false
+```
+
+And the env passthrough around line 129:
+
+```yaml
+        XFG_GITHUB_CLIENT_ID: ${{ inputs.github-client-id }}
+```
+
+- [ ] **Step 2: Verify no other references**
+
+Run: `grep -n "github-app-id\|XFG_GITHUB_APP_ID" action.yml`
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add action.yml
+git commit -m "feat(action)!: rename github-app-id input to github-client-id"
+```
+
+---
+
+## Task 2: Rename `GitHubAppTokenManager` internals
+
+**Files:**
+- Modify: `src/vcs/github-app-token-manager.ts:38-71`
+
+- [ ] **Step 1: Rename field, constructor param, and JWT iss claim**
+
+In `src/vcs/github-app-token-manager.ts`, replace lines 37–71 so the class opens like this:
+
+```ts
+export class GitHubAppTokenManager {
+  private readonly clientId: string;
+  private readonly privateKey: string;
+
+  /** Map of "apiHost:owner" -> installation ID */
+  private installations = new Map<string, number>();
+
+  /** Set of API hosts that have been discovered */
+  private discoveredHosts = new Set<string>();
+
+  /** Map of "apiHost:owner" -> cached token */
+  private tokenCache = new Map<string, CachedToken>();
+
+  constructor(clientId: string, privateKey: string) {
+    this.clientId = clientId;
+    this.privateKey = privateKey;
+  }
+
+  /**
+   * Generates a JWT for GitHub App authentication.
+   * The JWT is signed with RS256 and valid for 10 minutes.
+   */
+  generateJWT(): string {
+    const now = Math.floor(Date.now() / 1000);
+
+    const header = {
+      alg: "RS256",
+      typ: "JWT",
+    };
+
+    const payload = {
+      iat: now - 60, // Issued 60 seconds ago to account for clock drift
+      exp: now + 600, // Expires in 10 minutes
+      iss: this.clientId,
+    };
+```
+
+(Rest of file unchanged.)
+
+- [ ] **Step 2: Verify no stray `appId` left in the file**
+
+Run: `grep -n "appId" src/vcs/github-app-token-manager.ts`
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vcs/github-app-token-manager.ts
+git commit -m "refactor(vcs)!: rename GitHubAppTokenManager appId to clientId"
+```
+
+---
+
+## Task 3: Rename `AppCredentials` in `commit-strategy-selector.ts`
+
+**Files:**
+- Modify: `src/vcs/commit-strategy-selector.ts:10-23`
+
+- [ ] **Step 1: Rename the type field and the constructor argument**
+
+In `src/vcs/commit-strategy-selector.ts`, change line 10 from `appId: string;` to `clientId: string;`, and change line 23 from `new GitHubAppTokenManager(credentials.appId, credentials.privateKey)` to `new GitHubAppTokenManager(credentials.clientId, credentials.privateKey)`.
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "appId\|APP_ID" src/vcs/commit-strategy-selector.ts`
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/vcs/commit-strategy-selector.ts
+git commit -m "refactor(vcs)!: rename AppCredentials.appId to clientId"
+```
+
+---
+
+## Task 4: Rename env var reads and factory key in `sync-command.ts`
+
+**Files:**
+- Modify: `src/cli/sync-command.ts:690-697`
+
+- [ ] **Step 1: Replace the token-manager construction block**
+
+Replace lines 690–697 with:
+
+```ts
+  const tokenManager = createTokenManager(
+    process.env.XFG_GITHUB_CLIENT_ID && process.env.XFG_GITHUB_APP_PRIVATE_KEY
+      ? {
+          clientId: process.env.XFG_GITHUB_CLIENT_ID,
+          privateKey: process.env.XFG_GITHUB_APP_PRIVATE_KEY,
+        }
+      : undefined
+  );
+```
+
+Note: `XFG_GITHUB_APP_PRIVATE_KEY` is intentionally unchanged — only the ID name is in scope for this rename.
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "XFG_GITHUB_APP_ID\|appId" src/cli/sync-command.ts`
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/sync-command.ts
+git commit -m "refactor(cli)!: read XFG_GITHUB_CLIENT_ID instead of XFG_GITHUB_APP_ID"
+```
+
+---
+
+## Task 5: Verify build + run unit tests (fail-first expected)
+
+- [ ] **Step 1: TypeScript build**
+
+Run: `npm run build`
+Expected: FAIL — tests still reference `TEST_APP_ID` and unrenamed fixture keys, compile errors in `src/` should all be gone. Any compile errors should be in test files only. If any compile error is in `src/**`, STOP and fix before proceeding.
+
+- [ ] **Step 2: Run unit tests**
+
+Run: `npm test`
+Expected: FAIL in `test/unit/github-app-token-manager.test.ts`, `test/unit/vcs/commit-strategy-selector.test.ts`, `test/unit/repository-processor.test.ts` (missing `TEST_APP_ID`, wrong fixture key, wrong env var).
+
+This is the red state — proceed to Task 6.
+
+---
+
+## Task 6: Rename test fixtures
+
+**Files:**
+- Modify: `test/fixtures/test-fixtures.ts:37`
+
+- [ ] **Step 1: Rename the export**
+
+Change line 37 from:
+
+```ts
+export const TEST_APP_ID = "12345";
+```
+
+to:
+
+```ts
+export const TEST_CLIENT_ID = "12345";
+```
+
+- [ ] **Step 2: Commit (tests will still be broken — fixed in next tasks)**
+
+```bash
+git add test/fixtures/test-fixtures.ts
+git commit -m "test: rename TEST_APP_ID fixture to TEST_CLIENT_ID"
+```
+
+---
+
+## Task 7: Fix `github-app-token-manager.test.ts`
+
+**Files:**
+- Modify: `test/unit/github-app-token-manager.test.ts`
+
+- [ ] **Step 1: Update import, references, and test names**
+
+- Change the import on line 4: `TEST_APP_ID` → `TEST_CLIENT_ID`.
+- Replace ALL occurrences of `TEST_APP_ID` in the file with `TEST_CLIENT_ID` (21 call sites + the string passed to `GitHubAppTokenManager`).
+- Rename test on line 41 from `"creates instance with appId and privateKey"` to `"creates instance with clientId and privateKey"`.
+- Rename test on line 74 from `"JWT payload has correct issuer (appId)"` to `"JWT payload has correct issuer (clientId)"`.
+
+Use your editor's replace-in-file: `TEST_APP_ID` → `TEST_CLIENT_ID` (whole-word).
+
+- [ ] **Step 2: Run this test file to verify green**
+
+Run: `npx vitest run test/unit/github-app-token-manager.test.ts`
+Expected: PASS (all tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/github-app-token-manager.test.ts
+git commit -m "test: update GitHubAppTokenManager tests for clientId rename"
+```
+
+---
+
+## Task 8: Fix `commit-strategy-selector.test.ts`
+
+**Files:**
+- Modify: `test/unit/vcs/commit-strategy-selector.test.ts:26`
+
+- [ ] **Step 1: Update fixture key**
+
+Change line 26 from `appId: "12345",` to `clientId: "12345",`.
+
+- [ ] **Step 2: Run**
+
+Run: `npx vitest run test/unit/vcs/commit-strategy-selector.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/vcs/commit-strategy-selector.test.ts
+git commit -m "test: update commit-strategy-selector fixture for clientId rename"
+```
+
+---
+
+## Task 9: Fix `repository-processor.test.ts`
+
+**Files:**
+- Modify: `test/unit/repository-processor.test.ts`
+
+This file has many sites. Do them in a single sweep, then verify.
+
+- [ ] **Step 1: Global rename within this file**
+
+Perform the following in-file replacements (all whole-word):
+
+- `XFG_GITHUB_APP_ID` → `XFG_GITHUB_CLIENT_ID` (all env var references; covers lines 1749, 1754, 1858, 1860, 1872, 1877, 1938, 1940, 1951, 1955, 2010, 2012, 2023, 2027, 2082, 2084, 2095, 2099, 2153, 2155, 2295, 2298, 2304, 2306, 2318, 2320, 2459).
+- `originalAppId` → `originalClientId` (local variables at lines 1749, 1872, 1951, 2023, 2095, 2291, 2295, etc.).
+- `TEST_APP_ID` → `TEST_CLIENT_ID` (imports at 2389 and 2455, usage at 2414 and 2459).
+- On line 2320, the assertion message `"XFG_GITHUB_APP_ID should not be set"` → `"XFG_GITHUB_CLIENT_ID should not be set"`.
+- On line 2378, the inline fixture key `appId: "12345",` → `clientId: "12345",`.
+
+- [ ] **Step 2: Verify no stragglers**
+
+Run: `grep -n "XFG_GITHUB_APP_ID\|TEST_APP_ID\|originalAppId\|appId:" test/unit/repository-processor.test.ts`
+Expected: no matches.
+
+- [ ] **Step 3: Run the test file**
+
+Run: `npx vitest run test/unit/repository-processor.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/unit/repository-processor.test.ts
+git commit -m "test: update repository-processor tests for clientId rename"
+```
+
+---
+
+## Task 10: Fix integration tests
+
+**Files:**
+- Modify: `test/integration/github-app.test.ts:21, 25, 287`
+- Modify: `test/integration/github-lifecycle-app.test.ts:25, 29`
+
+- [ ] **Step 1: Rename env var references and skip messages in both files**
+
+In both files, replace:
+
+- `process.env.XFG_GITHUB_APP_ID` → `process.env.XFG_GITHUB_CLIENT_ID`
+- Skip message `"XFG_GITHUB_APP_ID and XFG_GITHUB_APP_PRIVATE_KEY not set"` → `"XFG_GITHUB_CLIENT_ID and XFG_GITHUB_APP_PRIVATE_KEY not set"`
+
+In `test/integration/github-app.test.ts` line 287 (an env override object):
+
+```ts
+    XFG_GITHUB_CLIENT_ID: undefined,
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -rn "XFG_GITHUB_APP_ID" test/integration/`
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/integration/github-app.test.ts test/integration/github-lifecycle-app.test.ts
+git commit -m "test(integration): rename XFG_GITHUB_APP_ID to XFG_GITHUB_CLIENT_ID"
+```
+
+---
+
+## Task 11: Full unit test + typecheck run
+
+- [ ] **Step 1: Run unit tests**
+
+Run: `npm test`
+Expected: PASS (entire suite).
+
+- [ ] **Step 2: Run test typecheck**
+
+Run: `npm run test:typecheck`
+Expected: PASS (no type errors).
+
+- [ ] **Step 3: Lint**
+
+Run: `./lint.sh`
+Expected: PASS.
+
+If any step fails, fix before proceeding. Do NOT skip this task.
+
+---
+
+## Task 12: Update integration workflow
+
+**Files:**
+- Modify: `.github/workflows/_integration-tests.yaml:107, 260, 391, 490`
+
+- [ ] **Step 1: Rename the 4 references**
+
+- Line 107: `XFG_GITHUB_APP_ID: ${{ vars.TEST_CLIENT_ID }}` → `XFG_GITHUB_CLIENT_ID: ${{ vars.TEST_CLIENT_ID }}`
+- Line 260: `github-app-id: ${{ vars.TEST_CLIENT_ID }}` → `github-client-id: ${{ vars.TEST_CLIENT_ID }}`
+- Line 391: `XFG_GITHUB_APP_ID: ${{ vars.TEST_CLIENT_ID }}` → `XFG_GITHUB_CLIENT_ID: ${{ vars.TEST_CLIENT_ID }}`
+- Line 490: `github-app-id: ${{ vars.TEST_CLIENT_ID }}` → `github-client-id: ${{ vars.TEST_CLIENT_ID }}`
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "github-app-id\|XFG_GITHUB_APP_ID" .github/workflows/_integration-tests.yaml`
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/_integration-tests.yaml
+git commit -m "ci!: rename github-app-id to github-client-id in integration workflow"
+```
+
+---
+
+## Task 13: Update docs
+
+**Files:**
+- Modify: `docs/platforms/github-app.md`
+- Modify: `docs/ci-cd/github-actions.md`
+- Modify: `README.md` (if it references either name — check first)
+
+- [ ] **Step 1: Update `docs/platforms/github-app.md`**
+
+- Line 39: `**Variables:** \`APP_ID\` (the numeric app ID)` → `**Variables:** \`CLIENT_ID\` (the GitHub App Client ID, starts with \`Iv23\`)`
+- Line 54: `github-app-id: ${{ vars.APP_ID }}` → `github-client-id: ${{ vars.CLIENT_ID }}`
+- Line 84: in the env var table, `XFG_GITHUB_APP_ID` → `XFG_GITHUB_CLIENT_ID` and description `App ID for installation token generation` → `GitHub App Client ID for installation token generation`
+- Line 88: `When \`XFG_GITHUB_APP_ID\` and \`XFG_GITHUB_APP_PRIVATE_KEY\` are set` → `When \`XFG_GITHUB_CLIENT_ID\` and \`XFG_GITHUB_APP_PRIVATE_KEY\` are set`
+- Line 114: `(\`github-app-id\` and \`github-app-private-key\` inputs)` → `(\`github-client-id\` and \`github-app-private-key\` inputs)`
+
+- [ ] **Step 2: Update `docs/ci-cd/github-actions.md`**
+
+- Line 29: input name cell `` `github-app-id` `` → `` `github-client-id` ``. Description `GitHub App ID for installation token generation` → `GitHub App Client ID for installation token generation`.
+- Line 102: `github-app-id: ${{ vars.APP_ID }}` → `github-client-id: ${{ vars.CLIENT_ID }}`
+
+- [ ] **Step 3: Check and update `README.md` if needed**
+
+Run: `grep -n "github-app-id\|XFG_GITHUB_APP_ID\|APP_ID" README.md`
+For each match: if it's a reference to the xfg input/env var/repo var, update to the new name. If it's talking about something else (unlikely), leave it.
+
+- [ ] **Step 4: Final grep across the whole repo (excluding historical plans and desloppify state)**
+
+Run:
+
+```bash
+grep -rn "XFG_GITHUB_APP_ID\|github-app-id\|TEST_APP_ID" \
+  --exclude-dir=node_modules \
+  --exclude-dir=.desloppify \
+  --exclude-dir=plans \
+  --exclude-dir=dist \
+  .
+```
+
+Expected: no matches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/platforms/github-app.md docs/ci-cd/github-actions.md README.md
+git commit -m "docs!: rename github-app-id to github-client-id"
+```
+
+(Omit `README.md` from the `git add` if it had no matches.)
+
+---
+
+## Task 14: Full pre-PR verification
+
+- [ ] **Step 1: Build**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 2: Unit tests**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 3: Test typecheck**
+
+Run: `npm run test:typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Lint**
+
+Run: `./lint.sh`
+Expected: PASS.
+
+- [ ] **Step 5: Integration tests (all three platforms)**
+
+Run, in order:
+
+```bash
+npm run test:integration:github
+npm run test:integration:ado
+npm run test:integration:gitlab
+```
+
+Expected: PASS (or the usual platform-gated skip for envs missing the required secrets — for the GitHub app suite, with the renamed `XFG_GITHUB_CLIENT_ID`, tests should actually run).
+
+If any of these fail, STOP — do not open the PR. Debug and fix first.
+
+---
+
+## Task 15: Open PR
+
+- [ ] **Step 1: Push**
+
+Run:
+
+```bash
+git push -u origin chore/rename-app-id-to-client-id
+```
+
+- [ ] **Step 2: Create PR**
+
+Run:
+
+````bash
+gh pr create --title "feat!: rename github-app-id to github-client-id (v6.0.0)" --body "$(cat <<'EOF'
+Closes #700
+
+## Summary
+- Rename action input `github-app-id` → `github-client-id`
+- Rename env var `XFG_GITHUB_APP_ID` → `XFG_GITHUB_CLIENT_ID`
+- Rename all xfg-owned internal identifiers (`appId` → `clientId`) across `src/` and `test/`
+- Update docs and integration workflow
+- Breaking change — ships as v6.0.0
+
+## Migration
+```text
+action.yml input: github-app-id → github-client-id
+env var:          XFG_GITHUB_APP_ID → XFG_GITHUB_CLIENT_ID
+```
+
+Octokit's `createAppAuth({ appId })` parameter name is third-party and unchanged; it already accepts Client IDs.
+
+## Test plan
+- [x] npm test
+- [x] npm run test:typecheck
+- [x] ./lint.sh
+- [x] npm run test:integration:github
+- [x] npm run test:integration:ado
+- [x] npm run test:integration:gitlab
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+````
+
+- [ ] **Step 3: Enable automerge**
+
+Run:
+
+```bash
+gh pr merge --auto --squash --delete-branch
+```
+
+- [ ] **Step 4: Wait for CI to pass, then confirm merge**
+
+Watch CI via `gh pr checks --watch`. After merge, checkout main, pull, and confirm main CI is green before recommending a release.
+
+- [ ] **Step 5: Release (only after user confirms)**
+
+After PR merged and main is green, tell the user to run:
+
+```bash
+gh workflow run release.yaml -f version=major
+```
+
+This ships v6.0.0.

--- a/plans/superpowers/plans/2026-04-15-rename-app-id-to-client-id.md
+++ b/plans/superpowers/plans/2026-04-15-rename-app-id-to-client-id.md
@@ -12,6 +12,19 @@
 
 ---
 
+## Task 0: Verify branch
+
+Branch `chore/rename-app-id-to-client-id` was created when the spec was committed. Confirm you are on it before any other task.
+
+- [ ] **Step 1: Confirm branch**
+
+Run: `git rev-parse --abbrev-ref HEAD`
+Expected output: `chore/rename-app-id-to-client-id`
+
+If not on that branch, run `git checkout chore/rename-app-id-to-client-id`. If it does not exist locally, run `git checkout -b chore/rename-app-id-to-client-id` from `main`.
+
+---
+
 ## File Map
 
 **Production code (modify):**
@@ -19,6 +32,9 @@
 - `src/vcs/github-app-token-manager.ts` — constructor param, private field, JWT iss
 - `src/vcs/commit-strategy-selector.ts` — `AppCredentials.appId` type field + usage
 - `src/cli/sync-command.ts` — `process.env.XFG_GITHUB_APP_ID` reads + factory options key
+
+**Verified re-export only (no edit):**
+- `src/vcs/index.ts` — re-exports from `commit-strategy-selector.ts`; no direct `appId` reference.
 
 **Tests (modify):**
 - `test/fixtures/test-fixtures.ts` — `TEST_APP_ID` export
@@ -200,19 +216,24 @@ git commit -m "refactor(cli)!: read XFG_GITHUB_CLIENT_ID instead of XFG_GITHUB_A
 
 ---
 
-## Task 5: Verify build + run unit tests (fail-first expected)
+## Task 5: Verify build + check red state
 
-- [ ] **Step 1: TypeScript build**
+- [ ] **Step 1: TypeScript build (production only — should PASS)**
 
 Run: `npm run build`
-Expected: FAIL — tests still reference `TEST_APP_ID` and unrenamed fixture keys, compile errors in `src/` should all be gone. Any compile errors should be in test files only. If any compile error is in `src/**`, STOP and fix before proceeding.
+Expected: PASS. `tsconfig.json` excludes tests, so `tsc` compiles only `src/**` which is now internally consistent after Tasks 1–4.
 
-- [ ] **Step 2: Run unit tests**
+If this FAILS, a production-code change is broken — fix before proceeding.
+
+- [ ] **Step 2: Test typecheck (should FAIL — this is the red state)**
+
+Run: `npm run test:typecheck`
+Expected: FAIL with type errors in `test/unit/github-app-token-manager.test.ts`, `test/unit/vcs/commit-strategy-selector.test.ts`, `test/unit/repository-processor.test.ts`, and both `test/integration/github*.ts` files — they reference the old `TEST_APP_ID` / `appId` / `XFG_GITHUB_APP_ID` names.
+
+- [ ] **Step 3: Run unit tests (should FAIL)**
 
 Run: `npm test`
-Expected: FAIL in `test/unit/github-app-token-manager.test.ts`, `test/unit/vcs/commit-strategy-selector.test.ts`, `test/unit/repository-processor.test.ts` (missing `TEST_APP_ID`, wrong fixture key, wrong env var).
-
-This is the red state — proceed to Task 6.
+Expected: FAIL in the same test files. This is the red state — proceed to Task 6.
 
 ---
 
@@ -436,20 +457,22 @@ git commit -m "ci!: rename github-app-id to github-client-id in integration work
 Run: `grep -n "github-app-id\|XFG_GITHUB_APP_ID\|APP_ID" README.md`
 For each match: if it's a reference to the xfg input/env var/repo var, update to the new name. If it's talking about something else (unlikely), leave it.
 
-- [ ] **Step 4: Final grep across the whole repo (excluding historical plans and desloppify state)**
+- [ ] **Step 4: Final grep across the whole repo (excluding historical plans and scanner state)**
 
 Run:
 
 ```bash
-grep -rn "XFG_GITHUB_APP_ID\|github-app-id\|TEST_APP_ID" \
+grep -rn -E "XFG_GITHUB_APP_ID|github-app-id|TEST_APP_ID|originalAppId|\bappId\b|\bAPP_ID\b" \
   --exclude-dir=node_modules \
   --exclude-dir=.desloppify \
   --exclude-dir=plans \
+  --exclude-dir=docs/superpowers \
   --exclude-dir=dist \
+  --exclude-dir=.git \
   .
 ```
 
-Expected: no matches.
+Expected: no matches. (Note: `appId` may still appear as a word inside a comment referring to Octokit's `createAppAuth({ appId })` third-party parameter if such a comment exists — if so, that is acceptable and the only allowed match. Otherwise no matches.)
 
 - [ ] **Step 5: Commit**
 

--- a/plans/superpowers/specs/2026-04-15-rename-app-id-to-client-id-design.md
+++ b/plans/superpowers/specs/2026-04-15-rename-app-id-to-client-id-design.md
@@ -1,0 +1,79 @@
+# Rename `appId` → `clientId` (xfg v6.0.0)
+
+**Issue:** [#700](https://github.com/anthony-spruyt/xfg/issues/700)
+**Status:** Approved design
+**Date:** 2026-04-15
+
+## Goal
+
+Rename all xfg-owned names from "App ID" to "Client ID" to accurately reflect that these values hold GitHub App Client IDs (`Iv23…`), not numeric App IDs. This is a breaking change released as v6.0.0 — no aliases, no deprecation shims.
+
+Octokit's `createAppAuth({ appId })` parameter name is third-party and stays as-is; we pass our `clientId` variable into that parameter at the call boundary. Octokit accepts Client IDs there.
+
+## External surface changes (breaking)
+
+| Old | New |
+| --- | --- |
+| `action.yml` input `github-app-id` | `github-client-id` |
+| Env var `XFG_GITHUB_APP_ID` | `XFG_GITHUB_CLIENT_ID` |
+
+No backwards-compatible aliases. No fallback reads of the old env var. No deprecation warnings. Users must update to the new names when upgrading to v6.0.0.
+
+## Internal renames (xfg-owned code)
+
+- `GitHubAppTokenManager` (`src/vcs/github-app-token-manager.ts`):
+  - Constructor parameter: `appId` → `clientId`
+  - Private field: `this.appId` → `this.clientId`
+  - JWT `iss` claim: continues to use `this.clientId` (GitHub accepts Client IDs in the `iss` claim)
+- `createTokenManager` factory (`src/vcs/index.ts` and callers): options object key `appId` → `clientId`
+- `src/cli/sync-command.ts`: read `process.env.XFG_GITHUB_CLIENT_ID`, pass as `clientId`
+- Any other xfg-owned types, interfaces, config keys, variables, or identifiers named `appId` / `APP_ID` → `clientId` / `CLIENT_ID`
+- Octokit call boundary: if `createAppAuth({ appId: ... })` is called anywhere in our code, the key `appId` stays (Octokit's API) but the value passed is our renamed `clientId` variable
+
+## Tests
+
+- Update `test/unit/github-app-token-manager.test.ts`, `test/unit/repository-processor.test.ts`, `test/unit/vcs/commit-strategy-selector.test.ts`, and any other unit tests that reference the old names.
+- Update `test/integration/github-app.test.ts` and `test/integration/github-lifecycle-app.test.ts` to use the new env var name.
+- Update any test fixtures and mocks.
+- No new tests needed — this is a pure rename with no behavior change.
+
+## Docs and workflow
+
+- `docs/platforms/github-app.md` — env var name, setup steps
+- `.github/workflows/_integration-tests.yaml` — use `github-client-id` input; reference `XFG_GITHUB_CLIENT_ID` where applicable
+- `docs/ci-cd/github-actions.md` — any references to the old input/env var
+- `README.md` — quick-start examples, if they reference either name
+- Repo variables (`RELEASE_CLIENT_ID`, `TEST_CLIENT_ID`) are already renamed per #699 — this design does not touch them
+
+## Verification
+
+Before PR (per `CLAUDE.md` pre-PR checklist):
+
+1. `npm test`
+2. `npm run test:typecheck`
+3. `./lint.sh`
+4. `npm run test:integration:github`
+5. `npm run test:integration:ado`
+6. `npm run test:integration:gitlab`
+
+## Release
+
+After merge to main:
+
+```bash
+gh workflow run release.yaml -f version=major
+```
+
+Release notes must call out the breaking change with a migration snippet:
+
+```text
+# Migration for xfg v6.0.0
+#   action.yml input: github-app-id → github-client-id
+#   env var:          XFG_GITHUB_APP_ID → XFG_GITHUB_CLIENT_ID
+```
+
+## Out of scope
+
+- Octokit's `createAppAuth({ appId })` parameter name — third-party, we don't own it
+- Any further changes to #699's already-renamed repo variables (`RELEASE_CLIENT_ID`, `TEST_CLIENT_ID`)
+- Deprecation shims or dual-name support

--- a/src/cli/sync-command.ts
+++ b/src/cli/sync-command.ts
@@ -688,9 +688,9 @@ export async function runSync(
   getLogger().log(`Branch: ${branchName}\n`);
 
   const tokenManager = createTokenManager(
-    process.env.XFG_GITHUB_APP_ID && process.env.XFG_GITHUB_APP_PRIVATE_KEY
+    process.env.XFG_GITHUB_CLIENT_ID && process.env.XFG_GITHUB_APP_PRIVATE_KEY
       ? {
-          appId: process.env.XFG_GITHUB_APP_ID,
+          clientId: process.env.XFG_GITHUB_CLIENT_ID,
           privateKey: process.env.XFG_GITHUB_APP_PRIVATE_KEY,
         }
       : undefined

--- a/src/lifecycle/github-lifecycle-provider.ts
+++ b/src/lifecycle/github-lifecycle-provider.ts
@@ -516,6 +516,7 @@ export class GitHubLifecycleProvider implements IRepoLifecycleProvider {
       () => this.executor.exec(command, this.cwd, { env: tokenEnv }),
       {
         retries: this.retries,
+        permanentErrorPatterns: POST_CREATE_PERMANENT_PATTERNS,
       }
     );
   }

--- a/src/vcs/commit-strategy-selector.ts
+++ b/src/vcs/commit-strategy-selector.ts
@@ -7,7 +7,7 @@ import { GitHubAppTokenManager } from "./github-app-token-manager.js";
 import type { ICommandExecutor } from "../shared/command-executor.js";
 
 interface GitHubAppCredentials {
-  appId: string;
+  clientId: string;
   privateKey: string;
 }
 
@@ -20,7 +20,10 @@ export function createTokenManager(
   if (!credentials) {
     return null;
   }
-  return new GitHubAppTokenManager(credentials.appId, credentials.privateKey);
+  return new GitHubAppTokenManager(
+    credentials.clientId,
+    credentials.privateKey
+  );
 }
 
 /**

--- a/src/vcs/github-app-token-manager.ts
+++ b/src/vcs/github-app-token-manager.ts
@@ -35,7 +35,7 @@ async function assertOkResponse(res: Response, context: string): Promise<void> {
  * Handles JWT generation, installation discovery, and token caching.
  */
 export class GitHubAppTokenManager {
-  private readonly appId: string;
+  private readonly clientId: string;
   private readonly privateKey: string;
 
   /** Map of "apiHost:owner" -> installation ID */
@@ -47,8 +47,8 @@ export class GitHubAppTokenManager {
   /** Map of "apiHost:owner" -> cached token */
   private tokenCache = new Map<string, CachedToken>();
 
-  constructor(appId: string, privateKey: string) {
-    this.appId = appId;
+  constructor(clientId: string, privateKey: string) {
+    this.clientId = clientId;
     this.privateKey = privateKey;
   }
 
@@ -67,7 +67,7 @@ export class GitHubAppTokenManager {
     const payload = {
       iat: now - 60, // Issued 60 seconds ago to account for clock drift
       exp: now + 600, // Expires in 10 minutes
-      iss: this.appId,
+      iss: this.clientId,
     };
 
     const encodedHeader = base64UrlEncode(JSON.stringify(header));

--- a/test/fixtures/test-fixtures.ts
+++ b/test/fixtures/test-fixtures.ts
@@ -34,4 +34,4 @@ FjHEMfmuYQEHGa7e2Tuo1ox4FdqKCSJ1F7lgsKsHqBVvYByh07blegIym4q8AVXE
 lHSxz4gPIusCQdTECjW4mmA=
 -----END PRIVATE KEY-----`;
 
-export const TEST_APP_ID = "12345";
+export const TEST_CLIENT_ID = "12345";

--- a/test/integration/github-app.test.ts
+++ b/test/integration/github-app.test.ts
@@ -18,11 +18,11 @@ import {
 
 const OWNER = "spruyt-labs";
 const SKIP_TESTS =
-  !process.env.XFG_GITHUB_APP_ID || !process.env.XFG_GITHUB_APP_PRIVATE_KEY;
+  !process.env.XFG_GITHUB_CLIENT_ID || !process.env.XFG_GITHUB_APP_PRIVATE_KEY;
 
 if (SKIP_TESTS) {
   console.log(
-    "\n  Skipping GitHub App integration tests: XFG_GITHUB_APP_ID and XFG_GITHUB_APP_PRIVATE_KEY not set\n"
+    "\n  Skipping GitHub App integration tests: XFG_GITHUB_CLIENT_ID and XFG_GITHUB_APP_PRIVATE_KEY not set\n"
   );
 }
 
@@ -284,7 +284,7 @@ repos:
 // Force PAT-only auth
 const patOnlyEnv = {
   env: {
-    XFG_GITHUB_APP_ID: undefined,
+    XFG_GITHUB_CLIENT_ID: undefined,
     XFG_GITHUB_APP_PRIVATE_KEY: undefined,
   },
 };

--- a/test/integration/github-lifecycle-app.test.ts
+++ b/test/integration/github-lifecycle-app.test.ts
@@ -22,11 +22,11 @@ const HAS_ADO_CREDS = !!process.env.AZURE_DEVOPS_EXT_PAT;
 
 // Skip all tests if GitHub App credentials are not set
 const SKIP_TESTS =
-  !process.env.XFG_GITHUB_APP_ID || !process.env.XFG_GITHUB_APP_PRIVATE_KEY;
+  !process.env.XFG_GITHUB_CLIENT_ID || !process.env.XFG_GITHUB_APP_PRIVATE_KEY;
 
 if (SKIP_TESTS) {
   console.log(
-    "\n  Skipping GitHub App lifecycle tests: XFG_GITHUB_APP_ID and XFG_GITHUB_APP_PRIVATE_KEY not set\n"
+    "\n  Skipping GitHub App lifecycle tests: XFG_GITHUB_CLIENT_ID and XFG_GITHUB_APP_PRIVATE_KEY not set\n"
   );
 }
 

--- a/test/integration/github-repo-settings.test.ts
+++ b/test/integration/github-repo-settings.test.ts
@@ -199,12 +199,28 @@ describe("GitHub Repo Settings Integration Test", () => {
       cwd: projectRoot,
     });
 
-    const output = await exec(`node dist/cli.js sync --config ${configPath}`, {
-      cwd: projectRoot,
-    });
-    assert.ok(
-      output.includes("No changes needed") ||
-        output.includes("0 to add, 0 to change")
+    // Security settings have eventual consistency on the GitHub API — a second
+    // sync run immediately after the first can read stale state and plan a
+    // non-zero diff. Retry until the idempotent run reports no changes.
+    await withTestRetry(
+      async () => {
+        const output = await exec(
+          `node dist/cli.js sync --config ${configPath}`,
+          {
+            cwd: projectRoot,
+          }
+        );
+        assert.ok(
+          output.includes("No changes needed") ||
+            output.includes("0 to add, 0 to change"),
+          `expected idempotent sync to report no changes; got:\n${output}`
+        );
+      },
+      {
+        description: "idempotent sync reports no changes",
+        retries: 5,
+        baseDelayMs: 3000,
+      }
     );
   });
 

--- a/test/unit/github-app-token-manager.test.ts
+++ b/test/unit/github-app-token-manager.test.ts
@@ -91,7 +91,7 @@ describe("GitHubAppTokenManager", () => {
       assert.equal(
         (payload as { iss: string }).iss,
         TEST_CLIENT_ID,
-        "iss should be the app ID"
+        "iss should be the client ID"
       );
     });
 

--- a/test/unit/github-app-token-manager.test.ts
+++ b/test/unit/github-app-token-manager.test.ts
@@ -1,7 +1,7 @@
 import { test, describe, beforeEach, afterEach, mock } from "node:test";
 import { strict as assert } from "node:assert";
 import { GitHubAppTokenManager } from "../../src/vcs/github-app-token-manager.js";
-import { TEST_PRIVATE_KEY, TEST_APP_ID } from "../fixtures/test-fixtures.js";
+import { TEST_PRIVATE_KEY, TEST_CLIENT_ID } from "../fixtures/test-fixtures.js";
 function base64UrlDecode(str: string): string {
   // Add padding if needed
   const padded = str + "=".repeat((4 - (str.length % 4)) % 4);
@@ -38,13 +38,19 @@ describe("GitHubAppTokenManager", () => {
   // Task 1: JWT Generation Tests
   // ============================================================
   describe("constructor and generateJWT", () => {
-    test("creates instance with appId and privateKey", () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+    test("creates instance with clientId and privateKey", () => {
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
       assert.ok(manager);
     });
 
     test("generateJWT returns a valid JWT structure", () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
       const jwt = manager.generateJWT();
 
       // JWT should have 3 parts separated by dots
@@ -61,7 +67,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("JWT header has correct algorithm and type", () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
       const jwt = manager.generateJWT();
       const { header } = parseJwt(jwt);
 
@@ -71,20 +80,26 @@ describe("GitHubAppTokenManager", () => {
       });
     });
 
-    test("JWT payload has correct issuer (appId)", () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+    test("JWT payload has correct issuer (clientId)", () => {
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
       const jwt = manager.generateJWT();
       const { payload } = parseJwt(jwt);
 
       assert.equal(
         (payload as { iss: string }).iss,
-        TEST_APP_ID,
+        TEST_CLIENT_ID,
         "iss should be the app ID"
       );
     });
 
     test("JWT payload has iat set to now minus 60 seconds", () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
       const beforeTime = Math.floor(Date.now() / 1000) - 60;
       const jwt = manager.generateJWT();
       const afterTime = Math.floor(Date.now() / 1000) - 60;
@@ -96,7 +111,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("JWT payload has exp set to now plus 600 seconds", () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
       const beforeTime = Math.floor(Date.now() / 1000) + 600;
       const jwt = manager.generateJWT();
       const afterTime = Math.floor(Date.now() / 1000) + 600;
@@ -114,7 +132,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("JWT signature is valid RS256", () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
       const jwt = manager.generateJWT();
 
       // Verify that the signature part exists and is non-empty
@@ -134,7 +155,10 @@ describe("GitHubAppTokenManager", () => {
   // ============================================================
   describe("discoverInstallations", () => {
     test("calls GET /app/installations with JWT auth", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let capturedUrl: string | undefined;
       let capturedHeaders: Record<string, string> | undefined;
@@ -171,7 +195,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("stores installations in map by apiHost:owner", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       globalThis.fetch = mock.fn(async () => {
         return new Response(
@@ -201,7 +228,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("getInstallationId returns undefined for unknown owner", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       globalThis.fetch = mock.fn(async () => {
         return new Response(
@@ -223,7 +253,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("handles GitHub Enterprise API host", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let capturedUrl: string | undefined;
 
@@ -252,7 +285,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("throws on non-200 response", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       globalThis.fetch = mock.fn(async () => {
         return new Response("Not Found", { status: 404 });
@@ -271,7 +307,10 @@ describe("GitHubAppTokenManager", () => {
   // ============================================================
   describe("getTokenForOwner", () => {
     test("calls POST /app/installations/{id}/access_tokens", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let capturedUrl: string | undefined;
       let capturedMethod: string | undefined;
@@ -315,7 +354,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("returns null if no installation found", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       globalThis.fetch = mock.fn(async () => {
         return new Response(JSON.stringify([]), {
@@ -334,7 +376,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("caches tokens for 45 minutes", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let tokenCallCount = 0;
 
@@ -379,7 +424,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("fetches new token after cache expires", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let tokenCallCount = 0;
 
@@ -431,7 +479,10 @@ describe("GitHubAppTokenManager", () => {
   // ============================================================
   describe("getTokenForRepo", () => {
     test("derives api.github.com for github.com host", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let discoveryHost: string | undefined;
 
@@ -475,7 +526,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("derives GHE API host with /api/v3 suffix", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let capturedUrl: string | undefined;
 
@@ -517,7 +571,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("auto-discovers installations if not already discovered", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let discoveryCalled = false;
 
@@ -558,7 +615,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("does not re-discover if already discovered for host", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let discoveryCount = 0;
 
@@ -603,7 +663,10 @@ describe("GitHubAppTokenManager", () => {
   // ============================================================
   describe("retry logic", () => {
     test("retries discoverInstallations on 5xx errors", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let callCount = 0;
 
@@ -628,7 +691,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("retries getTokenForOwner on 5xx errors", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let discoveryDone = false;
       let tokenCallCount = 0;
@@ -672,7 +738,10 @@ describe("GitHubAppTokenManager", () => {
     });
 
     test("does not retry on 4xx errors", async () => {
-      const manager = new GitHubAppTokenManager(TEST_APP_ID, TEST_PRIVATE_KEY);
+      const manager = new GitHubAppTokenManager(
+        TEST_CLIENT_ID,
+        TEST_PRIVATE_KEY
+      );
 
       let callCount = 0;
 

--- a/test/unit/repository-processor.test.ts
+++ b/test/unit/repository-processor.test.ts
@@ -1746,12 +1746,12 @@ describe("RepositoryProcessor", () => {
   describe("CommitStrategy integration", () => {
     test("should use GraphQL commit strategy when GitHub App credentials are set", async () => {
       // Save original env values
-      const originalAppId = process.env.XFG_GITHUB_APP_ID;
+      const originalClientId = process.env.XFG_GITHUB_CLIENT_ID;
       const originalPrivateKey = process.env.XFG_GITHUB_APP_PRIVATE_KEY;
 
       try {
         // Set GitHub App credentials to trigger GraphQL strategy
-        process.env.XFG_GITHUB_APP_ID = "12345";
+        process.env.XFG_GITHUB_CLIENT_ID = "12345";
         process.env.XFG_GITHUB_APP_PRIVATE_KEY = "test-private-key";
 
         const { mock: mockLogger, messages: loggerMessages } =
@@ -1854,10 +1854,10 @@ describe("RepositoryProcessor", () => {
         assert.ok(verifiedLog, "Should log that commit is verified");
       } finally {
         // Restore original env values
-        if (originalAppId === undefined) {
-          delete process.env.XFG_GITHUB_APP_ID;
+        if (originalClientId === undefined) {
+          delete process.env.XFG_GITHUB_CLIENT_ID;
         } else {
-          process.env.XFG_GITHUB_APP_ID = originalAppId;
+          process.env.XFG_GITHUB_CLIENT_ID = originalClientId;
         }
         if (originalPrivateKey === undefined) {
           delete process.env.XFG_GITHUB_APP_PRIVATE_KEY;
@@ -1869,12 +1869,12 @@ describe("RepositoryProcessor", () => {
 
     test("direct mode with CommitStrategy should return helpful error on branch protection", async () => {
       // Save original env values
-      const originalAppId = process.env.XFG_GITHUB_APP_ID;
+      const originalClientId = process.env.XFG_GITHUB_CLIENT_ID;
       const originalPrivateKey = process.env.XFG_GITHUB_APP_PRIVATE_KEY;
 
       try {
         // Set GitHub App credentials to trigger GraphQL strategy
-        process.env.XFG_GITHUB_APP_ID = "12345";
+        process.env.XFG_GITHUB_CLIENT_ID = "12345";
         process.env.XFG_GITHUB_APP_PRIVATE_KEY = "test-private-key";
 
         const { mock: mockLogger } = createMockLogger();
@@ -1934,10 +1934,10 @@ describe("RepositoryProcessor", () => {
         );
       } finally {
         // Restore original env values
-        if (originalAppId === undefined) {
-          delete process.env.XFG_GITHUB_APP_ID;
+        if (originalClientId === undefined) {
+          delete process.env.XFG_GITHUB_CLIENT_ID;
         } else {
-          process.env.XFG_GITHUB_APP_ID = originalAppId;
+          process.env.XFG_GITHUB_CLIENT_ID = originalClientId;
         }
         if (originalPrivateKey === undefined) {
           delete process.env.XFG_GITHUB_APP_PRIVATE_KEY;
@@ -1948,11 +1948,11 @@ describe("RepositoryProcessor", () => {
     });
 
     test("direct mode handles 'protected' keyword in error message", async () => {
-      const originalAppId = process.env.XFG_GITHUB_APP_ID;
+      const originalClientId = process.env.XFG_GITHUB_CLIENT_ID;
       const originalPrivateKey = process.env.XFG_GITHUB_APP_PRIVATE_KEY;
 
       try {
-        process.env.XFG_GITHUB_APP_ID = "12345";
+        process.env.XFG_GITHUB_CLIENT_ID = "12345";
         process.env.XFG_GITHUB_APP_PRIVATE_KEY = "test-private-key";
 
         const { mock: mockLogger } = createMockLogger();
@@ -2006,10 +2006,10 @@ describe("RepositoryProcessor", () => {
           "Message should mention branch protection"
         );
       } finally {
-        if (originalAppId === undefined) {
-          delete process.env.XFG_GITHUB_APP_ID;
+        if (originalClientId === undefined) {
+          delete process.env.XFG_GITHUB_CLIENT_ID;
         } else {
-          process.env.XFG_GITHUB_APP_ID = originalAppId;
+          process.env.XFG_GITHUB_CLIENT_ID = originalClientId;
         }
         if (originalPrivateKey === undefined) {
           delete process.env.XFG_GITHUB_APP_PRIVATE_KEY;
@@ -2020,11 +2020,11 @@ describe("RepositoryProcessor", () => {
     });
 
     test("direct mode handles 'denied' keyword in error message", async () => {
-      const originalAppId = process.env.XFG_GITHUB_APP_ID;
+      const originalClientId = process.env.XFG_GITHUB_CLIENT_ID;
       const originalPrivateKey = process.env.XFG_GITHUB_APP_PRIVATE_KEY;
 
       try {
-        process.env.XFG_GITHUB_APP_ID = "12345";
+        process.env.XFG_GITHUB_CLIENT_ID = "12345";
         process.env.XFG_GITHUB_APP_PRIVATE_KEY = "test-private-key";
 
         const { mock: mockLogger } = createMockLogger();
@@ -2078,10 +2078,10 @@ describe("RepositoryProcessor", () => {
           "Message should mention branch protection"
         );
       } finally {
-        if (originalAppId === undefined) {
-          delete process.env.XFG_GITHUB_APP_ID;
+        if (originalClientId === undefined) {
+          delete process.env.XFG_GITHUB_CLIENT_ID;
         } else {
-          process.env.XFG_GITHUB_APP_ID = originalAppId;
+          process.env.XFG_GITHUB_CLIENT_ID = originalClientId;
         }
         if (originalPrivateKey === undefined) {
           delete process.env.XFG_GITHUB_APP_PRIVATE_KEY;
@@ -2092,11 +2092,11 @@ describe("RepositoryProcessor", () => {
     });
 
     test("direct mode returns error result for unrecognized errors", async () => {
-      const originalAppId = process.env.XFG_GITHUB_APP_ID;
+      const originalClientId = process.env.XFG_GITHUB_CLIENT_ID;
       const originalPrivateKey = process.env.XFG_GITHUB_APP_PRIVATE_KEY;
 
       try {
-        process.env.XFG_GITHUB_APP_ID = "12345";
+        process.env.XFG_GITHUB_CLIENT_ID = "12345";
         process.env.XFG_GITHUB_APP_PRIVATE_KEY = "test-private-key";
 
         const { mock: mockLogger } = createMockLogger();
@@ -2149,10 +2149,10 @@ describe("RepositoryProcessor", () => {
           "Error message should contain the original error"
         );
       } finally {
-        if (originalAppId === undefined) {
-          delete process.env.XFG_GITHUB_APP_ID;
+        if (originalClientId === undefined) {
+          delete process.env.XFG_GITHUB_CLIENT_ID;
         } else {
-          process.env.XFG_GITHUB_APP_ID = originalAppId;
+          process.env.XFG_GITHUB_CLIENT_ID = originalClientId;
         }
         if (originalPrivateKey === undefined) {
           delete process.env.XFG_GITHUB_APP_PRIVATE_KEY;
@@ -2288,22 +2288,22 @@ describe("RepositoryProcessor", () => {
   });
 
   describe("GitHub App token manager integration", () => {
-    let originalAppId: string | undefined;
+    let originalClientId: string | undefined;
     let originalPrivateKey: string | undefined;
 
     beforeEach(() => {
-      originalAppId = process.env.XFG_GITHUB_APP_ID;
+      originalClientId = process.env.XFG_GITHUB_CLIENT_ID;
       originalPrivateKey = process.env.XFG_GITHUB_APP_PRIVATE_KEY;
       // Clear env vars before each test
-      delete process.env.XFG_GITHUB_APP_ID;
+      delete process.env.XFG_GITHUB_CLIENT_ID;
       delete process.env.XFG_GITHUB_APP_PRIVATE_KEY;
     });
 
     afterEach(() => {
-      if (originalAppId !== undefined) {
-        process.env.XFG_GITHUB_APP_ID = originalAppId;
+      if (originalClientId !== undefined) {
+        process.env.XFG_GITHUB_CLIENT_ID = originalClientId;
       } else {
-        delete process.env.XFG_GITHUB_APP_ID;
+        delete process.env.XFG_GITHUB_CLIENT_ID;
       }
       if (originalPrivateKey !== undefined) {
         process.env.XFG_GITHUB_APP_PRIVATE_KEY = originalPrivateKey;
@@ -2315,9 +2315,9 @@ describe("RepositoryProcessor", () => {
     test("does not use token manager when GitHub App credentials are not set", async () => {
       // Verify env vars are cleared
       assert.equal(
-        process.env.XFG_GITHUB_APP_ID,
+        process.env.XFG_GITHUB_CLIENT_ID,
         undefined,
-        "XFG_GITHUB_APP_ID should not be set"
+        "XFG_GITHUB_CLIENT_ID should not be set"
       );
       assert.equal(
         process.env.XFG_GITHUB_APP_PRIVATE_KEY,
@@ -2375,7 +2375,7 @@ describe("RepositoryProcessor", () => {
       );
 
       const manager = createTokenManager({
-        appId: "12345",
+        clientId: "12345",
         privateKey: "test-key",
       });
 
@@ -2386,7 +2386,7 @@ describe("RepositoryProcessor", () => {
     });
 
     test("skips repo when no GitHub App installation found for owner", async () => {
-      const { TEST_PRIVATE_KEY, TEST_APP_ID } =
+      const { TEST_PRIVATE_KEY, TEST_CLIENT_ID } =
         await import("../fixtures/test-fixtures.js");
 
       const { mock: mockLogger } = createMockLogger();
@@ -2411,7 +2411,7 @@ describe("RepositoryProcessor", () => {
         });
 
         const tokenManager = new GitHubAppTokenManager(
-          TEST_APP_ID,
+          TEST_CLIENT_ID,
           TEST_PRIVATE_KEY
         );
         const processor = new RepositoryProcessor(
@@ -2452,11 +2452,11 @@ describe("RepositoryProcessor", () => {
     });
 
     test("logs warning and continues when GitHub App token retrieval fails", async () => {
-      const { TEST_PRIVATE_KEY, TEST_APP_ID } =
+      const { TEST_PRIVATE_KEY, TEST_CLIENT_ID } =
         await import("../fixtures/test-fixtures.js");
 
       // Set GitHub App credentials
-      process.env.XFG_GITHUB_APP_ID = TEST_APP_ID;
+      process.env.XFG_GITHUB_CLIENT_ID = TEST_CLIENT_ID;
       process.env.XFG_GITHUB_APP_PRIVATE_KEY = TEST_PRIVATE_KEY;
 
       const { mock: mockLogger } = createMockLogger();

--- a/test/unit/vcs/commit-strategy-selector.test.ts
+++ b/test/unit/vcs/commit-strategy-selector.test.ts
@@ -23,7 +23,7 @@ describe("createTokenManager", () => {
 
   test("returns token manager when credentials provided", () => {
     const manager = createTokenManager({
-      appId: "12345",
+      clientId: "12345",
       privateKey: "-----BEGIN RSA PRIVATE KEY-----",
     });
 


### PR DESCRIPTION
Closes #700

## Summary
- Rename action input `github-app-id` → `github-client-id`
- Rename env var `XFG_GITHUB_APP_ID` → `XFG_GITHUB_CLIENT_ID`
- Rename all xfg-owned internal identifiers (`appId` → `clientId`) across `src/`, `test/`, fixtures, docs, and the integration workflow
- Breaking change — ships as **v6.0.0**

Repo variable renames (`RELEASE_APP_ID`/`TEST_APP_ID` → `RELEASE_CLIENT_ID`/`TEST_CLIENT_ID`) landed earlier in #699; this PR completes the migration for the xfg-owned surface.

## Migration

```text
action.yml input: github-app-id → github-client-id
env var:          XFG_GITHUB_APP_ID → XFG_GITHUB_CLIENT_ID
```

`XFG_GITHUB_APP_PRIVATE_KEY` is unchanged — only the ID name was misleading. Octokit's `createAppAuth({ appId })` parameter name is third-party and not touched.

## Release coordination

**Before cutting v6.0.0**, the docs version selector automation in #701 should ship so the docs for v5 get pinned to their final tag and v6 gets its own tab. Otherwise the v5 docs tab will be overwritten with v6 content.

## Test plan
- [x] npm test (2600/2600 pass)
- [x] npm run test:typecheck
- [x] ./lint.sh
- [ ] npm run test:integration:github (CI)
- [ ] npm run test:integration:ado (CI)
- [ ] npm run test:integration:gitlab (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)