### PR TITLE
ci(codeql): exclude test files from scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+name: xfg CodeQL config
+
+paths-ignore:
+  - test
+  - tests
+  - '**/*.test.ts'
+  - '**/*.spec.ts'


### PR DESCRIPTION
## Summary

Test file relocation in round 8 (flat `test/unit/*.test.ts` → mirrored `test/unit/<domain>/*.test.ts`) triggered 133 new CodeQL alerts — same rules already dismissed at the old flat paths. Add \`paths-ignore\` so tests stay outside scanning scope going forward.

Existing 132 test alerts have been bulk-dismissed as \`used in tests\`; 1 src alert (ado-pr-strategy.ts, carried from azure-pr-strategy.ts rename) dismissed separately.

## Test plan

- [x] \`.github/codeql/codeql-config.yml\` created with \`paths-ignore\` for test directories
- [ ] Next CodeQL run excludes test/** paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)