### PR TITLE
ci: auto-trigger docs rebuild on release tag

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,6 +10,8 @@ on:
       - "docs/**"
       - "!docs/superpowers/**"
       - "mkdocs.yml"
+    tags:
+      - "v*"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
After #704, releases still required a manual \`gh workflow run docs.yaml\` to surface the new major in the version selector — release.yaml doesn't touch \`docs/**\` so the existing push-path filter never fired.

This adds \`tags: ['v*']\` to the docs.yaml push trigger so any release tag automatically rebuilds the docs and updates \`latest\`.

## Test plan
- [x] actionlint, yamllint green
- Verified manually after v6.0.0 release: \`gh workflow run docs.yaml\` produced correct version selector (6.x as latest, 3.x/4.x/5.x pinned, next from main); after this merges, the next release will fire docs.yaml automatically without manual dispatch