### PR TITLE
ci: automate docs versioning, deploy main under 'next' alias

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -52,22 +52,35 @@ jobs:
           git config user.name "xfg-release[bot]"
           git config user.email "xfg-release[bot]@users.noreply.github.com"
 
-      - name: Build v3 docs from tag
+      - name: Build released majors from floating tags
+        # Source of truth is the `v{N}` floating tags maintained by
+        # release.yaml. The highest one also gets the `latest` alias.
+        # Adding a new major (v6+) needs no changes here — release.yaml
+        # creates the floating tag and this loop picks it up automatically.
         run: |
-          # Check out v3 docs sources into a temp directory
-          git worktree add /tmp/v3-docs v3
-          # Build v3 docs using v3's mkdocs.yml
-          mike deploy --config-file /tmp/v3-docs/mkdocs.yml 3.x
-          git worktree remove /tmp/v3-docs
+          set -euo pipefail
+          highest="$(git tag -l 'v[0-9]' | sort -V | tail -1)"
+          if [ -z "$highest" ]; then
+            echo "No released major tags (v[0-9]) found; skipping versioned deploys"
+            exit 0
+          fi
+          for tag in $(git tag -l 'v[0-9]' | sort -V); do
+            major="${tag#v}"
+            workdir="/tmp/${tag}-docs"
+            git worktree add "$workdir" "$tag"
+            if [ "$tag" = "$highest" ]; then
+              mike deploy --update-aliases --alias-type copy \
+                --config-file "$workdir/mkdocs.yml" "${major}.x" latest
+            else
+              mike deploy --config-file "$workdir/mkdocs.yml" "${major}.x"
+            fi
+            git worktree remove "$workdir"
+          done
 
-      - name: Build v4 docs from tag
-        run: |
-          git worktree add /tmp/v4-docs v4.0.5
-          mike deploy --config-file /tmp/v4-docs/mkdocs.yml 4.x
-          git worktree remove /tmp/v4-docs
-
-      - name: Build v5 docs from main
-        run: mike deploy --update-aliases --alias-type copy 5.x latest
+      - name: Build unreleased main under `next`
+        # Preview of unreleased docs — shown as its own tab, never aliased
+        # to `latest`, so users don't see main's content as a released version.
+        run: mike deploy next
 
       - name: Set default version
         run: mike set-default latest

--- a/plans/superpowers/specs/2026-04-15-automate-docs-versioning-design.md
+++ b/plans/superpowers/specs/2026-04-15-automate-docs-versioning-design.md
@@ -1,0 +1,74 @@
+# Automate docs version deployment
+
+**Issue:** [#701](https://github.com/anthony-spruyt/xfg/issues/701)
+**Status:** Approved design
+**Date:** 2026-04-15
+
+## Goal
+
+Remove the hardcoded per-major build steps in `.github/workflows/docs.yaml` so adding a new major release requires no workflow edits, and unreleased main-branch docs never masquerade as a released version (the immediate problem today: v6 code on `main` is being published under the `5.x` and `latest` labels).
+
+## Approach
+
+Source of truth: the floating major tags (`v3`, `v4`, `v5`, …) maintained by `release.yaml`. Every release updates `v{MAJOR}` to the latest patch of that major; once a new major ships, the previous major's floating tag stops moving and permanently pins the prior major's docs.
+
+Rewrite docs.yaml so that:
+
+1. **All `N.x` version tabs are built from tags, never from `main`.** Loop every `v[0-9]+` floating tag and build from it as version `{N}.x` (using that tag's `mkdocs.yml`).
+2. **`latest` alias points to the highest released major.** Determined by `git tag -l 'v[0-9]' | sort -V | tail -1`, fully deterministic from tags. No `package.json` dependency.
+3. **`main` builds under a separate `next` alias (own version tab).** So unreleased docs are previewable but clearly not a released version. `next` never aliases `latest`.
+4. **`mike set-default latest`** stays unchanged — the site still opens on the latest released major.
+
+## Immediate effect when this merges
+
+- `5.x` rebuilds from the `v5` tag (→ v5.7.0) — correct stable v5 docs.
+- `latest` → `5.x` — correct.
+- Current main content (v6 rename) builds under `next` — clearly unreleased.
+
+## When v6 ships
+
+- `release.yaml` creates `v6.0.0` and updates floating `v6`.
+- Next `docs.yaml` run: loop picks up `v6`, builds `6.x` from it, `latest` flips to `6.x`.
+- `main`/`next` continues to track main.
+- Zero `docs.yaml` changes required.
+
+## Implementation
+
+Replace the three "Build vN docs" steps (current lines 55–70) with one loop step plus one `next` step. Keep the git config, Pages configuration, and `set-default` steps as-is.
+
+```bash
+# Build every released major from its floating tag
+HIGHEST=$(git tag -l 'v[0-9]' | sort -V | tail -1)
+for tag in $(git tag -l 'v[0-9]' | sort -V); do
+  major="${tag#v}"
+  workdir="/tmp/${tag}-docs"
+  git worktree add "$workdir" "$tag"
+  if [ "$tag" = "$HIGHEST" ]; then
+    mike deploy --update-aliases --alias-type copy \
+      --config-file "$workdir/mkdocs.yml" "${major}.x" latest
+  else
+    mike deploy --config-file "$workdir/mkdocs.yml" "${major}.x"
+  fi
+  git worktree remove "$workdir"
+done
+
+# Build unreleased main under the `next` alias (separate tab, not `latest`)
+mike deploy next
+```
+
+## Acceptance criteria
+
+- [ ] `docs.yaml` has no hardcoded major version numbers in build steps
+- [ ] `5.x` tab rebuilds from the `v5` tag, not `main`
+- [ ] `latest` alias points to `5.x` (highest released major), not main
+- [ ] `main` content lives under a `next` tab
+- [ ] Adding a future major (v6+) requires zero workflow edits
+- [ ] `npm run build`, `./lint.sh`, actionlint green
+- [ ] Manually triggered via `workflow_dispatch` on the PR branch to verify the site renders as expected before merge
+
+## Out of scope
+
+- Removing old majors from the selector (manual gh-pages curation)
+- Prerelease / RC channels beyond the single `next` alias
+- Changes to `mkdocs.yml`
+- Changes to `release.yaml`


### PR DESCRIPTION
Closes #701

## Summary
- Replace three hardcoded per-major build steps in `docs.yaml` with a single loop driven by the `v{N}` floating tags
- `latest` alias now points to the highest released major (deterministic from tags), not `main`
- `main` now builds under a separate `next` alias — unreleased docs are previewable but never masquerade as a released version
- Fixes the immediate issue after #702 merged: `main`'s v6 rename content was being published under `5.x` / `latest`, misrepresenting v5 docs

## Behaviour

When this merges:
- `5.x` rebuilds from tag `v5` (→ v5.7.0 sources), not main
- `latest` → `5.x` (correct)
- Current main (v6 rename) lands under `next`

When v6 ships:
- `release.yaml` creates `v6.0.0` + updates floating `v6` tag
- Next `docs.yaml` run: loop picks up `v6`, builds `6.x`, `latest` flips to `6.x`
- Zero workflow edits required — now or for any future major

## Test plan
- [x] actionlint, yamllint green
- [x] `./lint.sh` green
- [ ] Manually trigger `Deploy Docs` via `workflow_dispatch` on this branch and verify site has `5.x` / `4.x` / `3.x` / `next` tabs and `latest` → `5.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)