### PR TITLE
chore: desloppify round 8 part 2 — 4 more clusters (16 issues)

### DIFF
--- a/.desloppify/config.json
+++ b/.desloppify/config.json
@@ -26,7 +26,7 @@
   "execution_log_max_entries": 10000,
   "needs_rescan": false,
   "commit_tracking_enabled": true,
-  "commit_pr": 0,
+  "commit_pr": 706,
   "commit_default_branch": "",
   "commit_message_template": "desloppify: {status} {count} issue(s) \u2014 {summary}",
   "trust_plugins": false,

--- a/.desloppify/config.json.bak
+++ b/.desloppify/config.json.bak
@@ -24,7 +24,7 @@
   "issue_noise_budget": 10,
   "issue_noise_global_budget": 0,
   "execution_log_max_entries": 10000,
-  "needs_rescan": true,
+  "needs_rescan": false,
   "commit_tracking_enabled": true,
   "commit_pr": 0,
   "commit_default_branch": "",

--- a/.desloppify/plan.json
+++ b/.desloppify/plan.json
@@ -1,16 +1,8 @@
 {
   "version": 8,
   "created": "2026-03-06T08:53:09+00:00",
-  "updated": "2026-04-16T08:34:05+00:00",
+  "updated": "2026-04-16T09:15:12+00:00",
   "queue_order": [
-    "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks",
-    "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
-    "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
-    "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
-    "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks",
-    "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
-    "review::.::holistic::design_coherence::validate_settings_multi_concern",
-    "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony",
     "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
     "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
     "review::.::holistic::contract_coherence::rethrow_name_but_returns",
@@ -413,7 +405,7 @@
       "skipped_at_scan": 199
     }
   },
-  "active_cluster": "structure-nav-layout",
+  "active_cluster": null,
   "overrides": {
     "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only": {
       "issue_id": "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only",
@@ -2584,32 +2576,32 @@
     "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks": {
       "issue_id": "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:33+00:00"
     },
     "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets": {
       "issue_id": "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:34+00:00"
     },
     "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins": {
       "issue_id": "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:34+00:00"
     },
     "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record": {
       "issue_id": "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:35+00:00"
     },
     "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks": {
       "issue_id": "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:35+00:00"
     },
     "review::.::holistic::ai_generated_debt::misattached_docstring_hasComplexValue": {
       "issue_id": "review::.::holistic::ai_generated_debt::misattached_docstring_hasComplexValue",
@@ -2674,20 +2666,20 @@
     "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl": {
       "issue_id": "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
       "created_at": "2026-04-16T07:26:22+00:00",
-      "cluster": "design-coherence-factory-consolidation",
-      "updated_at": "2026-04-16T07:26:22+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:14:44+00:00"
     },
     "review::.::holistic::design_coherence::validate_settings_multi_concern": {
       "issue_id": "review::.::holistic::design_coherence::validate_settings_multi_concern",
       "created_at": "2026-04-16T07:26:22+00:00",
-      "cluster": "design-coherence-factory-consolidation",
-      "updated_at": "2026-04-16T07:26:22+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:14:44+00:00"
     },
     "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony": {
       "issue_id": "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony",
       "created_at": "2026-04-16T07:26:22+00:00",
-      "cluster": "design-coherence-factory-consolidation",
-      "updated_at": "2026-04-16T07:26:22+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:14:45+00:00"
     },
     "review::.::holistic::cross_module_architecture::repo_module_missing_barrel": {
       "issue_id": "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
@@ -4389,7 +4381,7 @@
         "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
       ],
       "created_at": "2026-04-16T07:25:34+00:00",
-      "updated_at": "2026-04-16T07:28:37+00:00",
+      "updated_at": "2026-04-16T09:03:17+00:00",
       "auto": false,
       "cluster_key": "",
       "action": null,
@@ -4404,7 +4396,8 @@
           "effort": "small",
           "issue_refs": [
             "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Apply single-pass grouped-record idiom in labels/formatter and extract mergeNamedEntries",
@@ -4413,7 +4406,8 @@
           "issue_refs": [
             "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
             "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Extract enrichSettingsContext and pushFailure helpers",
@@ -4422,7 +4416,8 @@
           "issue_refs": [
             "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks",
             "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record"
-          ]
+          ],
+          "done": true
         }
       ]
     },
@@ -4504,7 +4499,7 @@
         "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
       ],
       "created_at": "2026-04-16T07:25:42+00:00",
-      "updated_at": "2026-04-16T07:32:21+00:00",
+      "updated_at": "2026-04-16T09:14:35+00:00",
       "auto": false,
       "cluster_key": "",
       "action": null,
@@ -4523,7 +4518,8 @@
           "issue_refs": [
             "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
             "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Split validateSettings into per-concern dispatchers",
@@ -4531,7 +4527,8 @@
           "effort": "small",
           "issue_refs": [
             "review::.::holistic::design_coherence::validate_settings_multi_concern"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Validate test-suite stays green after each of the two concerns ship",
@@ -4541,7 +4538,8 @@
             "repo_iteration_context_factory_sprawl",
             "validate_settings_multi_concern",
             "settings_processor_factory_ceremony"
-          ]
+          ],
+          "done": true
         }
       ]
     },
@@ -31343,6 +31341,342 @@
         "sha": "ae65389593d1",
         "branch": "desloppify/round-8"
       }
+    },
+    {
+      "timestamp": "2026-04-16T08:55:10+00:00",
+      "action": "focus",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "action": "clear",
+        "previous": "structure-nav-layout"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T08:57:42+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "low-elegance-helper-extraction",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:00:38+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "low-elegance-helper-extraction",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:03:17+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "low-elegance-helper-extraction",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:33+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:33+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:34+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:34+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:34+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:34+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:35+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:35+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:35+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:35+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:39+00:00",
+      "action": "commit_record",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks",
+        "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
+        "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
+        "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
+        "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "sha": "831ccd3aeafe",
+        "branch": "desloppify/round-8-part-2"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:05:02+00:00",
+      "action": "focus",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "action": "clear",
+        "previous": "low-elegance-helper-extraction"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:10:58+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "design-coherence-factory-consolidation",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:13:16+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "design-coherence-factory-consolidation",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:35+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "design-coherence-factory-consolidation",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:43+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Replaced 4 flat factory fields with SettingsProcessorFactories record on RepoIterationContext, SyncDependencies, and ApplyRepoSettingsContext.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:14:44+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Replaced 4 flat factory fields with SettingsProcessorFactories record on RepoIterationContext, SyncDependencies, and ApplyRepoSettingsContext.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Replaced 4 flat factory fields with SettingsProcessorFactories record on RepoIterationContext, SyncDependencies, and ApplyRepoSettingsContext. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:44+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::validate_settings_multi_concern"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Split validateSettings into 5 per-concern dispatchers: validateSettingsRulesets/Labels/DeleteOrphaned/Repo/CodeScanning. validateSettings now thin orchestrator.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:14:44+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::validate_settings_multi_concern"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Split validateSettings into 5 per-concern dispatchers: validateSettingsRulesets/Labels/DeleteOrphaned/Repo/CodeScanning. validateSettings now thin orchestrator.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Split validateSettings into 5 per-concern dispatchers: validateSettingsRulesets/Labels/DeleteOrphaned/Repo/CodeScanning. validateSettings now thin orchestrator. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:45+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Collapsed four factory fields into a single SettingsProcessorFactories record, reducing ceremony while preserving per-kind typing via interface members.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:14:45+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Collapsed four factory fields into a single SettingsProcessorFactories record, reducing ceremony while preserving per-kind typing via interface members.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Collapsed four factory fields into a single SettingsProcessorFactories record, reducing ceremony while preserving per-kind typing via interface members. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:51+00:00",
+      "action": "commit_record",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
+        "review::.::holistic::design_coherence::validate_settings_multi_concern",
+        "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "sha": "59c58de6fc29",
+        "branch": "desloppify/round-8-part-2"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:15:12+00:00",
+      "action": "focus",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "action": "clear",
+        "previous": "design-coherence-factory-consolidation"
+      }
     }
   ],
   "epic_triage_meta": {
@@ -32925,6 +33259,32 @@
         "review::.::holistic::high_level_elegance::unified_summary_is_cli_stitcher_in_output"
       ],
       "recorded_at": "2026-04-16T08:34:05+00:00",
+      "note": null,
+      "cluster_name": null
+    },
+    {
+      "sha": "831ccd3aeafe",
+      "branch": "desloppify/round-8-part-2",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks",
+        "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
+        "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
+        "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
+        "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
+      ],
+      "recorded_at": "2026-04-16T09:04:39+00:00",
+      "note": null,
+      "cluster_name": null
+    },
+    {
+      "sha": "59c58de6fc29",
+      "branch": "desloppify/round-8-part-2",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
+        "review::.::holistic::design_coherence::validate_settings_multi_concern",
+        "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
+      ],
+      "recorded_at": "2026-04-16T09:14:51+00:00",
       "note": null,
       "cluster_name": null
     }

--- a/.desloppify/plan.json
+++ b/.desloppify/plan.json
@@ -1,13 +1,8 @@
 {
   "version": 8,
   "created": "2026-03-06T08:53:09+00:00",
-  "updated": "2026-04-16T09:20:50+00:00",
+  "updated": "2026-04-16T09:37:01+00:00",
   "queue_order": [
-    "review::.::holistic::contract_coherence::rethrow_name_but_returns",
-    "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
-    "review::.::holistic::naming_quality::check_existing_pr_returns_url",
-    "review::.::holistic::api_surface_coherence::lifecycle_token_positional",
-    "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift",
     "review::.::holistic::initialization_coupling::program_ts_version_readfilesync_at_import",
     "review::.::holistic::initialization_coupling::sync_command_module_level_let_singletons",
     "review::.::holistic::error_consistency::branch_protection_string_match",
@@ -403,7 +398,7 @@
       "skipped_at_scan": 199
     }
   },
-  "active_cluster": "cross-module-architecture-layering",
+  "active_cluster": "api-and-contract-coherence",
   "overrides": {
     "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only": {
       "issue_id": "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only",
@@ -2694,32 +2689,32 @@
     "review::.::holistic::contract_coherence::rethrow_name_but_returns": {
       "issue_id": "review::.::holistic::contract_coherence::rethrow_name_but_returns",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:36:58+00:00"
     },
     "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return": {
       "issue_id": "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:36:59+00:00"
     },
     "review::.::holistic::naming_quality::check_existing_pr_returns_url": {
       "issue_id": "review::.::holistic::naming_quality::check_existing_pr_returns_url",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:36:59+00:00"
     },
     "review::.::holistic::api_surface_coherence::lifecycle_token_positional": {
       "issue_id": "review::.::holistic::api_surface_coherence::lifecycle_token_positional",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:37:00+00:00"
     },
     "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift": {
       "issue_id": "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:37:01+00:00"
     },
     "review::.::holistic::initialization_coupling::program_ts_version_readfilesync_at_import": {
       "issue_id": "review::.::holistic::initialization_coupling::program_ts_version_readfilesync_at_import",
@@ -4594,7 +4589,7 @@
         "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift"
       ],
       "created_at": "2026-04-16T07:25:47+00:00",
-      "updated_at": "2026-04-16T07:29:36+00:00",
+      "updated_at": "2026-04-16T09:36:50+00:00",
       "auto": false,
       "cluster_key": "",
       "action": null,
@@ -4610,7 +4605,8 @@
           "issue_refs": [
             "review::.::holistic::contract_coherence::rethrow_name_but_returns",
             "review::.::holistic::naming_quality::check_existing_pr_returns_url"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Align IRepoSettingsStrategy verbs with sibling strategies and migrate IRepoLifecycleProvider to options bag",
@@ -4619,7 +4615,8 @@
           "issue_refs": [
             "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift",
             "review::.::holistic::api_surface_coherence::lifecycle_token_positional"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Clarify GitOps.commit dry-run contract in JSDoc",
@@ -4627,7 +4624,8 @@
           "effort": "trivial",
           "issue_refs": [
             "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return"
-          ]
+          ],
+          "done": true
         }
       ]
     },
@@ -31749,6 +31747,191 @@
         "status": "fixed",
         "attestation": "I have actually src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider). and I am not gaming the score."
       }
+    },
+    {
+      "timestamp": "2026-04-16T09:23:59+00:00",
+      "action": "focus",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "action": "clear",
+        "previous": "cross-module-architecture-layering"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:27:13+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "api-and-contract-coherence",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:27:14+00:00",
+      "action": "commit_record",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "sha": "1573f9dafb58",
+        "branch": "desloppify/round-8-part-2"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:33:55+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "api-and-contract-coherence",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:36:50+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "api-and-contract-coherence",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:36:58+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::contract_coherence::rethrow_name_but_returns"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed rethrowIfUnexpectedCommitError->classifyCommitError.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:36:58+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::contract_coherence::rethrow_name_but_returns"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed rethrowIfUnexpectedCommitError->classifyCommitError.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Renamed rethrowIfUnexpectedCommitError->classifyCommitError. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:36:59+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Clarified JSDoc: dry-run mode returns true without inspecting working tree.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:36:59+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Clarified JSDoc: dry-run mode returns true without inspecting working tree.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Clarified JSDoc: dry-run mode returns true without inspecting working tree. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:36:59+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::naming_quality::check_existing_pr_returns_url"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed IPRStrategy.checkExistingPR->findExistingPRUrl.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:36:59+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::naming_quality::check_existing_pr_returns_url"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed IPRStrategy.checkExistingPR->findExistingPRUrl.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Renamed IPRStrategy.checkExistingPR->findExistingPRUrl. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:37:00+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::api_surface_coherence::lifecycle_token_positional"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Migrated IRepoLifecycleProvider methods to options bags; token inside options.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:37:00+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::api_surface_coherence::lifecycle_token_positional"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Migrated IRepoLifecycleProvider methods to options bags; token inside options.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Migrated IRepoLifecycleProvider methods to options bags; token inside options. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:37:00+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed IRepoSettingsStrategy methods: getSettings->get, updateSettings->update, setVulnerabilityAlerts->updateVulnerabilityAlerts.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:37:01+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed IRepoSettingsStrategy methods: getSettings->get, updateSettings->update, setVulnerabilityAlerts->updateVulnerabilityAlerts.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Renamed IRepoSettingsStrategy methods: getSettings->get, updateSettings->update, setVulnerabilityAlerts->updateVulnerabilityAlerts. and I am not gaming the score."
+      }
     }
   ],
   "epic_triage_meta": {
@@ -33359,11 +33542,25 @@
       "recorded_at": "2026-04-16T09:14:51+00:00",
       "note": null,
       "cluster_name": null
+    },
+    {
+      "sha": "1573f9dafb58",
+      "branch": "desloppify/round-8-part-2",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+      ],
+      "recorded_at": "2026-04-16T09:27:14+00:00",
+      "note": null,
+      "cluster_name": null
     }
   ],
   "uncommitted_issues": [
-    "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
-    "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+    "review::.::holistic::contract_coherence::rethrow_name_but_returns",
+    "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
+    "review::.::holistic::naming_quality::check_existing_pr_returns_url",
+    "review::.::holistic::api_surface_coherence::lifecycle_token_positional",
+    "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift"
   ],
   "commit_tracking_branch": null,
   "refresh_state": {

--- a/.desloppify/plan.json
+++ b/.desloppify/plan.json
@@ -1,10 +1,8 @@
 {
   "version": 8,
   "created": "2026-03-06T08:53:09+00:00",
-  "updated": "2026-04-16T09:15:12+00:00",
+  "updated": "2026-04-16T09:20:50+00:00",
   "queue_order": [
-    "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
-    "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
     "review::.::holistic::contract_coherence::rethrow_name_but_returns",
     "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
     "review::.::holistic::naming_quality::check_existing_pr_returns_url",
@@ -405,7 +403,7 @@
       "skipped_at_scan": 199
     }
   },
-  "active_cluster": null,
+  "active_cluster": "cross-module-architecture-layering",
   "overrides": {
     "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only": {
       "issue_id": "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only",
@@ -2684,14 +2682,14 @@
     "review::.::holistic::cross_module_architecture::repo_module_missing_barrel": {
       "issue_id": "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
       "created_at": "2026-04-16T07:26:24+00:00",
-      "cluster": "cross-module-architecture-layering",
-      "updated_at": "2026-04-16T07:26:24+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:20:50+00:00"
     },
     "review::.::holistic::cross_module_architecture::shared_imports_repo_type": {
       "issue_id": "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
       "created_at": "2026-04-16T07:26:24+00:00",
-      "cluster": "cross-module-architecture-layering",
-      "updated_at": "2026-04-16T07:26:24+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:20:50+00:00"
     },
     "review::.::holistic::contract_coherence::rethrow_name_but_returns": {
       "issue_id": "review::.::holistic::contract_coherence::rethrow_name_but_returns",
@@ -4547,11 +4545,11 @@
       "name": "cross-module-architecture-layering",
       "description": "Relocate gh-api-utils and xfg-template RepoInfo couplings out of src/shared/ to restore shared-as-leaf layering, and fix the repo barrel import angle at the same time",
       "issue_ids": [
-        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
-        "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
       ],
       "created_at": "2026-04-16T07:25:43+00:00",
-      "updated_at": "2026-04-16T07:33:20+00:00",
+      "updated_at": "2026-04-16T09:20:40+00:00",
       "auto": false,
       "cluster_key": "",
       "action": null,
@@ -4570,7 +4568,8 @@
           "issue_refs": [
             "shared_imports_repo_type",
             "repo_module_missing_barrel"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Verify madge graph after shared/repo layering fix",
@@ -4579,7 +4578,8 @@
           "issue_refs": [
             "repo_module_missing_barrel",
             "shared_imports_repo_type"
-          ]
+          ],
+          "done": true
         }
       ]
     },
@@ -31677,6 +31677,78 @@
         "action": "clear",
         "previous": "design-coherence-factory-consolidation"
       }
+    },
+    {
+      "timestamp": "2026-04-16T09:20:20+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "cross-module-architecture-layering",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:20:40+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "cross-module-architecture-layering",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:20:49+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Inverted dependency: gh-api-utils defines local GitHubApiTarget, xfg-template defines local RepoDisplayInfo \u2014 both structurally compatible with repo types. shared/ no longer imports repo/.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:20:50+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Inverted dependency: gh-api-utils defines local GitHubApiTarget, xfg-template defines local RepoDisplayInfo \u2014 both structurally compatible with repo types. shared/ no longer imports repo/.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Inverted dependency: gh-api-utils defines local GitHubApiTarget, xfg-template defines local RepoDisplayInfo \u2014 both structurally compatible with repo types. shared/ no longer imports repo/. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:20:50+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider).",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:20:50+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider).",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider). and I am not gaming the score."
+      }
     }
   ],
   "epic_triage_meta": {
@@ -33289,7 +33361,10 @@
       "cluster_name": null
     }
   ],
-  "uncommitted_issues": [],
+  "uncommitted_issues": [
+    "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
+    "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+  ],
   "commit_tracking_branch": null,
   "refresh_state": {
     "subjective_review_completed_at_scan_count": 198,

--- a/.desloppify/plan.json.bak
+++ b/.desloppify/plan.json.bak
@@ -1,13 +1,8 @@
 {
   "version": 8,
   "created": "2026-03-06T08:53:09+00:00",
-  "updated": "2026-04-16T09:20:50+00:00",
+  "updated": "2026-04-16T09:37:00+00:00",
   "queue_order": [
-    "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
-    "review::.::holistic::contract_coherence::rethrow_name_but_returns",
-    "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
-    "review::.::holistic::naming_quality::check_existing_pr_returns_url",
-    "review::.::holistic::api_surface_coherence::lifecycle_token_positional",
     "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift",
     "review::.::holistic::initialization_coupling::program_ts_version_readfilesync_at_import",
     "review::.::holistic::initialization_coupling::sync_command_module_level_let_singletons",
@@ -404,7 +399,7 @@
       "skipped_at_scan": 199
     }
   },
-  "active_cluster": "cross-module-architecture-layering",
+  "active_cluster": "api-and-contract-coherence",
   "overrides": {
     "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only": {
       "issue_id": "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only",
@@ -2683,8 +2678,8 @@
     "review::.::holistic::cross_module_architecture::repo_module_missing_barrel": {
       "issue_id": "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
       "created_at": "2026-04-16T07:26:24+00:00",
-      "cluster": "cross-module-architecture-layering",
-      "updated_at": "2026-04-16T07:26:24+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:20:50+00:00"
     },
     "review::.::holistic::cross_module_architecture::shared_imports_repo_type": {
       "issue_id": "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
@@ -2695,26 +2690,26 @@
     "review::.::holistic::contract_coherence::rethrow_name_but_returns": {
       "issue_id": "review::.::holistic::contract_coherence::rethrow_name_but_returns",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:36:58+00:00"
     },
     "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return": {
       "issue_id": "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:36:59+00:00"
     },
     "review::.::holistic::naming_quality::check_existing_pr_returns_url": {
       "issue_id": "review::.::holistic::naming_quality::check_existing_pr_returns_url",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:36:59+00:00"
     },
     "review::.::holistic::api_surface_coherence::lifecycle_token_positional": {
       "issue_id": "review::.::holistic::api_surface_coherence::lifecycle_token_positional",
       "created_at": "2026-04-16T07:26:26+00:00",
-      "cluster": "api-and-contract-coherence",
-      "updated_at": "2026-04-16T07:26:26+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:37:00+00:00"
     },
     "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift": {
       "issue_id": "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift",
@@ -4546,8 +4541,8 @@
       "name": "cross-module-architecture-layering",
       "description": "Relocate gh-api-utils and xfg-template RepoInfo couplings out of src/shared/ to restore shared-as-leaf layering, and fix the repo barrel import angle at the same time",
       "issue_ids": [
-        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
-        "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
       ],
       "created_at": "2026-04-16T07:25:43+00:00",
       "updated_at": "2026-04-16T09:20:40+00:00",
@@ -4588,14 +4583,14 @@
       "name": "api-and-contract-coherence",
       "description": "Rename rethrowIfUnexpectedCommitError to classifyCommitError, IPRStrategy.checkExistingPR to findExistingPRUrl, fix IRepoSettingsStrategy verbs, migrate IRepoLifecycleProvider to options bag, clarify GitOps.commit dry-run JSDoc",
       "issue_ids": [
+        "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift",
         "review::.::holistic::contract_coherence::rethrow_name_but_returns",
         "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
         "review::.::holistic::naming_quality::check_existing_pr_returns_url",
-        "review::.::holistic::api_surface_coherence::lifecycle_token_positional",
-        "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift"
+        "review::.::holistic::api_surface_coherence::lifecycle_token_positional"
       ],
       "created_at": "2026-04-16T07:25:47+00:00",
-      "updated_at": "2026-04-16T07:29:36+00:00",
+      "updated_at": "2026-04-16T09:36:50+00:00",
       "auto": false,
       "cluster_key": "",
       "action": null,
@@ -4611,7 +4606,8 @@
           "issue_refs": [
             "review::.::holistic::contract_coherence::rethrow_name_but_returns",
             "review::.::holistic::naming_quality::check_existing_pr_returns_url"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Align IRepoSettingsStrategy verbs with sibling strategies and migrate IRepoLifecycleProvider to options bag",
@@ -4620,7 +4616,8 @@
           "issue_refs": [
             "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift",
             "review::.::holistic::api_surface_coherence::lifecycle_token_positional"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Clarify GitOps.commit dry-run contract in JSDoc",
@@ -4628,7 +4625,8 @@
           "effort": "trivial",
           "issue_refs": [
             "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return"
-          ]
+          ],
+          "done": true
         }
       ]
     },
@@ -31736,6 +31734,191 @@
       "actor": "user",
       "note": "src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider).",
       "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:20:50+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider).",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider). and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:23:59+00:00",
+      "action": "focus",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "action": "clear",
+        "previous": "cross-module-architecture-layering"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:27:13+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "api-and-contract-coherence",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:27:14+00:00",
+      "action": "commit_record",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "sha": "1573f9dafb58",
+        "branch": "desloppify/round-8-part-2"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:33:55+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "api-and-contract-coherence",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:36:50+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "api-and-contract-coherence",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:36:58+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::contract_coherence::rethrow_name_but_returns"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed rethrowIfUnexpectedCommitError->classifyCommitError.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:36:58+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::contract_coherence::rethrow_name_but_returns"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed rethrowIfUnexpectedCommitError->classifyCommitError.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Renamed rethrowIfUnexpectedCommitError->classifyCommitError. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:36:59+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Clarified JSDoc: dry-run mode returns true without inspecting working tree.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:36:59+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Clarified JSDoc: dry-run mode returns true without inspecting working tree.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Clarified JSDoc: dry-run mode returns true without inspecting working tree. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:36:59+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::naming_quality::check_existing_pr_returns_url"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed IPRStrategy.checkExistingPR->findExistingPRUrl.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:36:59+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::naming_quality::check_existing_pr_returns_url"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed IPRStrategy.checkExistingPR->findExistingPRUrl.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Renamed IPRStrategy.checkExistingPR->findExistingPRUrl. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:37:00+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::api_surface_coherence::lifecycle_token_positional"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Migrated IRepoLifecycleProvider methods to options bags; token inside options.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:37:00+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::api_surface_coherence::lifecycle_token_positional"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Migrated IRepoLifecycleProvider methods to options bags; token inside options.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Migrated IRepoLifecycleProvider methods to options bags; token inside options. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:37:00+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Renamed IRepoSettingsStrategy methods: getSettings->get, updateSettings->update, setVulnerabilityAlerts->updateVulnerabilityAlerts.",
+      "detail": {}
     }
   ],
   "epic_triage_meta": {
@@ -33346,10 +33529,24 @@
       "recorded_at": "2026-04-16T09:14:51+00:00",
       "note": null,
       "cluster_name": null
+    },
+    {
+      "sha": "1573f9dafb58",
+      "branch": "desloppify/round-8-part-2",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+      ],
+      "recorded_at": "2026-04-16T09:27:14+00:00",
+      "note": null,
+      "cluster_name": null
     }
   ],
   "uncommitted_issues": [
-    "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
+    "review::.::holistic::contract_coherence::rethrow_name_but_returns",
+    "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
+    "review::.::holistic::naming_quality::check_existing_pr_returns_url",
+    "review::.::holistic::api_surface_coherence::lifecycle_token_positional"
   ],
   "commit_tracking_branch": null,
   "refresh_state": {

--- a/.desloppify/plan.json.bak
+++ b/.desloppify/plan.json.bak
@@ -1,16 +1,8 @@
 {
   "version": 8,
   "created": "2026-03-06T08:53:09+00:00",
-  "updated": "2026-04-16T08:33:48+00:00",
+  "updated": "2026-04-16T09:14:51+00:00",
   "queue_order": [
-    "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks",
-    "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
-    "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
-    "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
-    "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks",
-    "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
-    "review::.::holistic::design_coherence::validate_settings_multi_concern",
-    "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony",
     "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
     "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
     "review::.::holistic::contract_coherence::rethrow_name_but_returns",
@@ -413,7 +405,7 @@
       "skipped_at_scan": 199
     }
   },
-  "active_cluster": "structure-nav-layout",
+  "active_cluster": "design-coherence-factory-consolidation",
   "overrides": {
     "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only": {
       "issue_id": "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only",
@@ -2584,32 +2576,32 @@
     "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks": {
       "issue_id": "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:33+00:00"
     },
     "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets": {
       "issue_id": "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:34+00:00"
     },
     "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins": {
       "issue_id": "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:34+00:00"
     },
     "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record": {
       "issue_id": "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:35+00:00"
     },
     "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks": {
       "issue_id": "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks",
       "created_at": "2026-04-16T07:26:12+00:00",
-      "cluster": "low-elegance-helper-extraction",
-      "updated_at": "2026-04-16T07:26:12+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:04:35+00:00"
     },
     "review::.::holistic::ai_generated_debt::misattached_docstring_hasComplexValue": {
       "issue_id": "review::.::holistic::ai_generated_debt::misattached_docstring_hasComplexValue",
@@ -2674,20 +2666,20 @@
     "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl": {
       "issue_id": "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
       "created_at": "2026-04-16T07:26:22+00:00",
-      "cluster": "design-coherence-factory-consolidation",
-      "updated_at": "2026-04-16T07:26:22+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:14:44+00:00"
     },
     "review::.::holistic::design_coherence::validate_settings_multi_concern": {
       "issue_id": "review::.::holistic::design_coherence::validate_settings_multi_concern",
       "created_at": "2026-04-16T07:26:22+00:00",
-      "cluster": "design-coherence-factory-consolidation",
-      "updated_at": "2026-04-16T07:26:22+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:14:44+00:00"
     },
     "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony": {
       "issue_id": "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony",
       "created_at": "2026-04-16T07:26:22+00:00",
-      "cluster": "design-coherence-factory-consolidation",
-      "updated_at": "2026-04-16T07:26:22+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:14:45+00:00"
     },
     "review::.::holistic::cross_module_architecture::repo_module_missing_barrel": {
       "issue_id": "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
@@ -4389,7 +4381,7 @@
         "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
       ],
       "created_at": "2026-04-16T07:25:34+00:00",
-      "updated_at": "2026-04-16T07:28:37+00:00",
+      "updated_at": "2026-04-16T09:03:17+00:00",
       "auto": false,
       "cluster_key": "",
       "action": null,
@@ -4404,7 +4396,8 @@
           "effort": "small",
           "issue_refs": [
             "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Apply single-pass grouped-record idiom in labels/formatter and extract mergeNamedEntries",
@@ -4413,7 +4406,8 @@
           "issue_refs": [
             "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
             "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Extract enrichSettingsContext and pushFailure helpers",
@@ -4422,7 +4416,8 @@
           "issue_refs": [
             "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks",
             "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record"
-          ]
+          ],
+          "done": true
         }
       ]
     },
@@ -4504,7 +4499,7 @@
         "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
       ],
       "created_at": "2026-04-16T07:25:42+00:00",
-      "updated_at": "2026-04-16T07:32:21+00:00",
+      "updated_at": "2026-04-16T09:14:35+00:00",
       "auto": false,
       "cluster_key": "",
       "action": null,
@@ -4523,7 +4518,8 @@
           "issue_refs": [
             "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
             "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Split validateSettings into per-concern dispatchers",
@@ -4531,7 +4527,8 @@
           "effort": "small",
           "issue_refs": [
             "review::.::holistic::design_coherence::validate_settings_multi_concern"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Validate test-suite stays green after each of the two concerns ship",
@@ -4541,7 +4538,8 @@
             "repo_iteration_context_factory_sprawl",
             "validate_settings_multi_concern",
             "settings_processor_factory_ceremony"
-          ]
+          ],
+          "done": true
         }
       ]
     },
@@ -31325,6 +31323,348 @@
         "status": "fixed",
         "attestation": "I have actually Moved src/output/unified-summary.ts to src/cli/unified-summary.ts. Its only consumer is src/cli/sync-command.ts. Updated internal imports in the moved file to reference ../output/* for the individual report modules. and I am not gaming the score."
       }
+    },
+    {
+      "timestamp": "2026-04-16T08:34:05+00:00",
+      "action": "commit_record",
+      "issue_ids": [
+        "review::.::holistic::package_organization::repo_missing_index_barrel",
+        "review::.::holistic::package_organization::sanitize_utils_vcs_only",
+        "review::.::holistic::package_organization::test_layout_partially_mirrored",
+        "review::.::holistic::test_strategy::flat_test_naming_obscures_mapping",
+        "review::.::holistic::high_level_elegance::unified_summary_is_cli_stitcher_in_output"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "sha": "ae65389593d1",
+        "branch": "desloppify/round-8"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T08:55:10+00:00",
+      "action": "focus",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "action": "clear",
+        "previous": "structure-nav-layout"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T08:57:42+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "low-elegance-helper-extraction",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:00:38+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "low-elegance-helper-extraction",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:03:17+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "low-elegance-helper-extraction",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:33+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:33+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:34+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:34+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:34+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:34+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:35+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:35+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:35+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:04:35+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:04:39+00:00",
+      "action": "commit_record",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks",
+        "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
+        "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
+        "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
+        "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "sha": "831ccd3aeafe",
+        "branch": "desloppify/round-8-part-2"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:05:02+00:00",
+      "action": "focus",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "action": "clear",
+        "previous": "low-elegance-helper-extraction"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:10:58+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "design-coherence-factory-consolidation",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:13:16+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "design-coherence-factory-consolidation",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:35+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "design-coherence-factory-consolidation",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:43+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Replaced 4 flat factory fields with SettingsProcessorFactories record on RepoIterationContext, SyncDependencies, and ApplyRepoSettingsContext.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:14:44+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Replaced 4 flat factory fields with SettingsProcessorFactories record on RepoIterationContext, SyncDependencies, and ApplyRepoSettingsContext.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Replaced 4 flat factory fields with SettingsProcessorFactories record on RepoIterationContext, SyncDependencies, and ApplyRepoSettingsContext. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:44+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::validate_settings_multi_concern"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Split validateSettings into 5 per-concern dispatchers: validateSettingsRulesets/Labels/DeleteOrphaned/Repo/CodeScanning. validateSettings now thin orchestrator.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:14:44+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::validate_settings_multi_concern"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Split validateSettings into 5 per-concern dispatchers: validateSettingsRulesets/Labels/DeleteOrphaned/Repo/CodeScanning. validateSettings now thin orchestrator.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Split validateSettings into 5 per-concern dispatchers: validateSettingsRulesets/Labels/DeleteOrphaned/Repo/CodeScanning. validateSettings now thin orchestrator. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:45+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Collapsed four factory fields into a single SettingsProcessorFactories record, reducing ceremony while preserving per-kind typing via interface members.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:14:45+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Collapsed four factory fields into a single SettingsProcessorFactories record, reducing ceremony while preserving per-kind typing via interface members.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Collapsed four factory fields into a single SettingsProcessorFactories record, reducing ceremony while preserving per-kind typing via interface members. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:14:51+00:00",
+      "action": "commit_record",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
+        "review::.::holistic::design_coherence::validate_settings_multi_concern",
+        "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "sha": "59c58de6fc29",
+        "branch": "desloppify/round-8-part-2"
+      }
     }
   ],
   "epic_triage_meta": {
@@ -32895,15 +33235,49 @@
       "recorded_at": "2026-04-16T07:52:44+00:00",
       "note": null,
       "cluster_name": null
+    },
+    {
+      "sha": "ae65389593d1",
+      "branch": "desloppify/round-8",
+      "issue_ids": [
+        "review::.::holistic::package_organization::repo_missing_index_barrel",
+        "review::.::holistic::package_organization::sanitize_utils_vcs_only",
+        "review::.::holistic::package_organization::test_layout_partially_mirrored",
+        "review::.::holistic::test_strategy::flat_test_naming_obscures_mapping",
+        "review::.::holistic::high_level_elegance::unified_summary_is_cli_stitcher_in_output"
+      ],
+      "recorded_at": "2026-04-16T08:34:05+00:00",
+      "note": null,
+      "cluster_name": null
+    },
+    {
+      "sha": "831ccd3aeafe",
+      "branch": "desloppify/round-8-part-2",
+      "issue_ids": [
+        "review::.::holistic::low_level_elegance::file_ref_resolver_parallel_walks",
+        "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
+        "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
+        "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
+        "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks"
+      ],
+      "recorded_at": "2026-04-16T09:04:39+00:00",
+      "note": null,
+      "cluster_name": null
+    },
+    {
+      "sha": "59c58de6fc29",
+      "branch": "desloppify/round-8-part-2",
+      "issue_ids": [
+        "review::.::holistic::design_coherence::repo_iteration_context_factory_sprawl",
+        "review::.::holistic::design_coherence::validate_settings_multi_concern",
+        "review::.::holistic::abstraction_fitness::settings_processor_factory_ceremony"
+      ],
+      "recorded_at": "2026-04-16T09:14:51+00:00",
+      "note": null,
+      "cluster_name": null
     }
   ],
-  "uncommitted_issues": [
-    "review::.::holistic::package_organization::repo_missing_index_barrel",
-    "review::.::holistic::package_organization::sanitize_utils_vcs_only",
-    "review::.::holistic::package_organization::test_layout_partially_mirrored",
-    "review::.::holistic::test_strategy::flat_test_naming_obscures_mapping",
-    "review::.::holistic::high_level_elegance::unified_summary_is_cli_stitcher_in_output"
-  ],
+  "uncommitted_issues": [],
   "commit_tracking_branch": null,
   "refresh_state": {
     "subjective_review_completed_at_scan_count": 198,

--- a/.desloppify/plan.json.bak
+++ b/.desloppify/plan.json.bak
@@ -1,10 +1,9 @@
 {
   "version": 8,
   "created": "2026-03-06T08:53:09+00:00",
-  "updated": "2026-04-16T09:14:51+00:00",
+  "updated": "2026-04-16T09:20:50+00:00",
   "queue_order": [
     "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
-    "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
     "review::.::holistic::contract_coherence::rethrow_name_but_returns",
     "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
     "review::.::holistic::naming_quality::check_existing_pr_returns_url",
@@ -405,7 +404,7 @@
       "skipped_at_scan": 199
     }
   },
-  "active_cluster": "design-coherence-factory-consolidation",
+  "active_cluster": "cross-module-architecture-layering",
   "overrides": {
     "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only": {
       "issue_id": "test_coverage::src/config/validators/ruleset-validator.ts::transitive_only",
@@ -2690,8 +2689,8 @@
     "review::.::holistic::cross_module_architecture::shared_imports_repo_type": {
       "issue_id": "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
       "created_at": "2026-04-16T07:26:24+00:00",
-      "cluster": "cross-module-architecture-layering",
-      "updated_at": "2026-04-16T07:26:24+00:00"
+      "cluster": null,
+      "updated_at": "2026-04-16T09:20:50+00:00"
     },
     "review::.::holistic::contract_coherence::rethrow_name_but_returns": {
       "issue_id": "review::.::holistic::contract_coherence::rethrow_name_but_returns",
@@ -4551,7 +4550,7 @@
         "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
       ],
       "created_at": "2026-04-16T07:25:43+00:00",
-      "updated_at": "2026-04-16T07:33:20+00:00",
+      "updated_at": "2026-04-16T09:20:40+00:00",
       "auto": false,
       "cluster_key": "",
       "action": null,
@@ -4570,7 +4569,8 @@
           "issue_refs": [
             "shared_imports_repo_type",
             "repo_module_missing_barrel"
-          ]
+          ],
+          "done": true
         },
         {
           "title": "Verify madge graph after shared/repo layering fix",
@@ -4579,7 +4579,8 @@
           "issue_refs": [
             "repo_module_missing_barrel",
             "shared_imports_repo_type"
-          ]
+          ],
+          "done": true
         }
       ]
     },
@@ -31665,6 +31666,76 @@
         "sha": "59c58de6fc29",
         "branch": "desloppify/round-8-part-2"
       }
+    },
+    {
+      "timestamp": "2026-04-16T09:15:12+00:00",
+      "action": "focus",
+      "issue_ids": [],
+      "cluster_name": null,
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "action": "clear",
+        "previous": "design-coherence-factory-consolidation"
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:20:20+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "cross-module-architecture-layering",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:20:40+00:00",
+      "action": "cluster_update",
+      "issue_ids": [],
+      "cluster_name": "cross-module-architecture-layering",
+      "actor": "user",
+      "note": null,
+      "detail": {
+        "description": null
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:20:49+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Inverted dependency: gh-api-utils defines local GitHubApiTarget, xfg-template defines local RepoDisplayInfo \u2014 both structurally compatible with repo types. shared/ no longer imports repo/.",
+      "detail": {}
+    },
+    {
+      "timestamp": "2026-04-16T09:20:50+00:00",
+      "action": "resolve",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "Inverted dependency: gh-api-utils defines local GitHubApiTarget, xfg-template defines local RepoDisplayInfo \u2014 both structurally compatible with repo types. shared/ no longer imports repo/.",
+      "detail": {
+        "status": "fixed",
+        "attestation": "I have actually Inverted dependency: gh-api-utils defines local GitHubApiTarget, xfg-template defines local RepoDisplayInfo \u2014 both structurally compatible with repo types. shared/ no longer imports repo/. and I am not gaming the score."
+      }
+    },
+    {
+      "timestamp": "2026-04-16T09:20:50+00:00",
+      "action": "done",
+      "issue_ids": [
+        "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+      ],
+      "cluster_name": null,
+      "actor": "user",
+      "note": "src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider).",
+      "detail": {}
     }
   ],
   "epic_triage_meta": {
@@ -33277,7 +33348,9 @@
       "cluster_name": null
     }
   ],
-  "uncommitted_issues": [],
+  "uncommitted_issues": [
+    "review::.::holistic::cross_module_architecture::shared_imports_repo_type"
+  ],
   "commit_tracking_branch": null,
   "refresh_state": {
     "subjective_review_completed_at_scan_count": 198,

--- a/.desloppify/query.json
+++ b/.desloppify/query.json
@@ -1,67 +1,26 @@
 {
-  "command": "next",
-  "items": [
-    {
-      "id": "cross-module-architecture-layering",
-      "action_type": "manual_fix",
-      "summary": "Relocate gh-api-utils and xfg-template RepoInfo couplings out of src/shared/ to restore shared-as-leaf layering, and fix the repo barrel import angle at the same time",
-      "member_count": 2,
-      "members": [
-        {
-          "id": "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
-          "confidence": "high",
-          "detector": "review",
-          "file": ".",
-          "summary": "src/repo/ is the only top-level module without an index.ts barrel; consumers import from detector.ts as a de-facto barrel",
-          "status": "open",
-          "kind": "issue",
-          "primary_command": "desloppify plan resolve \"review::.::holistic::cross_module_architecture::repo_module_missing_barrel\" --note \"<what you did>\" --confirm"
-        },
-        {
-          "id": "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
-          "confidence": "medium",
-          "detector": "review",
-          "file": ".",
-          "summary": "src/shared/ has two files that import types from src/repo/, inverting the shared-as-leaf layering used for runtime imports",
-          "status": "open",
-          "kind": "issue",
-          "primary_command": "desloppify plan resolve \"review::.::holistic::cross_module_architecture::shared_imports_repo_type\" --note \"<what you did>\" --confirm"
-        }
-      ],
-      "cluster_name": "cross-module-architecture-layering",
-      "cluster_auto": false,
-      "detector": "review",
-      "kind": "cluster",
-      "primary_command": "desloppify next --cluster cross-module-architecture-layering --count 10",
-      "action_steps": [
-        {
-          "title": "Relocate gh-api-utils and xfg-template out of src/shared/ to restore shared-as-leaf layering",
-          "detail": "src/shared/gh-api-utils.ts imports RepoInfo from src/repo/detector.ts, inverting the shared-as-leaf layering. Move src/shared/gh-api-utils.ts into src/repo/ (or src/vcs/) and update all importers. src/shared/xfg-template.ts also typings RepoInfo \u2014 either move the file or invert the dep by narrowing to a RepoDisplayInfo shape passed in. Coordinate with structure-nav-layout which creates the src/repo/ barrel so importers can pivot to '../repo/index.js'.",
-          "effort": "medium",
-          "issue_refs": [
-            "shared_imports_repo_type",
-            "repo_module_missing_barrel"
-          ]
-        },
-        {
-          "title": "Verify madge graph after shared/repo layering fix",
-          "detail": "After the src/shared/gh-api-utils.ts and src/shared/xfg-template.ts relocations land (step 1), run 'npx madge --circular src/' and inspect the graph. Confirm no file under src/shared/ imports from src/repo/detector.ts, src/vcs/, src/cli/, src/sync/, src/settings/, src/lifecycle/, src/output/, or src/config/ (shared must remain a leaf). Confirm downstream importers still resolve via src/repo/detector.ts (or the new barrel from structure-nav). Commit only if graph is clean and no cycles were introduced.",
-          "effort": "trivial",
-          "issue_refs": [
-            "repo_module_missing_barrel",
-            "shared_imports_repo_type"
-          ]
-        }
-      ]
-    }
+  "command": "resolve",
+  "patterns": [
+    "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
   ],
-  "queue": {
-    "total": 1,
-    "mode": "execution"
-  },
+  "status": "fixed",
+  "resolved": [
+    "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+  ],
+  "count": 1,
+  "next_command": "desloppify next",
+  "overall_score": 91.4,
+  "objective_score": 92.7,
+  "strict_score": 90.2,
+  "verified_strict_score": 90.3,
+  "prev_overall_score": 91.4,
+  "prev_objective_score": 92.7,
+  "prev_strict_score": 90.2,
+  "prev_verified_strict_score": 90.3,
+  "attestation": "I have actually src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider). and I am not gaming the score.",
   "narrative": {
     "phase": "refinement",
-    "headline": "\u26a0 1 security issue \u2014 review before other cleanup.  (12 review work items \u2014 run `desloppify show review --status open`)",
+    "headline": "\u26a0 1 security issue \u2014 review before other cleanup.  (10 review work items \u2014 run `desloppify show review --status open`)",
     "dimensions": {
       "lowest_dimensions": [
         {
@@ -211,15 +170,11 @@
         "type": "refactor",
         "detector": "test_coverage",
         "count": 28,
-        "description": "28 test_coverage issues in 1 cluster(s) \u2014 run `desloppify next`",
-        "command": "desloppify next",
+        "description": "28 test_coverage work items \u2014 review test coverage gaps \u2014 focus on critical modules with many importers first; defer test writing until code quality issues are resolved",
+        "command": "desloppify show test_coverage --status open",
         "impact": 0.0,
         "dimension": "Test health",
         "priority": 6,
-        "clusters": [
-          "auto/test_coverage-transitive_only"
-        ],
-        "cluster_count": 1,
         "lane": "test_coverage"
       },
       {
@@ -258,8 +213,8 @@
       {
         "type": "refactor",
         "detector": "review",
-        "count": 12,
-        "description": "12 review work items need investigation \u2014 run `desloppify show review --status open` to see them",
+        "count": 10,
+        "description": "10 review work items need investigation \u2014 run `desloppify show review --status open` to see them",
         "command": "desloppify show review --status open",
         "impact": 0.0,
         "dimension": "Unknown",
@@ -281,16 +236,11 @@
         "type": "manual_fix",
         "detector": "exports",
         "count": 26,
-        "description": "26 exports issues in 2 cluster(s) \u2014 run `desloppify next`",
-        "command": "desloppify next",
+        "description": "26 exports work items \u2014 run `knip --fix` to remove dead exports",
+        "command": "desloppify show exports --status open",
         "impact": 0.0,
         "dimension": "Code quality",
         "priority": 12,
-        "clusters": [
-          "auto/exports-export",
-          "auto/exports-type"
-        ],
-        "cluster_count": 2,
         "lane": "refactor_4"
       },
       {
@@ -319,7 +269,7 @@
     "strategy": {
       "fixer_leverage": {
         "auto_fixable_count": 0,
-        "total_count": 249,
+        "total_count": 243,
         "coverage": 0.0,
         "impact_ratio": 0.0,
         "recommendation": "none"
@@ -413,7 +363,7 @@
         }
       },
       "can_parallelize": true,
-      "hint": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 12 issue(s) \u2014 `desloppify show review --status open`."
+      "hint": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 10 issue(s) \u2014 `desloppify show review --status open`."
     },
     "tools": {
       "fixers": [
@@ -459,7 +409,7 @@
       "command": "desloppify show flat_dirs --status open",
       "description": "1 flat_dirs issues \u2014 create subdirectories and use `desloppify move`"
     },
-    "why_now": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 12 issue(s) \u2014 `desloppify show review --status open`.",
+    "why_now": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 10 issue(s) \u2014 `desloppify show review --status open`.",
     "verification_step": {
       "command": "desloppify scan",
       "reason": "revalidate after changes"
@@ -478,7 +428,22 @@
       "state": "above",
       "warning": null
     },
-    "reminders": [],
+    "reminders": [
+      {
+        "type": "rereview_needed",
+        "message": "Subjective results may be stale after resolve. Re-run `desloppify review --prepare` to refresh, or reset with `desloppify scan --reset-subjective` before a clean rerun.",
+        "command": "desloppify review --prepare",
+        "priority": 1,
+        "severity": "high"
+      },
+      {
+        "type": "rescan_needed",
+        "message": "Rescan to verify \u2014 cascading effects may create new issues.",
+        "command": "desloppify scan",
+        "priority": 1,
+        "severity": "high"
+      }
+    ],
     "reminder_history": {
       "auto_fixers_available": 3,
       "zone_classification": 3,
@@ -491,704 +456,11 @@
       "badge_recommendation": 3,
       "review_issues_pending": 3,
       "wontfix_growing": 3,
-      "fp_calibration_test_coverage_production": 3
+      "fp_calibration_test_coverage_production": 3,
+      "rereview_needed": 1,
+      "rescan_needed": 1
     }
   },
-  "agent_notes": [
-    "Do NOT use `desloppify plan skip` unless the user explicitly asks you to skip an item.",
-    "If you cannot fix an item, report it and move to the next one.",
-    "For cluster items: if the autofix_hint finds 0 results, drill into individual issues with the primary_command."
-  ],
-  "plan": {
-    "active": true,
-    "focus": null,
-    "clusters": [
-      {
-        "name": "token-resolution",
-        "description": "Extract resolveGitHubToken from gh-api-utils.ts into dedicated auth module, centralize token resolution to happen once per repo",
-        "item_count": 3
-      },
-      {
-        "name": "accepted-debt",
-        "description": "Intentional design decisions to skip: unused token param in Azure/GitLab (documented interface sharing), merge mode convention (internally consistent), isPermanentError string matching (pragmatic)",
-        "item_count": 3
-      },
-      {
-        "name": "stale-findings",
-        "description": "Findings likely already fixed in prior commits (FileChange consolidation, Logger DI fix). Verify with rescan then resolve.",
-        "item_count": 3
-      },
-      {
-        "name": "barrel-hygiene",
-        "description": "Complete barrel exports in shared/ and vcs/, fix all cross-module import bypasses",
-        "item_count": 6
-      },
-      {
-        "name": "type-dedup",
-        "description": "Eliminate duplicate types, functions, and logic across codebase",
-        "item_count": 7
-      },
-      {
-        "name": "stale-docs",
-        "description": "Fix stale docstrings and JSDoc that contradict implementation",
-        "item_count": 4
-      },
-      {
-        "name": "param-sprawl",
-        "description": "Reduce positional parameter counts by grouping into context objects",
-        "item_count": 3
-      },
-      {
-        "name": "error-gaps",
-        "description": "Fix inconsistent error handling: swallowed errors, string matching, missing try/catch",
-        "item_count": 3
-      },
-      {
-        "name": "type-narrowing",
-        "description": "Strengthen type safety: link validation arrays to types, narrow string fields, remove double casts",
-        "item_count": 3
-      },
-      {
-        "name": "code-cleanup",
-        "description": "Fix logic issues: redundant checks, unreachable code, misplaced utilities",
-        "item_count": 3
-      },
-      {
-        "name": "api-consolidation",
-        "description": "Move misplaced utilities, add type overloads, narrow action parameter types \u2014 improves type_safety, api_surface_coherence",
-        "item_count": 3
-      },
-      {
-        "name": "design-coherence-cleanup",
-        "description": "Complete round 3 consolidation: use countActions utility, use formatCountEntry, single-pass countActions \u2014 improves design_coherence, logic_clarity",
-        "item_count": 3
-      },
-      {
-        "name": "module-boundary-fixes",
-        "description": "Fix vcs barrel exports, remove dead shared barrel, share PR strategy instance \u2014 improves cross_module_architecture, mid_level_elegance",
-        "item_count": 3
-      },
-      {
-        "name": "quick-wins",
-        "description": "Trivial fixes: simplify boolean return, remove formulaic comments, extract leaf renderer, defer sync-command singletons \u2014 improves logic_clarity, ai_generated_debt, low_level_elegance, initialization_coupling",
-        "item_count": 4
-      },
-      {
-        "name": "test-coverage",
-        "description": "Write unit tests for gh-api-utils.ts pure functions and resolveGitHubToken branching \u2014 improves test_strategy",
-        "item_count": 2
-      },
-      {
-        "name": "quick-cleanups",
-        "description": "Single-edit cleanups: remove comments, fix param name, use existing helpers",
-        "item_count": 5
-      },
-      {
-        "name": "import-cleanup",
-        "description": "Fix import paths to use canonical locations and barrel exports",
-        "item_count": 2
-      },
-      {
-        "name": "consolidate-utilities",
-        "description": "Reuse existing shared utilities instead of reimplementing",
-        "item_count": 4
-      },
-      {
-        "name": "type-safety-fixes",
-        "description": "Add function overloads and remove unsafe casts",
-        "item_count": 2
-      },
-      {
-        "name": "error-handling",
-        "description": "Consistent error wrapping across PR strategies",
-        "item_count": 1
-      },
-      {
-        "name": "naming-alignment",
-        "description": "Align naming conventions across codebase",
-        "item_count": 2
-      },
-      {
-        "name": "mid-level-refactor",
-        "description": "Reduce redundant IO and implicit mutation contracts",
-        "item_count": 2
-      },
-      {
-        "name": "api-refactor",
-        "description": "Align constructor signatures with options bag pattern",
-        "item_count": 1
-      },
-      {
-        "name": "output-structural-debt",
-        "description": "Fix import cycle between sync-report.ts and unified-summary.ts, delete dead output barrel",
-        "item_count": 3
-      },
-      {
-        "name": "output-dead-code",
-        "description": "Remove dead old summary API (formatSummary/writeSummary/SummaryData) superseded by unified-summary",
-        "item_count": 1
-      },
-      {
-        "name": "quick-consistency-fixes",
-        "description": "Standalone 1-2 file fixes: restating comments, options bag, error wrapping, type alias usage",
-        "item_count": 5
-      },
-      {
-        "name": "cli-cleanup",
-        "description": "Fix module-level singletons and add unit tests for CLI entry point",
-        "item_count": 2
-      },
-      {
-        "name": "dead-summary-cleanup",
-        "description": "Remove dead old summary API code: delete summary-utils.ts, remove formatSummary/writeSummary/SummaryData and all private helpers from github-summary.ts, update tests",
-        "item_count": 2
-      },
-      {
-        "name": "type-safety-docs",
-        "description": "Add documenting comment to withGitHubGuards in base-processor.ts explaining the TResult cast invariant",
-        "item_count": 2
-      },
-      {
-        "name": "output-renderSyncLines-fix",
-        "description": "Move renderSyncLines from unified-summary.ts to sync-report.ts, fixing dependency inversion",
-        "item_count": 2
-      },
-      {
-        "name": "lifecycle-cleanup",
-        "description": "Extract shared flag-building helper and standardize polling loop idiom in github-lifecycle-provider.ts",
-        "item_count": 2
-      },
-      {
-        "name": "comment-cleanup",
-        "description": "Fix mispositioned/restating comments: orphan docblock, type-labeling comments, missing loop explanation",
-        "item_count": 3
-      },
-      {
-        "name": "design-fixes",
-        "description": "Use countActions utility in settings-report-builder.ts and refactor ruleset update params",
-        "item_count": 2
-      },
-      {
-        "name": "init-fix",
-        "description": "Defer package.json readFileSync from module scope to lazy callback in program.ts",
-        "item_count": 1
-      },
-      {
-        "name": "auto/test_coverage-transitive_only",
-        "description": "Fix 28 test coverage issues",
-        "item_count": 26
-      },
-      {
-        "name": "auto/exports-export",
-        "description": "Fix 3 exports issues",
-        "item_count": 3
-      },
-      {
-        "name": "auto/exports-type",
-        "description": "Fix 23 exports issues",
-        "item_count": 23
-      },
-      {
-        "name": "type-safety-literal-consolidation",
-        "description": "Promote canonical RepoPlatform alias and export ActiveAction/LifecycleActionKind/FileActionKind; replace six inline literal unions across lifecycle, output, and sync type shapes with the shared aliases",
-        "item_count": 6
-      },
-      {
-        "name": "structure-nav-layout",
-        "description": "Add src/repo/index.ts barrel, relocate sanitize-utils into src/vcs/, move unified-summary.ts to src/cli/, and stage test/unit/ mirror migration in four validate-after-each steps",
-        "item_count": 5
-      },
-      {
-        "name": "low-elegance-helper-extraction",
-        "description": "Extract shared helpers to collapse parallel walk/merge/enrichment/push blocks: resolveContentInFilesMap, grouped-record filter, enrichSettingsContext, mergeNamedEntries, pushFailure",
-        "item_count": 5
-      },
-      {
-        "name": "convention-and-naming-quick-wins",
-        "description": "Trivial single-file renames, deletions, and version bumps across multiple dimensions: docstring move, ado/azure prefix align, counter helper use, node floor bump, naming cleanups, deepEqual return fix",
-        "item_count": 10
-      },
-      {
-        "name": "design-coherence-factory-consolidation",
-        "description": "Introduce SettingsProcessorFactories record collapsing four parallel factory fields, and split validateSettings into per-concern dispatchers while keeping thin orchestrator shell",
-        "item_count": 3
-      },
-      {
-        "name": "cross-module-architecture-layering",
-        "description": "Relocate gh-api-utils and xfg-template RepoInfo couplings out of src/shared/ to restore shared-as-leaf layering, and fix the repo barrel import angle at the same time",
-        "item_count": 2
-      },
-      {
-        "name": "api-and-contract-coherence",
-        "description": "Rename rethrowIfUnexpectedCommitError to classifyCommitError, IPRStrategy.checkExistingPR to findExistingPRUrl, fix IRepoSettingsStrategy verbs, migrate IRepoLifecycleProvider to options bag, clarify GitOps.commit dry-run JSDoc",
-        "item_count": 5
-      },
-      {
-        "name": "initialization-coupling-fixes",
-        "description": "Defer program.ts readFileSync version read to lazy callback, and move sync-command.ts module-level let singletons into per-invocation const bindings",
-        "item_count": 2
-      },
-      {
-        "name": "error-consistency-newly-surfaced",
-        "description": "After cross-checking against the 101 resolved error_consistency patterns, replace commit-push-manager substring matching with typed error classification and replace ambiguous false returns from closeExistingPR with discriminated status",
-        "item_count": 2
-      },
-      {
-        "name": "mid-elegance-settings-report-delta",
-        "description": "Fix the settings-report-builder codeScanning counter bypass by routing codeScanning entries through countActions instead of a parallel csCreates/csUpdates counter",
-        "item_count": 1
-      }
-    ],
-    "total_ordered": 18,
-    "total_skipped": 38,
-    "plan_overrides_narrative": true
-  },
-  "overall_score": 91.4,
-  "objective_score": 92.7,
-  "strict_score": 90.2,
-  "scorecard_dimensions": [
-    {
-      "name": "File health",
-      "score": 96.4,
-      "strict": 96.4,
-      "checks": 118,
-      "failing": 6,
-      "tier": 3,
-      "subjective": false
-    },
-    {
-      "name": "AI generated debt",
-      "score": 93.5,
-      "strict": 93.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "ai_generated_debt"
-      ]
-    },
-    {
-      "name": "API coherence",
-      "score": 92.0,
-      "strict": 92.0,
-      "checks": 10,
-      "failing": 2,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "api_surface_coherence"
-      ]
-    },
-    {
-      "name": "Abstraction fit",
-      "score": 90.5,
-      "strict": 90.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "abstraction_fitness"
-      ]
-    },
-    {
-      "name": "Auth consistency",
-      "score": 95.0,
-      "strict": 95.0,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "authorization_consistency"
-      ]
-    },
-    {
-      "name": "Code quality",
-      "score": 96.9,
-      "strict": 94.4,
-      "checks": 684,
-      "failing": 42,
-      "tier": 3,
-      "subjective": false
-    },
-    {
-      "name": "Contracts",
-      "score": 92.5,
-      "strict": 92.5,
-      "checks": 10,
-      "failing": 2,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "contract_coherence"
-      ]
-    },
-    {
-      "name": "Convention drift",
-      "score": 91.5,
-      "strict": 91.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "convention_outlier"
-      ]
-    },
-    {
-      "name": "Cross-module arch",
-      "score": 93.5,
-      "strict": 93.5,
-      "checks": 10,
-      "failing": 2,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "cross_module_architecture"
-      ]
-    },
-    {
-      "name": "Design coherence",
-      "score": 89.0,
-      "strict": 89.0,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "design_coherence"
-      ]
-    },
-    {
-      "name": "Duplication",
-      "score": 99.5,
-      "strict": 86.3,
-      "checks": 293,
-      "failing": 2,
-      "tier": 3,
-      "subjective": false
-    },
-    {
-      "name": "Elegance",
-      "score": 90.7,
-      "strict": 90.7,
-      "checks": 30,
-      "failing": 1,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "high_level_elegance",
-        "low_level_elegance",
-        "mid_level_elegance"
-      ]
-    },
-    {
-      "name": "Error consistency",
-      "score": 92.0,
-      "strict": 92.0,
-      "checks": 10,
-      "failing": 2,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "error_consistency"
-      ]
-    },
-    {
-      "name": "Naming quality",
-      "score": 91.5,
-      "strict": 91.5,
-      "checks": 10,
-      "failing": 1,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "naming_quality"
-      ]
-    },
-    {
-      "name": "Security",
-      "score": 99.6,
-      "strict": 95.1,
-      "checks": 236,
-      "failing": 1,
-      "tier": 4,
-      "subjective": false
-    },
-    {
-      "name": "Stale migration",
-      "score": 97.5,
-      "strict": 97.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "incomplete_migration"
-      ]
-    },
-    {
-      "name": "Structure nav",
-      "score": 88.5,
-      "strict": 88.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "package_organization"
-      ]
-    },
-    {
-      "name": "Test health",
-      "score": 70.2,
-      "strict": 64.5,
-      "checks": 1158,
-      "failing": 28,
-      "tier": 4,
-      "subjective": false
-    },
-    {
-      "name": "Test strategy",
-      "score": 92.0,
-      "strict": 92.0,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "test_strategy"
-      ]
-    },
-    {
-      "name": "Type safety",
-      "score": 89.5,
-      "strict": 89.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "type_safety"
-      ]
-    }
-  ],
-  "subjective_measures": [
-    {
-      "name": "AI generated debt",
-      "score": 93.5,
-      "strict": 93.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "ai_generated_debt"
-      ]
-    },
-    {
-      "name": "API coherence",
-      "score": 92.0,
-      "strict": 92.0,
-      "checks": 10,
-      "failing": 2,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "api_surface_coherence"
-      ]
-    },
-    {
-      "name": "Abstraction fit",
-      "score": 90.5,
-      "strict": 90.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "abstraction_fitness"
-      ]
-    },
-    {
-      "name": "Auth consistency",
-      "score": 95.0,
-      "strict": 95.0,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "authorization_consistency"
-      ]
-    },
-    {
-      "name": "Contracts",
-      "score": 92.5,
-      "strict": 92.5,
-      "checks": 10,
-      "failing": 2,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "contract_coherence"
-      ]
-    },
-    {
-      "name": "Convention drift",
-      "score": 91.5,
-      "strict": 91.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "convention_outlier"
-      ]
-    },
-    {
-      "name": "Cross-module arch",
-      "score": 93.5,
-      "strict": 93.5,
-      "checks": 10,
-      "failing": 2,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "cross_module_architecture"
-      ]
-    },
-    {
-      "name": "Design coherence",
-      "score": 89.0,
-      "strict": 89.0,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "design_coherence"
-      ]
-    },
-    {
-      "name": "Elegance",
-      "score": 90.7,
-      "strict": 90.7,
-      "checks": 30,
-      "failing": 1,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "high_level_elegance",
-        "low_level_elegance",
-        "mid_level_elegance"
-      ]
-    },
-    {
-      "name": "Error consistency",
-      "score": 92.0,
-      "strict": 92.0,
-      "checks": 10,
-      "failing": 2,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "error_consistency"
-      ]
-    },
-    {
-      "name": "Naming quality",
-      "score": 91.5,
-      "strict": 91.5,
-      "checks": 10,
-      "failing": 1,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "naming_quality"
-      ]
-    },
-    {
-      "name": "Stale migration",
-      "score": 97.5,
-      "strict": 97.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "incomplete_migration"
-      ]
-    },
-    {
-      "name": "Structure nav",
-      "score": 88.5,
-      "strict": 88.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "package_organization"
-      ]
-    },
-    {
-      "name": "Test strategy",
-      "score": 92.0,
-      "strict": 92.0,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "test_strategy"
-      ]
-    },
-    {
-      "name": "Type safety",
-      "score": 89.5,
-      "strict": 89.5,
-      "checks": 10,
-      "failing": 0,
-      "tier": 4,
-      "subjective": true,
-      "placeholder": false,
-      "cli_keys": [
-        "type_safety"
-      ]
-    }
-  ],
   "config": {
     "target_strict_score": 100,
     "review_max_age_days": 30,

--- a/.desloppify/query.json
+++ b/.desloppify/query.json
@@ -1,11 +1,499 @@
 {
   "command": "next",
-  "items": [],
+  "items": [
+    {
+      "id": "cross-module-architecture-layering",
+      "action_type": "manual_fix",
+      "summary": "Relocate gh-api-utils and xfg-template RepoInfo couplings out of src/shared/ to restore shared-as-leaf layering, and fix the repo barrel import angle at the same time",
+      "member_count": 2,
+      "members": [
+        {
+          "id": "review::.::holistic::cross_module_architecture::repo_module_missing_barrel",
+          "confidence": "high",
+          "detector": "review",
+          "file": ".",
+          "summary": "src/repo/ is the only top-level module without an index.ts barrel; consumers import from detector.ts as a de-facto barrel",
+          "status": "open",
+          "kind": "issue",
+          "primary_command": "desloppify plan resolve \"review::.::holistic::cross_module_architecture::repo_module_missing_barrel\" --note \"<what you did>\" --confirm"
+        },
+        {
+          "id": "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
+          "confidence": "medium",
+          "detector": "review",
+          "file": ".",
+          "summary": "src/shared/ has two files that import types from src/repo/, inverting the shared-as-leaf layering used for runtime imports",
+          "status": "open",
+          "kind": "issue",
+          "primary_command": "desloppify plan resolve \"review::.::holistic::cross_module_architecture::shared_imports_repo_type\" --note \"<what you did>\" --confirm"
+        }
+      ],
+      "cluster_name": "cross-module-architecture-layering",
+      "cluster_auto": false,
+      "detector": "review",
+      "kind": "cluster",
+      "primary_command": "desloppify next --cluster cross-module-architecture-layering --count 10",
+      "action_steps": [
+        {
+          "title": "Relocate gh-api-utils and xfg-template out of src/shared/ to restore shared-as-leaf layering",
+          "detail": "src/shared/gh-api-utils.ts imports RepoInfo from src/repo/detector.ts, inverting the shared-as-leaf layering. Move src/shared/gh-api-utils.ts into src/repo/ (or src/vcs/) and update all importers. src/shared/xfg-template.ts also typings RepoInfo \u2014 either move the file or invert the dep by narrowing to a RepoDisplayInfo shape passed in. Coordinate with structure-nav-layout which creates the src/repo/ barrel so importers can pivot to '../repo/index.js'.",
+          "effort": "medium",
+          "issue_refs": [
+            "shared_imports_repo_type",
+            "repo_module_missing_barrel"
+          ]
+        },
+        {
+          "title": "Verify madge graph after shared/repo layering fix",
+          "detail": "After the src/shared/gh-api-utils.ts and src/shared/xfg-template.ts relocations land (step 1), run 'npx madge --circular src/' and inspect the graph. Confirm no file under src/shared/ imports from src/repo/detector.ts, src/vcs/, src/cli/, src/sync/, src/settings/, src/lifecycle/, src/output/, or src/config/ (shared must remain a leaf). Confirm downstream importers still resolve via src/repo/detector.ts (or the new barrel from structure-nav). Commit only if graph is clean and no cycles were introduced.",
+          "effort": "trivial",
+          "issue_refs": [
+            "repo_module_missing_barrel",
+            "shared_imports_repo_type"
+          ]
+        }
+      ]
+    }
+  ],
   "queue": {
-    "total": 0,
+    "total": 1,
     "mode": "execution"
   },
-  "narrative": {},
+  "narrative": {
+    "phase": "refinement",
+    "headline": "\u26a0 1 security issue \u2014 review before other cleanup.  (12 review work items \u2014 run `desloppify show review --status open`)",
+    "dimensions": {
+      "lowest_dimensions": [
+        {
+          "name": "Test health",
+          "strict": 64.5,
+          "failing": 28,
+          "impact": 0.0
+        },
+        {
+          "name": "Duplication",
+          "strict": 86.3,
+          "failing": 2,
+          "impact": 0.0
+        },
+        {
+          "name": "Structure nav",
+          "strict": 88.5,
+          "failing": 0,
+          "impact": 0.0,
+          "subjective": true,
+          "impact_description": "re-review to improve"
+        }
+      ],
+      "biggest_gap_dimensions": [
+        {
+          "name": "Duplication",
+          "lenient": 99.5,
+          "strict": 86.3,
+          "gap": 13.2,
+          "wontfix_count": 0
+        },
+        {
+          "name": "Test health",
+          "lenient": 70.2,
+          "strict": 64.5,
+          "gap": 5.7,
+          "wontfix_count": 0
+        },
+        {
+          "name": "Security",
+          "lenient": 99.6,
+          "strict": 95.1,
+          "gap": 4.5,
+          "wontfix_count": 0
+        }
+      ],
+      "stagnant_dimensions": [
+        {
+          "name": "Code quality",
+          "strict": 94.4,
+          "stuck_scans": 5
+        },
+        {
+          "name": "File health",
+          "strict": 96.4,
+          "stuck_scans": 5
+        },
+        {
+          "name": "AI generated debt",
+          "strict": 93.5,
+          "stuck_scans": 5
+        },
+        {
+          "name": "Auth consistency",
+          "strict": 95.0,
+          "stuck_scans": 5
+        },
+        {
+          "name": "High elegance",
+          "strict": 91.0,
+          "stuck_scans": 5
+        },
+        {
+          "name": "Logic clarity",
+          "strict": 93.5,
+          "stuck_scans": 5
+        },
+        {
+          "name": "Low elegance",
+          "strict": 89.0,
+          "stuck_scans": 5
+        },
+        {
+          "name": "Mid elegance",
+          "strict": 92.0,
+          "stuck_scans": 5
+        }
+      ]
+    },
+    "actions": [
+      {
+        "type": "reorganize",
+        "detector": "flat_dirs",
+        "count": 1,
+        "description": "1 flat_dirs issues \u2014 create subdirectories and use `desloppify move`",
+        "command": "desloppify show flat_dirs --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 1,
+        "lane": "restructure"
+      },
+      {
+        "type": "reorganize",
+        "detector": "single_use",
+        "count": 2,
+        "description": "2 single_use issues \u2014 inline or relocate with `desloppify move`",
+        "command": "desloppify show single_use --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 2,
+        "lane": "restructure"
+      },
+      {
+        "type": "reorganize",
+        "detector": "facade",
+        "count": 1,
+        "description": "1 facade issues \u2014 flatten re-export facades or consolidate barrel files",
+        "command": "desloppify show facade --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 3,
+        "lane": "restructure"
+      },
+      {
+        "type": "refactor",
+        "detector": "structural",
+        "count": 44,
+        "description": "44 structural work items \u2014 review large files \u2014 split only when responsibilities are clearly separable",
+        "command": "desloppify show structural --status open",
+        "impact": 0.0,
+        "dimension": "File health",
+        "priority": 4,
+        "lane": "refactor_0"
+      },
+      {
+        "type": "refactor",
+        "detector": "props",
+        "count": 2,
+        "description": "2 props work items \u2014 split bloated components, extract sub-components",
+        "command": "desloppify show props --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 5,
+        "lane": "refactor_0"
+      },
+      {
+        "type": "refactor",
+        "detector": "test_coverage",
+        "count": 28,
+        "description": "28 test_coverage issues in 1 cluster(s) \u2014 run `desloppify next`",
+        "command": "desloppify next",
+        "impact": 0.0,
+        "dimension": "Test health",
+        "priority": 6,
+        "clusters": [
+          "auto/test_coverage-transitive_only"
+        ],
+        "cluster_count": 1,
+        "lane": "test_coverage"
+      },
+      {
+        "type": "refactor",
+        "detector": "signature",
+        "count": 1,
+        "description": "1 signature work items \u2014 consolidate inconsistent function signatures",
+        "command": "desloppify show signature --status open",
+        "impact": 0.0,
+        "dimension": "Unknown",
+        "priority": 7,
+        "lane": "refactor_0"
+      },
+      {
+        "type": "refactor",
+        "detector": "responsibility_cohesion",
+        "count": 1,
+        "description": "1 responsibility_cohesion work items \u2014 split modules with too many responsibilities \u2014 extract focused sub-modules",
+        "command": "desloppify show responsibility_cohesion --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 8,
+        "lane": "refactor_1"
+      },
+      {
+        "type": "refactor",
+        "detector": "boilerplate_duplication",
+        "count": 2,
+        "description": "2 boilerplate_duplication work items \u2014 extract shared boilerplate into reusable helpers or base classes",
+        "command": "desloppify show boilerplate_duplication --status open",
+        "impact": 0.0,
+        "dimension": "Duplication",
+        "priority": 9,
+        "lane": "refactor_2"
+      },
+      {
+        "type": "refactor",
+        "detector": "review",
+        "count": 12,
+        "description": "12 review work items need investigation \u2014 run `desloppify show review --status open` to see them",
+        "command": "desloppify show review --status open",
+        "impact": 0.0,
+        "dimension": "Unknown",
+        "priority": 10,
+        "lane": "refactor_3"
+      },
+      {
+        "type": "manual_fix",
+        "detector": "smells",
+        "count": 97,
+        "description": "97 smells issues \u2014 inspect with `desloppify next` and fix manually",
+        "command": "desloppify show smells --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 11,
+        "lane": "refactor_0"
+      },
+      {
+        "type": "manual_fix",
+        "detector": "exports",
+        "count": 26,
+        "description": "26 exports issues in 2 cluster(s) \u2014 run `desloppify next`",
+        "command": "desloppify next",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 12,
+        "clusters": [
+          "auto/exports-export",
+          "auto/exports-type"
+        ],
+        "cluster_count": 2,
+        "lane": "refactor_4"
+      },
+      {
+        "type": "manual_fix",
+        "detector": "stale_exclude",
+        "count": 1,
+        "description": "1 stale_exclude work items \u2014 remove stale exclusion or verify it's still needed",
+        "command": "desloppify show stale_exclude --status open",
+        "impact": 0.0,
+        "dimension": "Code quality",
+        "priority": 13,
+        "lane": "refactor_5"
+      },
+      {
+        "type": "manual_fix",
+        "detector": "security",
+        "count": 1,
+        "description": "1 security work items \u2014 review and fix security issues \u2014 prioritize by severity",
+        "command": "desloppify show security --status open",
+        "impact": 0.0,
+        "dimension": "Security",
+        "priority": 14,
+        "lane": "refactor_6"
+      }
+    ],
+    "strategy": {
+      "fixer_leverage": {
+        "auto_fixable_count": 0,
+        "total_count": 249,
+        "coverage": 0.0,
+        "impact_ratio": 0.0,
+        "recommendation": "none"
+      },
+      "lanes": {
+        "restructure": {
+          "actions": [
+            1,
+            2,
+            3
+          ],
+          "file_count": 4,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "refactor_0": {
+          "actions": [
+            4,
+            5,
+            7,
+            11
+          ],
+          "file_count": 94,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "refactor_1": {
+          "actions": [
+            8
+          ],
+          "file_count": 1,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "refactor_2": {
+          "actions": [
+            9
+          ],
+          "file_count": 2,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "refactor_3": {
+          "actions": [
+            10
+          ],
+          "file_count": 1,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "refactor_4": {
+          "actions": [
+            12
+          ],
+          "file_count": 9,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "refactor_5": {
+          "actions": [
+            13
+          ],
+          "file_count": 1,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "refactor_6": {
+          "actions": [
+            14
+          ],
+          "file_count": 1,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        },
+        "test_coverage": {
+          "actions": [
+            6
+          ],
+          "file_count": 28,
+          "total_impact": 0.0,
+          "automation": "manual",
+          "run_first": false
+        }
+      },
+      "can_parallelize": true,
+      "hint": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 12 issue(s) \u2014 `desloppify show review --status open`."
+    },
+    "tools": {
+      "fixers": [
+        {
+          "name": "dead-useeffect",
+          "detector": "smells",
+          "open_count": 97,
+          "command": "desloppify autofix dead-useeffect --dry-run"
+        },
+        {
+          "name": "empty-if-chain",
+          "detector": "smells",
+          "open_count": 97,
+          "command": "desloppify autofix empty-if-chain --dry-run"
+        }
+      ],
+      "move": {
+        "available": true,
+        "relevant": true,
+        "reason": "2 single-use files + 1 flat directories",
+        "usage": "desloppify move <source> <dest> [--dry-run]"
+      },
+      "plan": {
+        "command": "desloppify plan",
+        "description": "Generate prioritized markdown cleanup plan"
+      },
+      "badge": {
+        "generated": true,
+        "in_readme": false,
+        "path": "scorecard.png",
+        "recommendation": "Add to README: <img src=\"scorecard.png\" width=\"100%\">"
+      }
+    },
+    "debt": {
+      "overall_gap": 0.9,
+      "wontfix_count": 2,
+      "worst_dimension": "Duplication",
+      "worst_gap": 13.2,
+      "trend": "growing"
+    },
+    "milestone": null,
+    "primary_action": {
+      "command": "desloppify show flat_dirs --status open",
+      "description": "1 flat_dirs issues \u2014 create subdirectories and use `desloppify move`"
+    },
+    "why_now": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 12 issue(s) \u2014 `desloppify show review --status open`.",
+    "verification_step": {
+      "command": "desloppify scan",
+      "reason": "revalidate after changes"
+    },
+    "risk_flags": [
+      {
+        "type": "wontfix_gap",
+        "severity": "medium",
+        "message": "Strict/lenient gap is 0.9 pts with 2 wontfix issues"
+      }
+    ],
+    "strict_target": {
+      "target": 85.0,
+      "current": 90.2,
+      "gap": -5.2,
+      "state": "above",
+      "warning": null
+    },
+    "reminders": [],
+    "reminder_history": {
+      "auto_fixers_available": 3,
+      "zone_classification": 3,
+      "dry_run_first": 3,
+      "report_scores": 142,
+      "feedback_nudge": 3,
+      "review_findings_pending": 3,
+      "stagnant_nudge": 3,
+      "review_not_run": 3,
+      "badge_recommendation": 3,
+      "review_issues_pending": 3,
+      "wontfix_growing": 3,
+      "fp_calibration_test_coverage_production": 3
+    }
+  },
   "agent_notes": [
     "Do NOT use `desloppify plan skip` unless the user explicitly asks you to skip an item.",
     "If you cannot fix an item, report it and move to the next one.",
@@ -13,7 +501,7 @@
   ],
   "plan": {
     "active": true,
-    "focus": "structure-nav-layout",
+    "focus": null,
     "clusters": [
       {
         "name": "token-resolution",
@@ -251,7 +739,7 @@
         "item_count": 1
       }
     ],
-    "total_ordered": 26,
+    "total_ordered": 18,
     "total_skipped": 38,
     "plan_overrides_narrative": true
   },
@@ -299,7 +787,7 @@
       "score": 90.5,
       "strict": 90.5,
       "checks": 10,
-      "failing": 1,
+      "failing": 0,
       "tier": 4,
       "subjective": true,
       "placeholder": false,
@@ -373,7 +861,7 @@
       "score": 89.0,
       "strict": 89.0,
       "checks": 10,
-      "failing": 2,
+      "failing": 0,
       "tier": 4,
       "subjective": true,
       "placeholder": false,
@@ -395,7 +883,7 @@
       "score": 90.7,
       "strict": 90.7,
       "checks": 30,
-      "failing": 6,
+      "failing": 1,
       "tier": 4,
       "subjective": true,
       "placeholder": false,
@@ -534,7 +1022,7 @@
       "score": 90.5,
       "strict": 90.5,
       "checks": 10,
-      "failing": 1,
+      "failing": 0,
       "tier": 4,
       "subjective": true,
       "placeholder": false,
@@ -599,7 +1087,7 @@
       "score": 89.0,
       "strict": 89.0,
       "checks": 10,
-      "failing": 2,
+      "failing": 0,
       "tier": 4,
       "subjective": true,
       "placeholder": false,
@@ -612,7 +1100,7 @@
       "score": 90.7,
       "strict": 90.7,
       "checks": 30,
-      "failing": 6,
+      "failing": 1,
       "tier": 4,
       "subjective": true,
       "placeholder": false,
@@ -729,7 +1217,7 @@
     "needs_rescan": false,
     "languages": {},
     "commit_tracking_enabled": true,
-    "commit_pr": 0,
+    "commit_pr": 706,
     "commit_default_branch": "",
     "commit_message_template": "desloppify: {status} {count} issue(s) \u2014 {summary}",
     "trust_plugins": false,

--- a/.desloppify/query.json
+++ b/.desloppify/query.json
@@ -1,11 +1,11 @@
 {
   "command": "resolve",
   "patterns": [
-    "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+    "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift"
   ],
   "status": "fixed",
   "resolved": [
-    "review::.::holistic::cross_module_architecture::repo_module_missing_barrel"
+    "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift"
   ],
   "count": 1,
   "next_command": "desloppify next",
@@ -17,10 +17,10 @@
   "prev_objective_score": 92.7,
   "prev_strict_score": 90.2,
   "prev_verified_strict_score": 90.3,
-  "attestation": "I have actually src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider). and I am not gaming the score.",
+  "attestation": "I have actually Renamed IRepoSettingsStrategy methods: getSettings->get, updateSettings->update, setVulnerabilityAlerts->updateVulnerabilityAlerts. and I am not gaming the score.",
   "narrative": {
     "phase": "refinement",
-    "headline": "\u26a0 1 security issue \u2014 review before other cleanup.  (10 review work items \u2014 run `desloppify show review --status open`)",
+    "headline": "\u26a0 1 security issue \u2014 review before other cleanup.  (5 review work items \u2014 run `desloppify show review --status open`)",
     "dimensions": {
       "lowest_dimensions": [
         {
@@ -213,8 +213,8 @@
       {
         "type": "refactor",
         "detector": "review",
-        "count": 10,
-        "description": "10 review work items need investigation \u2014 run `desloppify show review --status open` to see them",
+        "count": 5,
+        "description": "5 review work items need investigation \u2014 run `desloppify show review --status open` to see them",
         "command": "desloppify show review --status open",
         "impact": 0.0,
         "dimension": "Unknown",
@@ -269,7 +269,7 @@
     "strategy": {
       "fixer_leverage": {
         "auto_fixable_count": 0,
-        "total_count": 243,
+        "total_count": 228,
         "coverage": 0.0,
         "impact_ratio": 0.0,
         "recommendation": "none"
@@ -363,7 +363,7 @@
         }
       },
       "can_parallelize": true,
-      "hint": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 10 issue(s) \u2014 `desloppify show review --status open`."
+      "hint": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 5 issue(s) \u2014 `desloppify show review --status open`."
     },
     "tools": {
       "fixers": [
@@ -409,7 +409,7 @@
       "command": "desloppify show flat_dirs --status open",
       "description": "1 flat_dirs issues \u2014 create subdirectories and use `desloppify move`"
     },
-    "why_now": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 10 issue(s) \u2014 `desloppify show review --status open`.",
+    "why_now": "9 independent workstreams, safe to parallelize. Rescan after each phase to verify. Review: 5 issue(s) \u2014 `desloppify show review --status open`.",
     "verification_step": {
       "command": "desloppify scan",
       "reason": "revalidate after changes"

--- a/.desloppify/state-typescript.json
+++ b/.desloppify/state-typescript.json
@@ -12,8 +12,8 @@
     "auto_resolved": 1095,
     "deferred": 0,
     "false_positive": 87,
-    "fixed": 255,
-    "open": 225,
+    "fixed": 257,
+    "open": 223,
     "triaged_out": 0,
     "wontfix": 2,
     "by_tier": {
@@ -21,8 +21,8 @@
         "auto_resolved": 8,
         "deferred": 0,
         "false_positive": 5,
-        "fixed": 101,
-        "open": 4,
+        "fixed": 102,
+        "open": 3,
         "triaged_out": 0,
         "wontfix": 0
       },
@@ -30,8 +30,8 @@
         "auto_resolved": 364,
         "deferred": 0,
         "false_positive": 50,
-        "fixed": 116,
-        "open": 41,
+        "fixed": 117,
+        "open": 40,
         "triaged_out": 0,
         "wontfix": 2
       },
@@ -94,8 +94,8 @@
       "source": "holistic",
       "assessed_at": "2026-04-16T05:39:25+00:00",
       "needs_review_refresh": true,
-      "refresh_reason": "mechanical_issues_changed",
-      "stale_since": "2026-04-16T05:39:25+00:00"
+      "refresh_reason": "review_issue_fixed",
+      "stale_since": "2026-04-16T09:20:50+00:00"
     },
     "convention_outlier": {
       "score": 91.5,
@@ -3187,13 +3187,13 @@
       "strict": 93.5,
       "verified_strict_score": 93.5,
       "checks": 10,
-      "failing": 2,
+      "failing": 0,
       "tier": 4,
       "detectors": {
         "subjective_assessment": {
           "potential": 10,
           "pass_rate": 0.935,
-          "failing": 2,
+          "failing": 0,
           "weighted_failures": 0.65,
           "assessment_score": 93.5,
           "placeholder": false,
@@ -68667,11 +68667,11 @@
         "reasoning": "",
         "summary_hash": "9e22bfd1"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider).",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:20:50+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -68679,7 +68679,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually src/repo/index.ts barrel exists with all public re-exports (types, detector, utils, metadata-provider). and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:20:50+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::cross_module_architecture::shared_imports_repo_type": {
       "id": "review::.::holistic::cross_module_architecture::shared_imports_repo_type",
@@ -68706,11 +68712,11 @@
         "reasoning": "",
         "summary_hash": "f419f2f1"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Inverted dependency: gh-api-utils defines local GitHubApiTarget, xfg-template defines local RepoDisplayInfo \u2014 both structurally compatible with repo types. shared/ no longer imports repo/.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:20:49+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -68718,7 +68724,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Inverted dependency: gh-api-utils defines local GitHubApiTarget, xfg-template defines local RepoDisplayInfo \u2014 both structurally compatible with repo types. shared/ no longer imports repo/. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:20:49+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::high_level_elegance::sync_command_is_app_orchestrator_in_cli": {
       "id": "review::.::holistic::high_level_elegance::sync_command_is_app_orchestrator_in_cli",

--- a/.desloppify/state-typescript.json
+++ b/.desloppify/state-typescript.json
@@ -12,8 +12,8 @@
     "auto_resolved": 1095,
     "deferred": 0,
     "false_positive": 87,
-    "fixed": 247,
-    "open": 233,
+    "fixed": 255,
+    "open": 225,
     "triaged_out": 0,
     "wontfix": 2,
     "by_tier": {
@@ -21,8 +21,8 @@
         "auto_resolved": 8,
         "deferred": 0,
         "false_positive": 5,
-        "fixed": 97,
-        "open": 8,
+        "fixed": 101,
+        "open": 4,
         "triaged_out": 0,
         "wontfix": 0
       },
@@ -30,8 +30,8 @@
         "auto_resolved": 364,
         "deferred": 0,
         "false_positive": 50,
-        "fixed": 113,
-        "open": 44,
+        "fixed": 116,
+        "open": 41,
         "triaged_out": 0,
         "wontfix": 2
       },
@@ -39,8 +39,8 @@
         "auto_resolved": 648,
         "deferred": 0,
         "false_positive": 32,
-        "fixed": 17,
-        "open": 180,
+        "fixed": 18,
+        "open": 179,
         "triaged_out": 0,
         "wontfix": 0
       },
@@ -134,8 +134,8 @@
         "Type Discipline": 93.0
       },
       "needs_review_refresh": true,
-      "refresh_reason": "review_issue_false_positive",
-      "stale_since": "2026-04-16T07:26:38+00:00"
+      "refresh_reason": "review_issue_fixed",
+      "stale_since": "2026-04-16T09:14:45+00:00"
     },
     "api_surface_coherence": {
       "score": 92.0,
@@ -193,15 +193,18 @@
     "low_level_elegance": {
       "score": 89.0,
       "source": "holistic",
-      "assessed_at": "2026-04-16T05:39:25+00:00"
+      "assessed_at": "2026-04-16T05:39:25+00:00",
+      "needs_review_refresh": true,
+      "refresh_reason": "review_issue_fixed",
+      "stale_since": "2026-04-16T09:04:35+00:00"
     },
     "design_coherence": {
       "score": 89.0,
       "source": "holistic",
       "assessed_at": "2026-04-16T05:39:25+00:00",
       "needs_review_refresh": true,
-      "refresh_reason": "mechanical_issues_changed",
-      "stale_since": "2026-04-16T05:39:33+00:00"
+      "refresh_reason": "review_issue_fixed",
+      "stale_since": "2026-04-16T09:14:44+00:00"
     },
     "contract_coherence": {
       "score": 92.5,
@@ -3043,13 +3046,13 @@
       "strict": 90.5,
       "verified_strict_score": 90.5,
       "checks": 10,
-      "failing": 1,
+      "failing": 0,
       "tier": 4,
       "detectors": {
         "subjective_assessment": {
           "potential": 10,
           "pass_rate": 0.905,
-          "failing": 1,
+          "failing": 0,
           "weighted_failures": 0.95,
           "assessment_score": 90.5,
           "placeholder": false,
@@ -3226,13 +3229,13 @@
       "strict": 89.0,
       "verified_strict_score": 89.0,
       "checks": 10,
-      "failing": 2,
+      "failing": 0,
       "tier": 4,
       "detectors": {
         "subjective_assessment": {
           "potential": 10,
           "pass_rate": 0.89,
-          "failing": 2,
+          "failing": 0,
           "weighted_failures": 1.1,
           "assessment_score": 89.0,
           "placeholder": false,
@@ -3352,13 +3355,13 @@
       "strict": 89.0,
       "verified_strict_score": 89.0,
       "checks": 10,
-      "failing": 5,
+      "failing": 0,
       "tier": 4,
       "detectors": {
         "subjective_assessment": {
           "potential": 10,
           "pass_rate": 0.89,
-          "failing": 5,
+          "failing": 0,
           "weighted_failures": 1.1,
           "assessment_score": 89.0,
           "placeholder": false,
@@ -69251,11 +69254,11 @@
         "reasoning": "",
         "summary_hash": "4310e945"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Collapsed four factory fields into a single SettingsProcessorFactories record, reducing ceremony while preserving per-kind typing via interface members.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:14:45+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69263,7 +69266,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Collapsed four factory fields into a single SettingsProcessorFactories record, reducing ceremony while preserving per-kind typing via interface members. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:14:45+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::dependency_health::engines_node_floor_mismatch": {
       "id": "review::.::holistic::dependency_health::engines_node_floor_mismatch",
@@ -69331,11 +69340,11 @@
         "reasoning": "",
         "summary_hash": "5b4cb102"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:04:33+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69343,7 +69352,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:04:33+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets": {
       "id": "review::.::holistic::low_level_elegance::labels_formatter_inconsistent_with_rulesets",
@@ -69368,11 +69383,11 @@
         "reasoning": "",
         "summary_hash": "3641af2c"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:04:34+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69380,7 +69395,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:04:34+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks": {
       "id": "review::.::holistic::low_level_elegance::validator_settings_context_enrichment_twin_blocks",
@@ -69404,11 +69425,11 @@
         "reasoning": "",
         "summary_hash": "78967a75"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:04:35+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69416,7 +69437,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:04:35+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins": {
       "id": "review::.::holistic::low_level_elegance::normalizer_mergeRawSettings_ruleset_label_twins",
@@ -69440,11 +69467,11 @@
         "reasoning": "",
         "summary_hash": "253c1112"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:04:34+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69452,7 +69479,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:04:34+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record": {
       "id": "review::.::holistic::low_level_elegance::sync_command_triplicated_failure_record",
@@ -69477,11 +69510,11 @@
         "reasoning": "",
         "summary_hash": "d6b0cac1"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Helper extraction cluster complete; twin blocks collapsed.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:04:35+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69489,7 +69522,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Helper extraction cluster complete; twin blocks collapsed. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:04:35+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::mid_level_elegance::session_options_runcontext_outlier": {
       "id": "review::.::holistic::mid_level_elegance::session_options_runcontext_outlier",
@@ -70139,11 +70178,11 @@
         "reasoning": "",
         "summary_hash": "02713cf2"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Replaced 4 flat factory fields with SettingsProcessorFactories record on RepoIterationContext, SyncDependencies, and ApplyRepoSettingsContext.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:14:43+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -70151,7 +70190,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Replaced 4 flat factory fields with SettingsProcessorFactories record on RepoIterationContext, SyncDependencies, and ApplyRepoSettingsContext. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:14:43+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::design_coherence::validate_settings_multi_concern": {
       "id": "review::.::holistic::design_coherence::validate_settings_multi_concern",
@@ -70174,11 +70219,11 @@
         "reasoning": "",
         "summary_hash": "e2fe3086"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Split validateSettings into 5 per-concern dispatchers: validateSettingsRulesets/Labels/DeleteOrphaned/Repo/CodeScanning. validateSettings now thin orchestrator.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:14:44+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -70186,7 +70231,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Split validateSettings into 5 per-concern dispatchers: validateSettingsRulesets/Labels/DeleteOrphaned/Repo/CodeScanning. validateSettings now thin orchestrator. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:14:44+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::contract_coherence::rethrow_name_but_returns": {
       "id": "review::.::holistic::contract_coherence::rethrow_name_but_returns",

--- a/.desloppify/state-typescript.json
+++ b/.desloppify/state-typescript.json
@@ -12,8 +12,8 @@
     "auto_resolved": 1095,
     "deferred": 0,
     "false_positive": 87,
-    "fixed": 257,
-    "open": 223,
+    "fixed": 262,
+    "open": 218,
     "triaged_out": 0,
     "wontfix": 2,
     "by_tier": {
@@ -21,8 +21,8 @@
         "auto_resolved": 8,
         "deferred": 0,
         "false_positive": 5,
-        "fixed": 102,
-        "open": 3,
+        "fixed": 103,
+        "open": 2,
         "triaged_out": 0,
         "wontfix": 0
       },
@@ -30,8 +30,8 @@
         "auto_resolved": 364,
         "deferred": 0,
         "false_positive": 50,
-        "fixed": 117,
-        "open": 40,
+        "fixed": 120,
+        "open": 37,
         "triaged_out": 0,
         "wontfix": 2
       },
@@ -39,8 +39,8 @@
         "auto_resolved": 648,
         "deferred": 0,
         "false_positive": 32,
-        "fixed": 18,
-        "open": 179,
+        "fixed": 19,
+        "open": 178,
         "triaged_out": 0,
         "wontfix": 0
       },
@@ -140,7 +140,10 @@
     "api_surface_coherence": {
       "score": 92.0,
       "source": "holistic",
-      "assessed_at": "2026-04-16T05:39:25+00:00"
+      "assessed_at": "2026-04-16T05:39:25+00:00",
+      "needs_review_refresh": true,
+      "refresh_reason": "review_issue_fixed",
+      "stale_since": "2026-04-16T09:37:00+00:00"
     },
     "authorization_consistency": {
       "score": 95.0,
@@ -209,7 +212,10 @@
     "contract_coherence": {
       "score": 92.5,
       "source": "holistic",
-      "assessed_at": "2026-04-16T05:39:25+00:00"
+      "assessed_at": "2026-04-16T05:39:25+00:00",
+      "needs_review_refresh": true,
+      "refresh_reason": "review_issue_fixed",
+      "stale_since": "2026-04-16T09:36:59+00:00"
     },
     "dependency_health": {
       "score": 94.5,
@@ -238,7 +244,7 @@
       "assessed_at": "2026-04-16T05:39:25+00:00",
       "needs_review_refresh": true,
       "refresh_reason": "review_issue_fixed",
-      "stale_since": "2026-04-16T07:52:34+00:00"
+      "stale_since": "2026-04-16T09:36:59+00:00"
     },
     "test_strategy": {
       "score": 92.0,
@@ -3103,13 +3109,13 @@
       "strict": 92.0,
       "verified_strict_score": 92.0,
       "checks": 10,
-      "failing": 2,
+      "failing": 0,
       "tier": 4,
       "detectors": {
         "subjective_assessment": {
           "potential": 10,
           "pass_rate": 0.92,
-          "failing": 2,
+          "failing": 0,
           "weighted_failures": 0.8,
           "assessment_score": 92.0,
           "placeholder": false,
@@ -3145,13 +3151,13 @@
       "strict": 92.5,
       "verified_strict_score": 92.5,
       "checks": 10,
-      "failing": 2,
+      "failing": 0,
       "tier": 4,
       "detectors": {
         "subjective_assessment": {
           "potential": 10,
           "pass_rate": 0.925,
-          "failing": 2,
+          "failing": 0,
           "weighted_failures": 0.75,
           "assessment_score": 92.5,
           "placeholder": false,
@@ -3397,13 +3403,13 @@
       "strict": 91.5,
       "verified_strict_score": 91.5,
       "checks": 10,
-      "failing": 1,
+      "failing": 0,
       "tier": 4,
       "detectors": {
         "subjective_assessment": {
           "potential": 10,
           "pass_rate": 0.915,
-          "failing": 1,
+          "failing": 0,
           "weighted_failures": 0.85,
           "assessment_score": 91.5,
           "placeholder": false,
@@ -69102,11 +69108,11 @@
         "reasoning": "",
         "summary_hash": "b17158fc"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Renamed IPRStrategy.checkExistingPR->findExistingPRUrl.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:36:59+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69114,7 +69120,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Renamed IPRStrategy.checkExistingPR->findExistingPRUrl. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:36:59+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::naming_quality::gitops_underscore_field_outlier": {
       "id": "review::.::holistic::naming_quality::gitops_underscore_field_outlier",
@@ -69734,11 +69746,11 @@
         "reasoning": "",
         "summary_hash": "b4383132"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Migrated IRepoLifecycleProvider methods to options bags; token inside options.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:37:00+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69746,7 +69758,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Migrated IRepoLifecycleProvider methods to options bags; token inside options. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:37:00+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift": {
       "id": "review::.::holistic::api_surface_coherence::repo_settings_strategy_verb_drift",
@@ -69773,11 +69791,11 @@
         "reasoning": "",
         "summary_hash": "b1627a6e"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Renamed IRepoSettingsStrategy methods: getSettings->get, updateSettings->update, setVulnerabilityAlerts->updateVulnerabilityAlerts.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:37:00+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -69785,7 +69803,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Renamed IRepoSettingsStrategy methods: getSettings->get, updateSettings->update, setVulnerabilityAlerts->updateVulnerabilityAlerts. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:37:00+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::authorization_consistency::force_merge_audit_log_only": {
       "id": "review::.::holistic::authorization_consistency::force_merge_audit_log_only",
@@ -70272,11 +70296,11 @@
         "reasoning": "",
         "summary_hash": "a87de593"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Renamed rethrowIfUnexpectedCommitError->classifyCommitError.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:36:58+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -70284,7 +70308,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Renamed rethrowIfUnexpectedCommitError->classifyCommitError. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:36:58+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return": {
       "id": "review::.::holistic::contract_coherence::git_ops_commit_dry_run_return",
@@ -70307,11 +70337,11 @@
         "reasoning": "",
         "summary_hash": "d8839b3c"
       },
-      "status": "open",
-      "note": null,
+      "status": "fixed",
+      "note": "Clarified JSDoc: dry-run mode returns true without inspecting working tree.",
       "first_seen": "2026-04-16T05:39:25+00:00",
       "last_seen": "2026-04-16T05:39:25+00:00",
-      "resolved_at": null,
+      "resolved_at": "2026-04-16T09:36:59+00:00",
       "reopen_count": 0,
       "work_item_kind": "review_defect",
       "issue_kind": "review_defect",
@@ -70319,7 +70349,13 @@
       "lang": "typescript",
       "suppressed": false,
       "suppressed_at": null,
-      "suppression_pattern": null
+      "suppression_pattern": null,
+      "resolution_attestation": {
+        "kind": "manual",
+        "text": "I have actually Clarified JSDoc: dry-run mode returns true without inspecting working tree. and I am not gaming the score.",
+        "attested_at": "2026-04-16T09:36:59+00:00",
+        "scan_verified": false
+      }
     },
     "review::.::holistic::logic_clarity::deepequal_redundant_return": {
       "id": "review::.::holistic::logic_clarity::deepequal_redundant_return",

--- a/src/cli/sync-command.ts
+++ b/src/cli/sync-command.ts
@@ -40,6 +40,7 @@ import {
   type SettingsResult,
   type SyncOptions,
   type ApplyRepoSettingsContext,
+  type SettingsProcessorFactories,
   type RulesetProcessorFactory,
   type RepoSettingsProcessorFactory,
   type LabelsProcessorFactory,
@@ -217,18 +218,9 @@ async function runAndStoreResult(
 function buildSettingsDescriptors(
   ctx: ApplyRepoSettingsContext
 ): SettingsDescriptor[] {
-  const {
-    repoConfig,
-    repoInfo,
-    options,
-    token,
-    repoName,
-    settingsCollector,
-    rulesetProcessorFactory,
-    repoSettingsProcessorFactory,
-    labelsProcessorFactory,
-    codeScanningProcessorFactory,
-  } = ctx;
+  const { repoConfig, repoInfo, options, token, repoName, settingsCollector } =
+    ctx;
+  const { factories } = ctx;
   const sharedOpts = {
     dryRun: options.dryRun,
     noDelete: options.noDelete,
@@ -241,7 +233,7 @@ function buildSettingsDescriptors(
       label: "Rulesets",
       run: () =>
         runAndStoreResult(
-          rulesetProcessorFactory,
+          factories.rulesets,
           repoConfig,
           repoInfo,
           sharedOpts,
@@ -257,7 +249,7 @@ function buildSettingsDescriptors(
       label: "Labels",
       run: () =>
         runAndStoreResult(
-          labelsProcessorFactory,
+          factories.labels,
           repoConfig,
           repoInfo,
           sharedOpts,
@@ -273,7 +265,7 @@ function buildSettingsDescriptors(
       label: "Repo Settings",
       run: () =>
         runAndStoreResult(
-          repoSettingsProcessorFactory,
+          factories.repo,
           repoConfig,
           repoInfo,
           { dryRun: options.dryRun, token },
@@ -289,7 +281,7 @@ function buildSettingsDescriptors(
       label: "Code Scanning",
       run: () =>
         runAndStoreResult(
-          codeScanningProcessorFactory,
+          factories.codeScanning,
           repoConfig,
           repoInfo,
           sharedOpts,
@@ -401,18 +393,7 @@ interface RepoIterationContext {
   reportResults: SyncResultEntry[];
   lifecycleReportInputs: LifecycleAction[];
   settingsCollector: ResultsCollector;
-  rulesetProcessorFactory: NonNullable<
-    SyncDependencies["rulesetProcessorFactory"]
-  >;
-  repoSettingsProcessorFactory: NonNullable<
-    SyncDependencies["repoSettingsProcessorFactory"]
-  >;
-  labelsProcessorFactory: NonNullable<
-    SyncDependencies["labelsProcessorFactory"]
-  >;
-  codeScanningProcessorFactory: NonNullable<
-    SyncDependencies["codeScanningProcessorFactory"]
-  >;
+  factories: SettingsProcessorFactories;
 }
 
 interface RepoPhaseParams {
@@ -519,10 +500,7 @@ async function processSingleRepo(
     options,
     token: repoToken,
     settingsCollector: ctx.settingsCollector,
-    rulesetProcessorFactory: ctx.rulesetProcessorFactory,
-    repoSettingsProcessorFactory: ctx.repoSettingsProcessorFactory,
-    labelsProcessorFactory: ctx.labelsProcessorFactory,
-    codeScanningProcessorFactory: ctx.codeScanningProcessorFactory,
+    factories: ctx.factories,
   });
 }
 
@@ -647,13 +625,21 @@ export async function runSync(
   _defaultExecutor = undefined;
   _logger = undefined;
 
-  const {
-    lifecycleManager,
-    rulesetProcessorFactory = createDefaultRulesetProcessorFactory(),
-    repoSettingsProcessorFactory = createDefaultRepoSettingsProcessorFactory(),
-    labelsProcessorFactory = createDefaultLabelsProcessorFactory(),
-    codeScanningProcessorFactory = createDefaultCodeScanningProcessorFactory(),
-  } = deps;
+  const { lifecycleManager, settingsProcessorFactories } = deps;
+  const factories: SettingsProcessorFactories = {
+    rulesets:
+      settingsProcessorFactories?.rulesets ??
+      createDefaultRulesetProcessorFactory(),
+    labels:
+      settingsProcessorFactories?.labels ??
+      createDefaultLabelsProcessorFactory(),
+    repo:
+      settingsProcessorFactories?.repo ??
+      createDefaultRepoSettingsProcessorFactory(),
+    codeScanning:
+      settingsProcessorFactories?.codeScanning ??
+      createDefaultCodeScanningProcessorFactory(),
+  };
   const configPath = resolve(options.config);
 
   if (!existsSync(configPath)) {
@@ -719,10 +705,7 @@ export async function runSync(
     reportResults: [],
     lifecycleReportInputs: [],
     settingsCollector: new ResultsCollector(),
-    rulesetProcessorFactory,
-    repoSettingsProcessorFactory,
-    labelsProcessorFactory,
-    codeScanningProcessorFactory,
+    factories,
   };
 
   for (let i = 0; i < config.repos.length; i++) {

--- a/src/cli/sync-command.ts
+++ b/src/cli/sync-command.ts
@@ -424,6 +424,19 @@ interface RepoPhaseParams {
   token: string | undefined;
 }
 
+function pushFailure(
+  results: SyncResultEntry[],
+  repoName: string,
+  error: unknown
+): void {
+  results.push({
+    repoName,
+    success: false,
+    fileChanges: [],
+    error: toErrorMessage(error),
+  });
+}
+
 /**
  * Process a single repository: resolve URL, run lifecycle check, sync files, apply settings.
  * Pushes results into ctx.reportResults, ctx.lifecycleReportInputs, and ctx.settingsCollector.
@@ -461,12 +474,7 @@ async function processSingleRepo(
     });
   } catch (error) {
     getLogger().error(repoNumber, repoConfig.git, toErrorMessage(error));
-    ctx.reportResults.push({
-      repoName: repoConfig.git,
-      success: false,
-      fileChanges: [],
-      error: toErrorMessage(error),
-    });
+    pushFailure(ctx.reportResults, repoConfig.git, error);
     return;
   }
 
@@ -573,12 +581,7 @@ async function runLifecyclePhase(
       repo.repoName,
       `Lifecycle error: ${toErrorMessage(error)}`
     );
-    ctx.reportResults.push({
-      repoName: repo.repoName,
-      success: false,
-      fileChanges: [],
-      error: toErrorMessage(error),
-    });
+    pushFailure(ctx.reportResults, repo.repoName, error);
     return true;
   }
 }
@@ -632,12 +635,7 @@ async function runFileSyncPhase(
     }
   } catch (error) {
     getLogger().error(repoNumber, repo.repoName, toErrorMessage(error));
-    ctx.reportResults.push({
-      repoName: repo.repoName,
-      success: false,
-      fileChanges: [],
-      error: toErrorMessage(error),
-    });
+    pushFailure(ctx.reportResults, repo.repoName, error);
   }
 }
 

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -25,16 +25,22 @@ export type LabelsProcessorFactory = SettingsProcessorFactory<ILabelsProcessor>;
 export type CodeScanningProcessorFactory =
   SettingsProcessorFactory<ICodeScanningProcessor>;
 
+export type SettingsKind = "rulesets" | "labels" | "repo" | "codeScanning";
+
+export interface SettingsProcessorFactories {
+  rulesets: RulesetProcessorFactory;
+  labels: LabelsProcessorFactory;
+  repo: RepoSettingsProcessorFactory;
+  codeScanning: CodeScanningProcessorFactory;
+}
+
 /**
  * Dependencies for the sync command (dependency injection).
  */
 export interface SyncDependencies {
   processorFactory?: ProcessorFactory;
   lifecycleManager?: IRepoLifecycleManager;
-  rulesetProcessorFactory?: RulesetProcessorFactory;
-  repoSettingsProcessorFactory?: RepoSettingsProcessorFactory;
-  labelsProcessorFactory?: LabelsProcessorFactory;
-  codeScanningProcessorFactory?: CodeScanningProcessorFactory;
+  settingsProcessorFactories?: Partial<SettingsProcessorFactories>;
 }
 
 export interface SharedOptions {
@@ -82,16 +88,5 @@ export interface ApplyRepoSettingsContext {
   options: SyncOptions;
   token: string | undefined;
   settingsCollector: ResultsCollector;
-  rulesetProcessorFactory: NonNullable<
-    SyncDependencies["rulesetProcessorFactory"]
-  >;
-  repoSettingsProcessorFactory: NonNullable<
-    SyncDependencies["repoSettingsProcessorFactory"]
-  >;
-  labelsProcessorFactory: NonNullable<
-    SyncDependencies["labelsProcessorFactory"]
-  >;
-  codeScanningProcessorFactory: NonNullable<
-    SyncDependencies["codeScanningProcessorFactory"]
-  >;
+  factories: SettingsProcessorFactories;
 }

--- a/src/config/file-reference-resolver.ts
+++ b/src/config/file-reference-resolver.ts
@@ -126,6 +126,31 @@ function resolveContentValue(
   return value;
 }
 
+function resolveContentInFilesMap(
+  filesMap: Record<string, unknown> | undefined,
+  configDir: string
+): void {
+  if (!filesMap) {
+    return;
+  }
+  for (const [fileName, fileConfig] of Object.entries(filesMap)) {
+    if (fileConfig === false) {
+      continue;
+    }
+    if (
+      fileConfig &&
+      typeof fileConfig === "object" &&
+      "content" in fileConfig
+    ) {
+      const typed = fileConfig as { content?: ContentValue };
+      const resolved = resolveContentValue(typed.content, configDir);
+      if (resolved !== undefined) {
+        filesMap[fileName] = { ...fileConfig, content: resolved };
+      }
+    }
+  }
+}
+
 /**
  * Resolve all file references in a raw config.
  * Walks through files at root level and per-repo level.
@@ -151,88 +176,38 @@ export function resolveFileReferencesInConfig(
   }
 
   // Resolve root-level file content
-  if (result.files) {
-    for (const [fileName, fileConfig] of Object.entries(result.files)) {
-      if (
-        fileConfig &&
-        typeof fileConfig === "object" &&
-        "content" in fileConfig
-      ) {
-        const resolved = resolveContentValue(fileConfig.content, configDir);
-        if (resolved !== undefined) {
-          result.files[fileName] = { ...fileConfig, content: resolved };
-        }
-      }
-    }
-  }
+  resolveContentInFilesMap(
+    result.files as Record<string, unknown> | undefined,
+    configDir
+  );
 
   // Resolve group-level file content
   if (result.groups) {
-    for (const [groupName, group] of Object.entries(result.groups)) {
-      if (group.files) {
-        for (const [fileName, fileConfig] of Object.entries(group.files)) {
-          if (
-            fileConfig &&
-            typeof fileConfig === "object" &&
-            "content" in fileConfig
-          ) {
-            const resolved = resolveContentValue(fileConfig.content, configDir);
-            if (resolved !== undefined) {
-              result.groups[groupName].files![fileName] = {
-                ...fileConfig,
-                content: resolved,
-              };
-            }
-          }
-        }
-      }
+    for (const group of Object.values(result.groups)) {
+      resolveContentInFilesMap(
+        group.files as Record<string, unknown> | undefined,
+        configDir
+      );
     }
   }
 
   // Resolve conditional group file content
   if (result.conditionalGroups) {
     for (const cg of result.conditionalGroups) {
-      if (cg.files) {
-        for (const [fileName, fileConfig] of Object.entries(cg.files)) {
-          if (
-            fileConfig &&
-            typeof fileConfig === "object" &&
-            "content" in fileConfig
-          ) {
-            const resolved = resolveContentValue(fileConfig.content, configDir);
-            if (resolved !== undefined) {
-              cg.files[fileName] = { ...fileConfig, content: resolved };
-            }
-          }
-        }
-      }
+      resolveContentInFilesMap(
+        cg.files as Record<string, unknown> | undefined,
+        configDir
+      );
     }
   }
 
   // Resolve per-repo file content
   if (result.repos) {
     for (const repo of result.repos) {
-      if (repo.files) {
-        for (const [fileName, fileOverride] of Object.entries(repo.files)) {
-          // Skip false (exclusion) entries
-          if (fileOverride === false) {
-            continue;
-          }
-          if (
-            fileOverride &&
-            typeof fileOverride === "object" &&
-            "content" in fileOverride
-          ) {
-            const resolved = resolveContentValue(
-              fileOverride.content,
-              configDir
-            );
-            if (resolved !== undefined) {
-              repo.files[fileName] = { ...fileOverride, content: resolved };
-            }
-          }
-        }
-      }
+      resolveContentInFilesMap(
+        repo.files as Record<string, unknown> | undefined,
+        configDir
+      );
     }
   }
 

--- a/src/config/normalizer.ts
+++ b/src/config/normalizer.ts
@@ -420,6 +420,33 @@ function mergeGroupPROptions(
 }
 
 /**
+ * Merges a named-entry map (e.g. rulesets, labels) where overlay entries
+ * extend or replace base entries. `inherit: false` in the overlay discards
+ * the base; `false` values mark explicit opt-outs. The merge callback runs
+ * when both base and overlay have an entry with the same name.
+ */
+function mergeNamedEntries<T>(
+  base: Record<string, T | false> | undefined,
+  overlay: Record<string, T | false | boolean | undefined>,
+  merge: (existing: T | false | undefined, entry: T) => T
+): Record<string, T | false> {
+  const inherit = shouldInherit(overlay);
+  const result: Record<string, T | false> = inherit ? { ...(base ?? {}) } : {};
+
+  for (const [name, entry] of Object.entries(overlay)) {
+    if (name === "inherit") continue;
+    if (entry === false) {
+      result[name] = false;
+    } else if (typeof entry === "object" && entry !== null) {
+      const existing = result[name];
+      result[name] = merge(existing, entry as T);
+    }
+  }
+
+  return result;
+}
+
+/**
  * Merges two raw settings layers (root/group into accumulated).
  * Unlike mergeSettings(), this operates on raw types and returns raw types,
  * preserving false values and inherit keys for downstream processing.
@@ -436,23 +463,14 @@ function mergeRawSettings(
 
   // Merge rulesets
   if (overlay.rulesets) {
-    const inheritRulesets = shouldInherit(overlay.rulesets);
-    if (!inheritRulesets) {
-      // Discard accumulated rulesets, start fresh with overlay's own
-      result.rulesets = {};
-    }
-    if (!result.rulesets) result.rulesets = {};
-    for (const [name, ruleset] of Object.entries(overlay.rulesets)) {
-      if (name === "inherit") continue;
-      if (ruleset === false) {
-        result.rulesets[name] = false;
-      } else if (typeof ruleset === "object") {
-        const existing = result.rulesets[name];
-        result.rulesets[name] = existing
-          ? mergeRuleset(existing, ruleset)
-          : structuredClone(ruleset);
-      }
-    }
+    result.rulesets = mergeNamedEntries(
+      result.rulesets,
+      overlay.rulesets,
+      (existing, entry) =>
+        existing && typeof existing === "object"
+          ? mergeRuleset(existing as Ruleset, entry as Ruleset)
+          : structuredClone(entry)
+    );
   }
 
   // Merge repo settings: overlay replaces base (shallow merge, same as mergeSettings)
@@ -469,23 +487,14 @@ function mergeRawSettings(
 
   // Merge labels
   if (overlay.labels) {
-    const inheritLabels = shouldInherit(overlay.labels);
-    if (!inheritLabels) {
-      result.labels = {};
-    }
-    if (!result.labels) result.labels = {};
-    for (const [name, label] of Object.entries(overlay.labels)) {
-      if (name === "inherit") continue;
-      if (label === false) {
-        result.labels[name] = false;
-      } else if (typeof label === "object") {
-        const existing = result.labels[name];
-        result.labels[name] = {
-          ...(existing && typeof existing === "object" ? existing : {}),
-          ...label,
-        };
-      }
-    }
+    result.labels = mergeNamedEntries(
+      result.labels,
+      overlay.labels,
+      (existing, entry) => ({
+        ...(existing && typeof existing === "object" ? existing : {}),
+        ...(entry as Label),
+      })
+    );
   }
 
   // Merge code scanning: overlay fully replaces base (same semantics as mergeSettings)

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -905,6 +905,29 @@ function validateRepoFiles(
   }
 }
 
+function enrichSettingsContext(
+  rootCtx: RootSettingsContext,
+  settings: RawRepoSettings | RawRootSettings | undefined
+): void {
+  if (!settings) return;
+  if (settings.rulesets) {
+    for (const name of Object.keys(settings.rulesets)) {
+      if (name !== "inherit") rootCtx.rulesetNames.push(name);
+    }
+  }
+  if (settings.labels) {
+    for (const name of Object.keys(settings.labels)) {
+      if (name !== "inherit") rootCtx.labelNames.push(name);
+    }
+  }
+  if (settings.repo !== undefined && settings.repo !== false) {
+    rootCtx.hasRepoSettings = true;
+  }
+  if (settings.codeScanning !== undefined && settings.codeScanning !== false) {
+    rootCtx.hasCodeScanningSettings = true;
+  }
+}
+
 function validateRepoSettingsEntry(
   config: RawConfig,
   repo: RawConfig["repos"][number],
@@ -917,52 +940,12 @@ function validateRepoSettingsEntry(
   if (repo.groups && config.groups) {
     const expandedGroups = expandRepoGroups(repo.groups, config.groups);
     for (const groupName of expandedGroups) {
-      const group = config.groups[groupName];
-      if (group?.settings?.rulesets) {
-        for (const name of Object.keys(group.settings.rulesets)) {
-          if (name !== "inherit") rootCtx.rulesetNames.push(name);
-        }
-      }
-      if (group?.settings?.labels) {
-        for (const name of Object.keys(group.settings.labels)) {
-          if (name !== "inherit") rootCtx.labelNames.push(name);
-        }
-      }
-      if (
-        group?.settings?.repo !== undefined &&
-        group.settings.repo !== false
-      ) {
-        rootCtx.hasRepoSettings = true;
-      }
-      if (
-        group?.settings?.codeScanning !== undefined &&
-        group.settings.codeScanning !== false
-      ) {
-        rootCtx.hasCodeScanningSettings = true;
-      }
+      enrichSettingsContext(rootCtx, config.groups[groupName]?.settings);
     }
   }
   if (config.conditionalGroups) {
     for (const cg of config.conditionalGroups) {
-      if (cg.settings?.rulesets) {
-        for (const name of Object.keys(cg.settings.rulesets)) {
-          if (name !== "inherit") rootCtx.rulesetNames.push(name);
-        }
-      }
-      if (cg.settings?.labels) {
-        for (const name of Object.keys(cg.settings.labels)) {
-          if (name !== "inherit") rootCtx.labelNames.push(name);
-        }
-      }
-      if (cg.settings?.repo !== undefined && cg.settings.repo !== false) {
-        rootCtx.hasRepoSettings = true;
-      }
-      if (
-        cg.settings?.codeScanning !== undefined &&
-        cg.settings.codeScanning !== false
-      ) {
-        rootCtx.hasCodeScanningSettings = true;
-      }
+      enrichSettingsContext(rootCtx, cg.settings);
     }
   }
 

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -213,6 +213,118 @@ function buildRootSettingsContext(config: RawConfig): RootSettingsContext {
 /**
  * Validates settings object containing rulesets, labels, and repo settings.
  */
+function validateSettingsRulesets(
+  settings: Record<string, unknown>,
+  context: string,
+  rootCtx?: RootSettingsContext
+): void {
+  if (settings.rulesets === undefined) return;
+  if (!isPlainObject(settings.rulesets)) {
+    throw new ValidationError(`${context}: rulesets must be an object`);
+  }
+
+  const rulesets = settings.rulesets;
+  for (const [name, ruleset] of Object.entries(rulesets)) {
+    if (name === "inherit") continue;
+
+    if (ruleset === false) {
+      if (rootCtx && !rootCtx.rulesetNames.includes(name)) {
+        throw new ValidationError(
+          `${context}: Cannot opt out of '${name}' - not defined in root settings.rulesets`
+        );
+      }
+      continue;
+    }
+
+    validateRuleset(ruleset, name, context);
+  }
+}
+
+function validateSettingsLabels(
+  settings: Record<string, unknown>,
+  context: string,
+  rootCtx?: RootSettingsContext
+): void {
+  if (settings.labels === undefined) return;
+  if (!isPlainObject(settings.labels)) {
+    throw new ValidationError(`${context}: labels must be an object`);
+  }
+  const labels = settings.labels;
+  for (const [name, label] of Object.entries(labels)) {
+    if (name === "inherit") continue;
+    if (label === false) {
+      if (rootCtx && !rootCtx.labelNames.includes(name)) {
+        throw new ValidationError(
+          `${context}: Cannot opt out of label '${name}' - not defined in root settings.labels`
+        );
+      }
+      continue;
+    }
+    validateLabel(label, name, context);
+  }
+}
+
+function validateSettingsDeleteOrphaned(
+  settings: Record<string, unknown>,
+  context: string
+): void {
+  if (
+    settings.deleteOrphaned !== undefined &&
+    typeof settings.deleteOrphaned !== "boolean"
+  ) {
+    throw new ValidationError(
+      `${context}: settings.deleteOrphaned must be a boolean`
+    );
+  }
+}
+
+function validateSettingsRepo(
+  settings: Record<string, unknown>,
+  context: string,
+  rootCtx?: RootSettingsContext
+): void {
+  if (settings.repo === undefined) return;
+  if (settings.repo === false) {
+    if (!rootCtx) {
+      throw new ValidationError(
+        `${context}: repo: false is not valid at root level. Define repo settings or remove the field.`
+      );
+    }
+    if (!rootCtx.hasRepoSettings) {
+      throw new ValidationError(
+        `${context}: Cannot opt out of repo settings — not defined in root settings.repo`
+      );
+    }
+    return;
+  }
+  validateRepoSettings(settings.repo, context);
+}
+
+function validateSettingsCodeScanning(
+  settings: Record<string, unknown>,
+  context: string,
+  rootCtx?: RootSettingsContext
+): void {
+  if (settings.codeScanning === undefined) return;
+  if (settings.codeScanning === false) {
+    if (!rootCtx) {
+      throw new ValidationError(
+        `${context}: codeScanning: false is not valid at root level. Define codeScanning settings or remove the field.`
+      );
+    }
+    if (!rootCtx.hasCodeScanningSettings) {
+      throw new ValidationError(
+        `${context}: Cannot opt out of code scanning settings — not defined in root settings.codeScanning`
+      );
+    }
+    return;
+  }
+  validateCodeScanningSettings(
+    settings.codeScanning,
+    `${context} codeScanning`
+  );
+}
+
 function validateSettings(
   settings: unknown,
   context: string,
@@ -222,97 +334,11 @@ function validateSettings(
     throw new ValidationError(`${context}: settings must be an object`);
   }
 
-  if (settings.rulesets !== undefined) {
-    if (!isPlainObject(settings.rulesets)) {
-      throw new ValidationError(`${context}: rulesets must be an object`);
-    }
-
-    const rulesets = settings.rulesets;
-    for (const [name, ruleset] of Object.entries(rulesets)) {
-      // Skip reserved key
-      if (name === "inherit") continue;
-
-      if (ruleset === false) {
-        if (rootCtx && !rootCtx.rulesetNames.includes(name)) {
-          throw new ValidationError(
-            `${context}: Cannot opt out of '${name}' - not defined in root settings.rulesets`
-          );
-        }
-        continue; // Skip further validation for false entries
-      }
-
-      validateRuleset(ruleset, name, context);
-    }
-  }
-
-  if (settings.labels !== undefined) {
-    if (!isPlainObject(settings.labels)) {
-      throw new ValidationError(`${context}: labels must be an object`);
-    }
-    const labels = settings.labels;
-    for (const [name, label] of Object.entries(labels)) {
-      if (name === "inherit") continue;
-      if (label === false) {
-        if (rootCtx && !rootCtx.labelNames.includes(name)) {
-          throw new ValidationError(
-            `${context}: Cannot opt out of label '${name}' - not defined in root settings.labels`
-          );
-        }
-        continue;
-      }
-      validateLabel(label, name, context);
-    }
-  }
-
-  if (
-    settings.deleteOrphaned !== undefined &&
-    typeof settings.deleteOrphaned !== "boolean"
-  ) {
-    throw new ValidationError(
-      `${context}: settings.deleteOrphaned must be a boolean`
-    );
-  }
-
-  if (settings.repo !== undefined) {
-    if (settings.repo === false) {
-      if (!rootCtx) {
-        // Root level — repo: false not valid here
-        throw new ValidationError(
-          `${context}: repo: false is not valid at root level. Define repo settings or remove the field.`
-        );
-      }
-      // Per-repo level — check root has repo settings to opt out of
-      if (!rootCtx.hasRepoSettings) {
-        throw new ValidationError(
-          `${context}: Cannot opt out of repo settings — not defined in root settings.repo`
-        );
-      }
-      // Valid opt-out, skip further repo validation
-    } else {
-      validateRepoSettings(settings.repo, context);
-    }
-  }
-
-  if (settings.codeScanning !== undefined) {
-    if (settings.codeScanning === false) {
-      if (!rootCtx) {
-        throw new ValidationError(
-          `${context}: codeScanning: false is not valid at root level. Define codeScanning settings or remove the field.`
-        );
-      }
-      // Per-repo level — check root has codeScanning settings to opt out of
-      if (!rootCtx.hasCodeScanningSettings) {
-        throw new ValidationError(
-          `${context}: Cannot opt out of code scanning settings — not defined in root settings.codeScanning`
-        );
-      }
-    } else {
-      validateCodeScanningSettings(
-        settings.codeScanning,
-        `${context} codeScanning`
-      );
-    }
-  }
+  validateSettingsRulesets(settings, context, rootCtx);
+  validateSettingsLabels(settings, context, rootCtx);
+  validateSettingsDeleteOrphaned(settings, context);
+  validateSettingsRepo(settings, context, rootCtx);
+  validateSettingsCodeScanning(settings, context, rootCtx);
 }
 
 const VALID_CODE_SCANNING_STATES = ["configured", "not-configured"];

--- a/src/lifecycle/github-lifecycle-provider.ts
+++ b/src/lifecycle/github-lifecycle-provider.ts
@@ -18,6 +18,10 @@ import type {
   IRepoLifecycleProvider,
   LifecyclePlatform,
   CreateRepoSettings,
+  LifecycleExistsParams,
+  LifecycleCreateParams,
+  LifecycleForkParams,
+  LifecycleReceiveMigrationParams,
 } from "./types.js";
 
 /**
@@ -185,7 +189,8 @@ export class GitHubLifecycleProvider implements IRepoLifecycleProvider {
     return { tokenEnv, prefix: `gh api ${hostnamePart}`, apiPath };
   }
 
-  async exists(repoInfo: RepoInfo, token?: string): Promise<boolean> {
+  async exists(params: LifecycleExistsParams): Promise<boolean> {
+    const { repo: repoInfo, token } = params;
     this.assertGitHub(repoInfo);
 
     const { tokenEnv, prefix, apiPath } = this.buildGhApiPrefix(
@@ -214,11 +219,8 @@ export class GitHubLifecycleProvider implements IRepoLifecycleProvider {
     }
   }
 
-  async create(
-    repoInfo: RepoInfo,
-    settings?: CreateRepoSettings,
-    token?: string
-  ): Promise<void> {
+  async create(params: LifecycleCreateParams): Promise<void> {
+    const { repo: repoInfo, settings, token } = params;
     this.assertGitHub(repoInfo);
 
     const tokenEnv = buildTokenEnv(token);
@@ -286,12 +288,8 @@ export class GitHubLifecycleProvider implements IRepoLifecycleProvider {
     await this.deleteReadme(repoInfo, token);
   }
 
-  async fork(
-    upstream: RepoInfo,
-    target: RepoInfo,
-    settings?: CreateRepoSettings,
-    token?: string
-  ): Promise<void> {
+  async fork(params: LifecycleForkParams): Promise<void> {
+    const { upstream, target, settings, token } = params;
     this.assertGitHub(upstream);
     this.assertGitHub(target);
 
@@ -359,7 +357,7 @@ export class GitHubLifecycleProvider implements IRepoLifecycleProvider {
 
     while (Date.now() < deadline) {
       try {
-        const ready = await this.exists(repoInfo, token);
+        const ready = await this.exists({ repo: repoInfo, token });
         if (ready) {
           return;
         }
@@ -416,11 +414,9 @@ export class GitHubLifecycleProvider implements IRepoLifecycleProvider {
   }
 
   async receiveMigration(
-    repoInfo: RepoInfo,
-    sourceDir: string,
-    settings?: CreateRepoSettings,
-    token?: string
+    params: LifecycleReceiveMigrationParams
   ): Promise<void> {
+    const { repo: repoInfo, sourceDir, settings, token } = params;
     this.assertGitHub(repoInfo);
 
     const tokenEnv = buildTokenEnv(token);

--- a/src/lifecycle/repo-lifecycle-manager.ts
+++ b/src/lifecycle/repo-lifecycle-manager.ts
@@ -58,7 +58,7 @@ export class RepoLifecycleManager implements IRepoLifecycleManager {
 
     const { token } = options;
 
-    const exists = await provider.exists(repoInfo, token);
+    const exists = await provider.exists({ repo: repoInfo, token });
 
     if (exists) {
       // Repo exists - nothing to do (ignore upstream/source)
@@ -97,7 +97,7 @@ export class RepoLifecycleManager implements IRepoLifecycleManager {
       };
     }
 
-    await provider.create(repoInfo, settings, options.token);
+    await provider.create({ repo: repoInfo, settings, token: options.token });
     await this.waitForRepoReady(provider, repoInfo, options.token);
 
     return {
@@ -130,7 +130,12 @@ export class RepoLifecycleManager implements IRepoLifecycleManager {
     const upstreamInfo = parseGitUrl(repoConfig.upstream!, {
       githubHosts: options.githubHosts,
     });
-    await provider.fork(upstreamInfo, repoInfo, settings, options.token);
+    await provider.fork({
+      upstream: upstreamInfo,
+      target: repoInfo,
+      settings,
+      token: options.token,
+    });
     await this.waitForRepoReady(provider, repoInfo, options.token);
 
     return {
@@ -167,12 +172,12 @@ export class RepoLifecycleManager implements IRepoLifecycleManager {
 
       // Create target and push content
       const provider = this.factory.getProvider(repoInfo.type);
-      await provider.receiveMigration(
-        repoInfo,
+      await provider.receiveMigration({
+        repo: repoInfo,
         sourceDir,
         settings,
-        options.token
-      );
+        token: options.token,
+      });
       await this.waitForRepoReady(provider, repoInfo, options.token);
 
       return {
@@ -202,7 +207,7 @@ export class RepoLifecycleManager implements IRepoLifecycleManager {
   ): Promise<void> {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
-      if (await provider.exists(repoInfo, token)) {
+      if (await provider.exists({ repo: repoInfo, token })) {
         return;
       }
       await new Promise((resolve) => setTimeout(resolve, pollMs));

--- a/src/lifecycle/types.ts
+++ b/src/lifecycle/types.ts
@@ -31,6 +31,31 @@ export interface CreateRepoSettings {
   defaultBranch?: string;
 }
 
+export interface LifecycleExistsParams {
+  repo: RepoInfo;
+  token?: string;
+}
+
+export interface LifecycleCreateParams {
+  repo: RepoInfo;
+  settings?: CreateRepoSettings;
+  token?: string;
+}
+
+export interface LifecycleForkParams {
+  upstream: RepoInfo;
+  target: RepoInfo;
+  settings?: CreateRepoSettings;
+  token?: string;
+}
+
+export interface LifecycleReceiveMigrationParams {
+  repo: RepoInfo;
+  sourceDir: string;
+  settings?: CreateRepoSettings;
+  token?: string;
+}
+
 /**
  * Provider for platform-specific lifecycle operations.
  * Implementations handle create/fork/receive for a specific platform.
@@ -42,37 +67,23 @@ export interface IRepoLifecycleProvider {
    * Check if a repository exists on this platform.
    * @throws LifecycleError on network/auth failures (NOT for "repo not found")
    */
-  exists(repoInfo: RepoInfo, token?: string): Promise<boolean>;
+  exists(params: LifecycleExistsParams): Promise<boolean>;
 
   /**
    * Create an empty repository.
    */
-  create(
-    repoInfo: RepoInfo,
-    settings?: CreateRepoSettings,
-    token?: string
-  ): Promise<void>;
+  create(params: LifecycleCreateParams): Promise<void>;
 
   /**
    * Fork from an upstream repository.
    * Optional - not all platforms support forking.
    */
-  fork?(
-    upstream: RepoInfo,
-    target: RepoInfo,
-    settings?: CreateRepoSettings,
-    token?: string
-  ): Promise<void>;
+  fork?(params: LifecycleForkParams): Promise<void>;
 
   /**
    * Receive migrated content (repo already created, push content).
    */
-  receiveMigration(
-    repoInfo: RepoInfo,
-    sourceDir: string,
-    settings?: CreateRepoSettings,
-    token?: string
-  ): Promise<void>;
+  receiveMigration(params: LifecycleReceiveMigrationParams): Promise<void>;
 }
 
 /**

--- a/src/settings/labels/formatter.ts
+++ b/src/settings/labels/formatter.ts
@@ -37,15 +37,21 @@ export function formatLabelsPlan(changes: LabelChange[]): LabelsPlanResult {
     delete: deletes,
     unchanged,
   } = countActions(changes);
-  const createChanges = changes.filter((c) => c.action === "create");
-  const updateChanges = changes.filter((c) => c.action === "update");
-  const deleteChanges = changes.filter((c) => c.action === "delete");
-  const unchangedItems = changes.filter((c) => c.action === "unchanged");
+
+  const grouped: Record<LabelAction, LabelChange[]> = {
+    create: [],
+    update: [],
+    delete: [],
+    unchanged: [],
+  };
+  for (const c of changes) {
+    grouped[c.action].push(c);
+  }
 
   // Format creates
-  if (createChanges.length > 0) {
+  if (grouped.create.length > 0) {
     lines.push(chalk.bold("  Create:"));
-    for (const change of createChanges) {
+    for (const change of grouped.create) {
       lines.push(chalk.green(`    + label "${change.name}"`));
       if (change.desired) {
         lines.push(chalk.green(`        color: "${change.desired.color}"`));
@@ -65,9 +71,9 @@ export function formatLabelsPlan(changes: LabelChange[]): LabelsPlanResult {
   }
 
   // Format updates
-  if (updateChanges.length > 0) {
+  if (grouped.update.length > 0) {
     lines.push(chalk.bold("  Update:"));
-    for (const change of updateChanges) {
+    for (const change of grouped.update) {
       if (change.newName) {
         lines.push(
           chalk.yellow(
@@ -104,9 +110,9 @@ export function formatLabelsPlan(changes: LabelChange[]): LabelsPlanResult {
   }
 
   // Format deletes
-  if (deleteChanges.length > 0) {
+  if (grouped.delete.length > 0) {
     lines.push(chalk.bold("  Delete:"));
-    for (const change of deleteChanges) {
+    for (const change of grouped.delete) {
       lines.push(chalk.red(`    - label "${change.name}"`));
       entries.push({ name: change.name, action: "delete" });
     }
@@ -114,7 +120,7 @@ export function formatLabelsPlan(changes: LabelChange[]): LabelsPlanResult {
   }
 
   // Unchanged (entries only, no output lines)
-  for (const change of unchangedItems) {
+  for (const change of grouped.unchanged) {
     entries.push({ name: change.name, action: "unchanged" });
   }
 

--- a/src/settings/repo-settings/github-repo-settings-strategy.ts
+++ b/src/settings/repo-settings/github-repo-settings-strategy.ts
@@ -92,7 +92,7 @@ export class GitHubRepoSettingsStrategy implements IRepoSettingsStrategy {
     this.api = new GhApiClient(executor, options.retries ?? 3, options.cwd);
   }
 
-  async getSettings(
+  async get(
     repoInfo: RepoInfo,
     options?: GhApiOptions
   ): Promise<CurrentRepoSettings> {
@@ -124,7 +124,7 @@ export class GitHubRepoSettingsStrategy implements IRepoSettingsStrategy {
     return settings;
   }
 
-  async updateSettings(
+  async update(
     repoInfo: RepoInfo,
     settings: GitHubRepoSettings,
     options?: GhApiOptions
@@ -142,7 +142,7 @@ export class GitHubRepoSettingsStrategy implements IRepoSettingsStrategy {
     await this.api.call("PATCH", endpoint, { payload, options });
   }
 
-  async setVulnerabilityAlerts(
+  async updateVulnerabilityAlerts(
     repoInfo: RepoInfo,
     enable: boolean,
     options?: GhApiOptions

--- a/src/settings/repo-settings/processor.ts
+++ b/src/settings/repo-settings/processor.ts
@@ -72,7 +72,7 @@ export class RepoSettingsProcessor implements IRepoSettingsProcessor {
 
     // Fetch current settings and metadata in parallel
     const [currentSettings, metadata] = await Promise.all([
-      this.strategy.getSettings(githubRepo, strategyOptions),
+      this.strategy.get(githubRepo, strategyOptions),
       this.metadataProvider.getMetadata(githubRepo, strategyOptions),
     ]);
 
@@ -177,13 +177,13 @@ export class RepoSettingsProcessor implements IRepoSettingsProcessor {
 
     // Update main settings via PATCH /repos
     if (Object.keys(mainSettings).length > 0) {
-      await this.strategy.updateSettings(repoInfo, mainSettings, options);
+      await this.strategy.update(repoInfo, mainSettings, options);
     }
 
     // Handle vulnerability alerts (separate endpoint)
     // Must be done before automated security fixes
     if (vulnerabilityAlerts !== undefined) {
-      await this.strategy.setVulnerabilityAlerts(
+      await this.strategy.updateVulnerabilityAlerts(
         repoInfo,
         vulnerabilityAlerts,
         options

--- a/src/settings/repo-settings/types.ts
+++ b/src/settings/repo-settings/types.ts
@@ -49,15 +49,12 @@ export interface IRepoSettingsStrategy {
   /**
    * Gets current repository settings.
    */
-  getSettings(
-    repoInfo: RepoInfo,
-    options?: GhApiOptions
-  ): Promise<CurrentRepoSettings>;
+  get(repoInfo: RepoInfo, options?: GhApiOptions): Promise<CurrentRepoSettings>;
 
   /**
    * Updates repository settings.
    */
-  updateSettings(
+  update(
     repoInfo: RepoInfo,
     settings: GitHubRepoSettings,
     options?: GhApiOptions
@@ -66,7 +63,7 @@ export interface IRepoSettingsStrategy {
   /**
    * Enables or disables vulnerability alerts.
    */
-  setVulnerabilityAlerts(
+  updateVulnerabilityAlerts(
     repoInfo: RepoInfo,
     enable: boolean,
     options?: GhApiOptions

--- a/src/shared/gh-api-utils.ts
+++ b/src/shared/gh-api-utils.ts
@@ -1,13 +1,17 @@
 import { escapeShellArg } from "./shell-utils.js";
 import { withRetry } from "./retry-utils.js";
 import type { ICommandExecutor } from "./command-executor.js";
-import type { GitHubRepoInfo } from "../repo/index.js";
 import { toErrorMessage } from "./type-guards.js";
 
 import type { DebugWarnLog } from "./logger.js";
 
+export interface GitHubApiTarget {
+  host: string;
+  owner: string;
+}
+
 interface ITokenManager {
-  getTokenForRepo(repoInfo: GitHubRepoInfo): Promise<string | null>;
+  getTokenForRepo(repoInfo: GitHubApiTarget): Promise<string | null>;
 }
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -39,7 +43,9 @@ interface GhApiCallOptions {
  * Get the hostname flag for gh commands.
  * Returns "--hostname HOST" for GHE, empty string for github.com.
  */
-export function getHostnameFlag(repoInfo: GitHubRepoInfo): string {
+export function getHostnameFlag(
+  repoInfo: Pick<GitHubApiTarget, "host">
+): string {
   if (repoInfo.host !== "github.com") {
     return `--hostname ${escapeShellArg(repoInfo.host)}`;
   }
@@ -223,7 +229,7 @@ export class GhApiClient {
 }
 
 interface ResolveGitHubTokenOptions {
-  repoInfo: GitHubRepoInfo;
+  repoInfo: GitHubApiTarget;
   tokenManager: ITokenManager | null;
   context: string;
   log?: DebugWarnLog;

--- a/src/shared/xfg-template.ts
+++ b/src/shared/xfg-template.ts
@@ -10,14 +10,38 @@ import {
   type InterpolationConfig,
 } from "./interpolation-engine.js";
 
-import type { RepoInfo } from "../repo/index.js";
 import { ValidationError } from "./errors.js";
 
 type TemplateContent = Record<string, unknown> | string | string[];
 
+export type RepoDisplayInfo =
+  | {
+      type: "github";
+      gitUrl: string;
+      repo: string;
+      owner: string;
+      host: string;
+    }
+  | {
+      type: "azure-devops";
+      gitUrl: string;
+      repo: string;
+      owner: string;
+      organization: string;
+      project: string;
+    }
+  | {
+      type: "gitlab";
+      gitUrl: string;
+      repo: string;
+      owner: string;
+      namespace: string;
+      host: string;
+    };
+
 export interface XfgTemplateContext {
   /** Repository information from URL parsing */
-  repoInfo: RepoInfo;
+  repoInfo: RepoDisplayInfo;
   /** Current file being processed */
   fileName: string;
   /** Custom variables defined in config */

--- a/src/sync/commit-push-manager.ts
+++ b/src/sync/commit-push-manager.ts
@@ -83,7 +83,7 @@ export class CommitPushManager implements ICommitPushManager {
       this.log.info(`Committed: ${result.sha} (verified: ${result.verified})`);
       return { success: true };
     } catch (error) {
-      return this.rethrowIfUnexpectedCommitError(
+      return this.classifyCommitError(
         error,
         isDirectMode,
         pushBranch,
@@ -92,7 +92,7 @@ export class CommitPushManager implements ICommitPushManager {
     }
   }
 
-  private rethrowIfUnexpectedCommitError(
+  private classifyCommitError(
     error: unknown,
     isDirectMode: boolean,
     pushBranch: string,

--- a/src/vcs/ado-pr-strategy.ts
+++ b/src/vcs/ado-pr-strategy.ts
@@ -72,7 +72,7 @@ export class AdoPRStrategy extends BasePRStrategy {
     }
   }
 
-  async checkExistingPR(
+  async findExistingPRUrl(
     options: CloseExistingPROptions
   ): Promise<string | null> {
     const { repoInfo, branchName, baseBranch, workDir, retries = 3 } = options;

--- a/src/vcs/git-ops.ts
+++ b/src/vcs/git-ops.ts
@@ -274,7 +274,7 @@ export class GitOps implements ILocalGitOps {
   /**
    * Stage all changes and commit with the given message.
    * Uses --no-verify to skip pre-commit hooks (config sync should always succeed).
-   * @returns true if a commit was made (or would be made in dry-run mode), false if there were no staged changes
+   * @returns true if a commit was made, or false if there were no staged changes. In dry-run mode, always returns true without inspecting the working tree.
    */
   async commit(message: string): Promise<boolean> {
     if (this.dryRun) {

--- a/src/vcs/github-pr-strategy.ts
+++ b/src/vcs/github-pr-strategy.ts
@@ -37,7 +37,7 @@ function buildPRUrlRegex(host: string): RegExp {
 }
 
 export class GitHubPRStrategy extends BasePRStrategy {
-  async checkExistingPR(
+  async findExistingPRUrl(
     options: CloseExistingPROptions
   ): Promise<string | null> {
     const { repoInfo, branchName, workDir, retries = 3, token } = options;
@@ -82,7 +82,7 @@ export class GitHubPRStrategy extends BasePRStrategy {
     assertGitHubRepo(repoInfo, "GitHub PR strategy");
 
     // First check if there's an existing PR (pass token through)
-    const existingUrl = await this.checkExistingPR({
+    const existingUrl = await this.findExistingPRUrl({
       repoInfo,
       branchName,
       baseBranch,

--- a/src/vcs/gitlab-pr-strategy.ts
+++ b/src/vcs/gitlab-pr-strategy.ts
@@ -89,7 +89,7 @@ export class GitLabPRStrategy extends BasePRStrategy {
     }
   }
 
-  async checkExistingPR(
+  async findExistingPRUrl(
     options: CloseExistingPROptions
   ): Promise<string | null> {
     const { repoInfo, branchName, workDir, retries = 3 } = options;
@@ -136,7 +136,7 @@ export class GitLabPRStrategy extends BasePRStrategy {
     assertGitLabRepo(repoInfo, "GitLab PR strategy");
 
     // First check if there's an existing MR
-    const existingUrl = await this.checkExistingPR({
+    const existingUrl = await this.findExistingPRUrl({
       repoInfo,
       branchName,
       baseBranch,

--- a/src/vcs/pr-strategy.ts
+++ b/src/vcs/pr-strategy.ts
@@ -27,7 +27,7 @@ export abstract class BasePRStrategy implements IPRStrategy {
     this.log = log;
   }
 
-  abstract checkExistingPR(
+  abstract findExistingPRUrl(
     options: CloseExistingPROptions
   ): Promise<string | null>;
   abstract closeExistingPR(options: CloseExistingPROptions): Promise<boolean>;
@@ -64,7 +64,7 @@ export class PRWorkflowExecutor {
 
   async execute(options: PRStrategyOptions): Promise<PRResult> {
     try {
-      const existingUrl = await this.strategy.checkExistingPR(options);
+      const existingUrl = await this.strategy.findExistingPRUrl(options);
       if (existingUrl) {
         return {
           url: existingUrl,

--- a/src/vcs/types.ts
+++ b/src/vcs/types.ts
@@ -108,7 +108,7 @@ export interface CloseExistingPROptions {
 
 /**
  * Interface for PR creation strategies (platform-specific implementations).
- * Strategies focus on platform-specific logic (checkExistingPR, create, merge).
+ * Strategies focus on platform-specific logic (findExistingPRUrl, create, merge).
  * Use PRWorkflowExecutor for full workflow orchestration with error handling.
  *
  * Error contract: create() and merge() may throw on infrastructure failures
@@ -121,7 +121,7 @@ export interface IPRStrategy {
    * Check if a PR already exists for the given branch.
    * @returns PR URL if exists, null if not found or on error
    */
-  checkExistingPR(options: CloseExistingPROptions): Promise<string | null>;
+  findExistingPRUrl(options: CloseExistingPROptions): Promise<string | null>;
 
   /**
    * Close an existing PR and delete its branch.

--- a/test/unit/cli/sync-command.test.ts
+++ b/test/unit/cli/sync-command.test.ts
@@ -464,7 +464,9 @@ ${VALID_RULESET}
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          rulesetProcessorFactory: () => mockRulesetProcessor,
+          settingsProcessorFactories: {
+            rulesets: () => mockRulesetProcessor,
+          },
         }
       );
 
@@ -498,7 +500,9 @@ ${VALID_LABELS}
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          labelsProcessorFactory: () => mockLabelsProcessor,
+          settingsProcessorFactories: {
+            labels: () => mockLabelsProcessor,
+          },
         }
       );
 
@@ -532,7 +536,9 @@ repos:
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          repoSettingsProcessorFactory: () => mockRepoSettingsProcessor,
+          settingsProcessorFactories: {
+            repo: () => mockRepoSettingsProcessor,
+          },
         }
       );
 
@@ -572,7 +578,9 @@ ${VALID_RULESET}
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          rulesetProcessorFactory: () => mockRulesetProcessor,
+          settingsProcessorFactories: {
+            rulesets: () => mockRulesetProcessor,
+          },
         }
       );
 
@@ -606,7 +614,9 @@ ${VALID_LABELS}
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          labelsProcessorFactory: () => mockLabelsProcessor,
+          settingsProcessorFactories: {
+            labels: () => mockLabelsProcessor,
+          },
         }
       );
 
@@ -637,7 +647,9 @@ ${VALID_RULESET}
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          rulesetProcessorFactory: () => mockRulesetProcessor,
+          settingsProcessorFactories: {
+            rulesets: () => mockRulesetProcessor,
+          },
         }
       );
 
@@ -674,7 +686,9 @@ ${VALID_RULESET}
             {
               processorFactory: () => createMockProcessor(),
               lifecycleManager: noopLifecycleManager,
-              rulesetProcessorFactory: () => mockRulesetProcessor,
+              settingsProcessorFactories: {
+                rulesets: () => mockRulesetProcessor,
+              },
             }
           ),
         /One or more repositories had errors during sync/
@@ -709,7 +723,9 @@ ${VALID_RULESET}
             {
               processorFactory: () => createMockProcessor(),
               lifecycleManager: noopLifecycleManager,
-              rulesetProcessorFactory: () => mockRulesetProcessor,
+              settingsProcessorFactories: {
+                rulesets: () => mockRulesetProcessor,
+              },
             }
           ),
         /One or more repositories had errors during sync/
@@ -749,7 +765,9 @@ ${VALID_LABELS}
               processorFactory: () =>
                 createMockProcessor({ success: true, message: "Files synced" }),
               lifecycleManager: noopLifecycleManager,
-              labelsProcessorFactory: () => mockLabelsProcessor,
+              settingsProcessorFactories: {
+                labels: () => mockLabelsProcessor,
+              },
             }
           ),
         /One or more repositories had errors during sync/
@@ -782,9 +800,11 @@ ${VALID_LABELS}
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          rulesetProcessorFactory: () => mockRulesetProcessor,
-          labelsProcessorFactory: () => mockLabelsProcessor,
-          repoSettingsProcessorFactory: () => mockRepoSettingsProcessor,
+          settingsProcessorFactories: {
+            rulesets: () => mockRulesetProcessor,
+            labels: () => mockLabelsProcessor,
+            repo: () => mockRepoSettingsProcessor,
+          },
         }
       );
 
@@ -836,7 +856,9 @@ ${VALID_LABELS}
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          labelsProcessorFactory: () => mockLabelsProcessor,
+          settingsProcessorFactories: {
+            labels: () => mockLabelsProcessor,
+          },
         }
       );
 
@@ -873,7 +895,9 @@ ${VALID_LABELS}
             {
               processorFactory: () => createMockProcessor(),
               lifecycleManager: noopLifecycleManager,
-              labelsProcessorFactory: () => mockLabelsProcessor,
+              settingsProcessorFactories: {
+                labels: () => mockLabelsProcessor,
+              },
             }
           ),
         /One or more repositories had errors during sync/
@@ -923,7 +947,9 @@ repos:
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          repoSettingsProcessorFactory: () => mockRepoSettingsProcessor,
+          settingsProcessorFactories: {
+            repo: () => mockRepoSettingsProcessor,
+          },
         }
       );
 
@@ -976,7 +1002,9 @@ repos:
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          repoSettingsProcessorFactory: () => mockRepoSettingsProcessor,
+          settingsProcessorFactories: {
+            repo: () => mockRepoSettingsProcessor,
+          },
         }
       );
 
@@ -1011,7 +1039,9 @@ repos:
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          repoSettingsProcessorFactory: () => mockRepoSettingsProcessor,
+          settingsProcessorFactories: {
+            repo: () => mockRepoSettingsProcessor,
+          },
         }
       );
 
@@ -1047,7 +1077,9 @@ repos:
             {
               processorFactory: () => createMockProcessor(),
               lifecycleManager: noopLifecycleManager,
-              repoSettingsProcessorFactory: () => mockRepoSettingsProcessor,
+              settingsProcessorFactories: {
+                repo: () => mockRepoSettingsProcessor,
+              },
             }
           ),
         /One or more repositories had errors during sync/
@@ -1086,7 +1118,9 @@ repos:
             {
               processorFactory: () => createMockProcessor(),
               lifecycleManager: noopLifecycleManager,
-              repoSettingsProcessorFactory: () => mockRepoSettingsProcessor,
+              settingsProcessorFactories: {
+                repo: () => mockRepoSettingsProcessor,
+              },
             }
           ),
         /One or more repositories had errors during sync/
@@ -1123,7 +1157,9 @@ ${VALID_RULESET}
         {
           processorFactory: () => createMockProcessor(),
           lifecycleManager: noopLifecycleManager,
-          rulesetProcessorFactory: () => mockRulesetProcessor,
+          settingsProcessorFactories: {
+            rulesets: () => mockRulesetProcessor,
+          },
         }
       );
 

--- a/test/unit/lifecycle/github-lifecycle-provider.test.ts
+++ b/test/unit/lifecycle/github-lifecycle-provider.test.ts
@@ -24,7 +24,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       const provider = new GitHubLifecycleProvider({ executor, cwd: "/test" });
-      const result = await provider.exists(mockRepoInfo);
+      const result = await provider.exists({ repo: mockRepoInfo });
 
       assert.equal(result, true);
     });
@@ -42,7 +42,7 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await provider.exists(mockRepoInfo);
+      const result = await provider.exists({ repo: mockRepoInfo });
 
       assert.equal(result, false);
     });
@@ -60,7 +60,10 @@ describe("GitHubLifecycleProvider", () => {
         cwd: "/test",
       });
 
-      await assert.rejects(() => provider.exists(mockRepoInfo), /Network/);
+      await assert.rejects(
+        () => provider.exists({ repo: mockRepoInfo }),
+        /Network/
+      );
     });
 
     test("uses correct gh api command", async () => {
@@ -69,7 +72,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       const provider = new GitHubLifecycleProvider({ executor, cwd: "/test" });
-      await provider.exists(mockRepoInfo);
+      await provider.exists({ repo: mockRepoInfo });
 
       assert.equal(calls.length, 1);
       assert.ok(calls[0].command.includes("gh api"));
@@ -97,7 +100,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.exists(adoRepo),
+        () => provider.exists({ repo: adoRepo }),
         /requires GitHub repo/
       );
     });
@@ -114,7 +117,7 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await provider.exists(mockRepoInfo);
+      const result = await provider.exists({ repo: mockRepoInfo });
 
       assert.equal(result, false);
     });
@@ -131,7 +134,7 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await provider.exists(mockRepoInfo);
+      const result = await provider.exists({ repo: mockRepoInfo });
 
       assert.equal(result, false);
     });
@@ -142,7 +145,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       const provider = new GitHubLifecycleProvider({ executor, cwd: "/test" });
-      await provider.exists(mockRepoInfo);
+      await provider.exists({ repo: mockRepoInfo });
 
       assert.ok(!calls[0].command.includes("--hostname"));
     });
@@ -161,7 +164,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       const provider = new GitHubLifecycleProvider({ executor, cwd: "/test" });
-      await provider.exists(gheRepoInfo);
+      await provider.exists({ repo: gheRepoInfo });
 
       assert.equal(calls.length, 1);
       assert.ok(calls[0].command.includes("--hostname"));
@@ -181,7 +184,7 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo);
+      await provider.create({ repo: mockRepoInfo });
 
       // calls[0] = gh repo create, calls[1] = GET README sha, calls[2] = DELETE README
       assert.equal(calls.length, 3);
@@ -204,7 +207,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo, { visibility: "private" });
+      await provider.create({
+        repo: mockRepoInfo,
+        settings: { visibility: "private" },
+      });
 
       assert.ok(calls[0].command.includes("--private"));
     });
@@ -219,7 +225,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo, { visibility: "internal" });
+      await provider.create({
+        repo: mockRepoInfo,
+        settings: { visibility: "internal" },
+      });
 
       assert.ok(calls[0].command.includes("--internal"));
     });
@@ -234,7 +243,7 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo);
+      await provider.create({ repo: mockRepoInfo });
 
       assert.ok(calls[0].command.includes("--private"));
     });
@@ -249,7 +258,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo, { visibility: "public" });
+      await provider.create({
+        repo: mockRepoInfo,
+        settings: { visibility: "public" },
+      });
 
       assert.ok(calls[0].command.includes("--public"));
     });
@@ -264,7 +276,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo, { description: "Test repo" });
+      await provider.create({
+        repo: mockRepoInfo,
+        settings: { description: "Test repo" },
+      });
 
       assert.ok(calls[0].command.includes("--description"));
       assert.ok(calls[0].command.includes("Test repo"));
@@ -280,7 +295,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo, { hasIssues: false });
+      await provider.create({
+        repo: mockRepoInfo,
+        settings: { hasIssues: false },
+      });
 
       assert.ok(calls[0].command.includes("--disable-issues"));
     });
@@ -295,7 +313,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo, { hasWiki: false });
+      await provider.create({
+        repo: mockRepoInfo,
+        settings: { hasWiki: false },
+      });
 
       assert.ok(calls[0].command.includes("--disable-wiki"));
     });
@@ -310,7 +331,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo, { hasIssues: true });
+      await provider.create({
+        repo: mockRepoInfo,
+        settings: { hasIssues: true },
+      });
 
       assert.ok(!calls[0].command.includes("--disable-issues"));
     });
@@ -326,7 +350,7 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo);
+      await provider.create({ repo: mockRepoInfo });
 
       // calls[0] = gh repo create with --add-readme
       // calls[1] = gh api .../contents/README.md --jq '.sha' (GET sha)
@@ -369,7 +393,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.create(adoRepo),
+        () => provider.create({ repo: adoRepo }),
         /requires GitHub repo/
       );
     });
@@ -388,7 +412,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.create(mockRepoInfo),
+        () => provider.create({ repo: mockRepoInfo }),
         /Permission denied/
       );
     });
@@ -422,7 +446,10 @@ describe("GitHubLifecycleProvider", () => {
           retries: 0,
           cwd: "/test",
         });
-        await provider.create(mockRepoInfo, { defaultBranch: "main" });
+        await provider.create({
+          repo: mockRepoInfo,
+          settings: { defaultBranch: "main" },
+        });
 
         // Should have: create, get default_branch, rename, poll default_branch, get README sha, delete README
         assert.ok(calls.length >= 5);
@@ -450,7 +477,10 @@ describe("GitHubLifecycleProvider", () => {
           retries: 0,
           cwd: "/test",
         });
-        await provider.create(mockRepoInfo, { defaultBranch: "main" });
+        await provider.create({
+          repo: mockRepoInfo,
+          settings: { defaultBranch: "main" },
+        });
 
         // Should have: create, get default_branch, get README sha, delete README (no rename)
         assert.equal(calls.length, 4);
@@ -468,7 +498,7 @@ describe("GitHubLifecycleProvider", () => {
           retries: 0,
           cwd: "/test",
         });
-        await provider.create(mockRepoInfo);
+        await provider.create({ repo: mockRepoInfo });
 
         // Should have: create, get README sha, delete README (no default_branch check)
         assert.equal(calls.length, 3);
@@ -502,7 +532,10 @@ describe("GitHubLifecycleProvider", () => {
           retries: 0,
           cwd: "/test",
         });
-        await provider.create(mockRepoInfo, { defaultBranch: "main" });
+        await provider.create({
+          repo: mockRepoInfo,
+          settings: { defaultBranch: "main" },
+        });
 
         // Should have recovered from the error and continued polling
         const pollCalls = calls.filter((c) =>
@@ -534,7 +567,11 @@ describe("GitHubLifecycleProvider", () => {
         });
 
         await assert.rejects(
-          () => provider.create(mockRepoInfo, { defaultBranch: "main" }),
+          () =>
+            provider.create({
+              repo: mockRepoInfo,
+              settings: { defaultBranch: "main" },
+            }),
           /Rename failed/
         );
 
@@ -569,7 +606,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, mockRepoInfo);
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+      });
 
       // Find the fork command (not the API check)
       const forkCall = calls.find((c) => c.command.includes("gh repo fork"));
@@ -604,7 +644,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, personalRepoInfo);
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: personalRepoInfo,
+      });
 
       // Find the fork command (not the API check)
       const forkCall = calls.find((c) => c.command.includes("gh repo fork"));
@@ -629,7 +672,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, mockRepoInfo);
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+      });
 
       const forkCall = calls.find((c) => c.command.includes("gh repo fork"));
       assert.ok(forkCall);
@@ -650,7 +696,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, mockRepoInfo);
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+      });
 
       // Should default to --org when we can't determine owner type
       const forkCall = calls.find((c) => c.command.includes("gh repo fork"));
@@ -673,8 +722,12 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, mockRepoInfo, {
-        visibility: "private",
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+        settings: {
+          visibility: "private",
+        },
       });
 
       // Should call gh repo edit after fork
@@ -702,8 +755,12 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, mockRepoInfo, {
-        description: "My custom fork",
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+        settings: {
+          description: "My custom fork",
+        },
       });
 
       // Should call gh repo edit after fork
@@ -727,7 +784,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, mockRepoInfo);
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+      });
 
       // Should NOT call gh repo edit
       const editCall = calls.find((c) => c.command.includes("gh repo edit"));
@@ -755,7 +815,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.fork!(adoRepo, mockRepoInfo),
+        () => provider.fork!({ upstream: adoRepo, target: mockRepoInfo }),
         /requires GitHub repo/
       );
     });
@@ -781,7 +841,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.fork!(upstreamRepoInfo, adoRepo),
+        () => provider.fork!({ upstream: upstreamRepoInfo, target: adoRepo }),
         /requires GitHub repo/
       );
     });
@@ -801,7 +861,8 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.fork!(upstreamRepoInfo, mockRepoInfo),
+        () =>
+          provider.fork!({ upstream: upstreamRepoInfo, target: mockRepoInfo }),
         /Cannot fork private repo/
       );
     });
@@ -826,7 +887,8 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.fork!(sameOwnerUpstream, mockRepoInfo),
+        () =>
+          provider.fork!({ upstream: sameOwnerUpstream, target: mockRepoInfo }),
         /Cannot fork test-org\/original-repo to the same owner/
       );
     });
@@ -854,7 +916,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.fork!(upstream, target),
+        () => provider.fork!({ upstream: upstream, target: target }),
         /Cannot fork.*same owner/
       );
     });
@@ -873,8 +935,12 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, mockRepoInfo, {
-        defaultBranch: "main",
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+        settings: {
+          defaultBranch: "main",
+        },
       });
 
       // Should not call any branch rename API
@@ -923,7 +989,10 @@ describe("GitHubLifecycleProvider", () => {
         cwd: "/test",
       });
 
-      await provider.fork!(upstreamRepoInfo2, mockRepoInfo);
+      await provider.fork!({
+        upstream: upstreamRepoInfo2,
+        target: mockRepoInfo,
+      });
 
       // Should have polled exists() 3 times (2 not-found + 1 success)
       assert.equal(apiCallCount, 3);
@@ -957,7 +1026,8 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.fork!(upstreamRepoInfo2, mockRepoInfo),
+        () =>
+          provider.fork!({ upstream: upstreamRepoInfo2, target: mockRepoInfo }),
         /Timed out waiting for fork.*to become available/
       );
     });
@@ -980,7 +1050,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.receiveMigration(mockRepoInfo, "/tmp/source-mirror");
+      await provider.receiveMigration({
+        repo: mockRepoInfo,
+        sourceDir: "/tmp/source-mirror",
+      });
 
       // calls[0] = remote remove origin
       // calls[1] = for-each-ref (all refs)
@@ -1027,7 +1100,11 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       await assert.rejects(
-        () => provider.receiveMigration(adoRepo, "/tmp/source"),
+        () =>
+          provider.receiveMigration({
+            repo: adoRepo,
+            sourceDir: "/tmp/source",
+          }),
         /requires GitHub repo/
       );
     });
@@ -1045,8 +1122,12 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.receiveMigration(mockRepoInfo, "/tmp/source", {
-        visibility: "private",
+      await provider.receiveMigration({
+        repo: mockRepoInfo,
+        sourceDir: "/tmp/source",
+        settings: {
+          visibility: "private",
+        },
       });
 
       // calls[0] = git remote remove origin, calls[1] = git for-each-ref,
@@ -1075,7 +1156,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.receiveMigration(mockRepoInfo, "/tmp/source-mirror");
+      await provider.receiveMigration({
+        repo: mockRepoInfo,
+        sourceDir: "/tmp/source-mirror",
+      });
 
       // Should still reach gh repo create despite remote remove failure
       const createCall = calls.find((c) =>
@@ -1100,7 +1184,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.receiveMigration(mockRepoInfo, "/tmp/source-mirror");
+      await provider.receiveMigration({
+        repo: mockRepoInfo,
+        sourceDir: "/tmp/source-mirror",
+      });
 
       // Should still reach gh repo create despite ref cleanup failure
       const createCall = calls.find((c) =>
@@ -1127,8 +1214,12 @@ describe("GitHubLifecycleProvider", () => {
           retries: 0,
           cwd: "/test",
         });
-        await provider.receiveMigration(mockRepoInfo, "/tmp/source-mirror", {
-          defaultBranch: "main",
+        await provider.receiveMigration({
+          repo: mockRepoInfo,
+          sourceDir: "/tmp/source-mirror",
+          settings: {
+            defaultBranch: "main",
+          },
         });
 
         const branchRenameCall = calls.find((c) =>
@@ -1159,8 +1250,12 @@ describe("GitHubLifecycleProvider", () => {
           retries: 0,
           cwd: "/test",
         });
-        await provider.receiveMigration(mockRepoInfo, "/tmp/source-mirror", {
-          defaultBranch: "main",
+        await provider.receiveMigration({
+          repo: mockRepoInfo,
+          sourceDir: "/tmp/source-mirror",
+          settings: {
+            defaultBranch: "main",
+          },
         });
 
         assert.ok(!calls.some((c) => c.command.includes("branch -m")));
@@ -1182,7 +1277,10 @@ describe("GitHubLifecycleProvider", () => {
           retries: 0,
           cwd: "/test",
         });
-        await provider.receiveMigration(mockRepoInfo, "/tmp/source-mirror");
+        await provider.receiveMigration({
+          repo: mockRepoInfo,
+          sourceDir: "/tmp/source-mirror",
+        });
 
         assert.ok(!calls.some((c) => c.command.includes("symbolic-ref HEAD")));
         assert.ok(!calls.some((c) => c.command.includes("branch -m")));
@@ -1205,8 +1303,12 @@ describe("GitHubLifecycleProvider", () => {
 
         await assert.rejects(
           () =>
-            provider.receiveMigration(mockRepoInfo, "/tmp/source-mirror", {
-              defaultBranch: "main",
+            provider.receiveMigration({
+              repo: mockRepoInfo,
+              sourceDir: "/tmp/source-mirror",
+              settings: {
+                defaultBranch: "main",
+              },
             }),
           /refs\/heads\//
         );
@@ -1221,7 +1323,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       const provider = new GitHubLifecycleProvider({ executor, cwd: "/test" });
-      await provider.exists(mockRepoInfo, "ghs_test_token");
+      await provider.exists({ repo: mockRepoInfo, token: "ghs_test_token" });
 
       assert.equal(calls.length, 1);
       assert.ok(calls[0].command.startsWith("gh api"));
@@ -1234,7 +1336,7 @@ describe("GitHubLifecycleProvider", () => {
       });
 
       const provider = new GitHubLifecycleProvider({ executor, cwd: "/test" });
-      await provider.exists(mockRepoInfo);
+      await provider.exists({ repo: mockRepoInfo });
 
       assert.equal(calls.length, 1);
       assert.ok(calls[0].command.startsWith("gh api"));
@@ -1251,7 +1353,7 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.create(mockRepoInfo, undefined, "ghs_test_token");
+      await provider.create({ repo: mockRepoInfo, token: "ghs_test_token" });
 
       // calls[0] = gh repo create, calls[1] = GET README sha, calls[2] = DELETE README
       assert.equal(calls.length, 3);
@@ -1272,12 +1374,11 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.receiveMigration(
-        mockRepoInfo,
-        "/tmp/source",
-        undefined,
-        "ghs_test_token"
-      );
+      await provider.receiveMigration({
+        repo: mockRepoInfo,
+        sourceDir: "/tmp/source",
+        token: "ghs_test_token",
+      });
 
       // calls[0] = git remote remove origin, calls[1] = git for-each-ref, calls[2] = gh repo create
       assert.equal(calls.length, 3);
@@ -1307,12 +1408,11 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(
-        upstreamRepoInfo,
-        mockRepoInfo,
-        undefined,
-        "ghs_test_token"
-      );
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+        token: "ghs_test_token",
+      });
 
       // isOrganization API call should have token via env
       const apiCall = calls.find((c) => c.command.includes("users/"));
@@ -1349,7 +1449,10 @@ describe("GitHubLifecycleProvider", () => {
         retries: 0,
         cwd: "/test",
       });
-      await provider.fork!(upstreamRepoInfo, mockRepoInfo);
+      await provider.fork!({
+        upstream: upstreamRepoInfo,
+        target: mockRepoInfo,
+      });
 
       // Should still fork with --org flag (defaults to org when check fails)
       const forkCall = calls.find((c) => c.command.includes("gh repo fork"));

--- a/test/unit/settings/repo-settings/github-repo-settings-strategy.test.ts
+++ b/test/unit/settings/repo-settings/github-repo-settings-strategy.test.ts
@@ -85,7 +85,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       // 4 commands: base settings + 3 security endpoints
       assert.equal(mockExecutor.commands.length, 4);
@@ -116,7 +116,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.owner_type, "Organization");
     });
@@ -140,7 +140,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.owner_type, "User");
     });
@@ -163,7 +163,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.owner_type, undefined);
     });
@@ -186,7 +186,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.vulnerability_alerts, true);
     });
@@ -207,7 +207,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.vulnerability_alerts, false);
     });
@@ -227,10 +227,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         cwd: "/test",
       });
 
-      await assert.rejects(
-        async () => strategy.getSettings(githubRepo),
-        /HTTP 500/
-      );
+      await assert.rejects(async () => strategy.get(githubRepo), /HTTP 500/);
     });
 
     test("should return automated_security_fixes true when endpoint returns 204", async () => {
@@ -249,7 +246,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.automated_security_fixes, true);
     });
@@ -272,7 +269,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       // Should return true based on API response, not vulnerability_alerts state
       // This allows diff to correctly show change is needed when vuln alerts are enabled
@@ -298,7 +295,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.automated_security_fixes, false);
     });
@@ -319,10 +316,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         cwd: "/test",
       });
 
-      await assert.rejects(
-        async () => strategy.getSettings(githubRepo),
-        /HTTP 401/
-      );
+      await assert.rejects(async () => strategy.get(githubRepo), /HTTP 401/);
     });
 
     test("should return private_vulnerability_reporting true when enabled", async () => {
@@ -341,7 +335,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.private_vulnerability_reporting, true);
     });
@@ -362,7 +356,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.private_vulnerability_reporting, false);
     });
@@ -383,7 +377,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.private_vulnerability_reporting, false);
     });
@@ -405,10 +399,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         cwd: "/test",
       });
 
-      await assert.rejects(
-        async () => strategy.getSettings(githubRepo),
-        /HTTP 500/
-      );
+      await assert.rejects(async () => strategy.get(githubRepo), /HTTP 500/);
     });
   });
 
@@ -420,7 +411,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      await strategy.updateSettings(githubRepo, {
+      await strategy.update(githubRepo, {
         hasIssues: false,
         allowSquashMerge: true,
       });
@@ -437,7 +428,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      await strategy.updateSettings(githubRepo, {
+      await strategy.update(githubRepo, {
         webCommitSignoffRequired: true,
       });
 
@@ -455,7 +446,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      await strategy.updateSettings(githubRepo, {
+      await strategy.update(githubRepo, {
         defaultBranch: "develop",
       });
 
@@ -471,7 +462,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      await strategy.updateSettings(githubRepo, {
+      await strategy.update(githubRepo, {
         description: "My repo description",
       });
 
@@ -486,7 +477,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      await strategy.updateSettings(githubRepo, {});
+      await strategy.update(githubRepo, {});
 
       assert.equal(mockExecutor.commands.length, 0);
     });
@@ -500,7 +491,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      await strategy.setVulnerabilityAlerts(githubRepo, true);
+      await strategy.updateVulnerabilityAlerts(githubRepo, true);
 
       assert.equal(mockExecutor.commands.length, 1);
       assert.ok(mockExecutor.commands[0].includes("-X PUT"));
@@ -514,7 +505,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      await strategy.setVulnerabilityAlerts(githubRepo, false);
+      await strategy.updateVulnerabilityAlerts(githubRepo, false);
 
       assert.equal(mockExecutor.commands.length, 1);
       assert.ok(mockExecutor.commands[0].includes("-X DELETE"));
@@ -603,7 +594,7 @@ describe("GitHubRepoSettingsStrategy", () => {
       });
 
       await assert.rejects(
-        async () => strategy.getSettings(azureRepo),
+        async () => strategy.get(azureRepo),
         /GitHub Repo Settings strategy requires GitHub repositories/
       );
     });
@@ -628,7 +619,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 0,
         cwd: "/test",
       });
-      await strategy.getSettings(gheRepo, { host: "github.example.com" });
+      await strategy.get(gheRepo, { host: "github.example.com" });
 
       assert.ok(mockExecutor.commands[0].includes("--hostname"));
       assert.ok(mockExecutor.commands[0].includes("github.example.com"));
@@ -718,7 +709,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 1,
         cwd: "/test",
       });
-      await strategy.updateSettings(githubRepo, { hasIssues: true });
+      await strategy.update(githubRepo, { hasIssues: true });
 
       assert.ok(
         callCount >= 2,
@@ -747,7 +738,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         cwd: "/test",
       });
       await assert.rejects(
-        async () => strategy.updateSettings(githubRepo, { hasIssues: true }),
+        async () => strategy.update(githubRepo, { hasIssues: true }),
         /404/
       );
 
@@ -784,7 +775,7 @@ describe("GitHubRepoSettingsStrategy", () => {
         retries: 1,
         cwd: "/test",
       });
-      const result = await strategy.getSettings(githubRepo);
+      const result = await strategy.get(githubRepo);
 
       assert.equal(result.vulnerability_alerts, false);
       assert.equal(

--- a/test/unit/settings/repo-settings/processor.test.ts
+++ b/test/unit/settings/repo-settings/processor.test.ts
@@ -63,7 +63,7 @@ class MockStrategy implements IRepoSettingsStrategy {
     options?: GhApiOptions;
   }> = [];
 
-  async getSettings(
+  async get(
     repoInfo: RepoInfo,
     options?: GhApiOptions
   ): Promise<CurrentRepoSettings> {
@@ -71,7 +71,7 @@ class MockStrategy implements IRepoSettingsStrategy {
     return this.getSettingsResult;
   }
 
-  async updateSettings(
+  async update(
     repoInfo: RepoInfo,
     settings: GitHubRepoSettings,
     options?: GhApiOptions
@@ -79,7 +79,7 @@ class MockStrategy implements IRepoSettingsStrategy {
     this.updateSettingsCalls.push({ repoInfo, settings, options });
   }
 
-  async setVulnerabilityAlerts(
+  async updateVulnerabilityAlerts(
     repoInfo: RepoInfo,
     enable: boolean,
     options?: GhApiOptions
@@ -422,11 +422,11 @@ describe("RepoSettingsProcessor", () => {
 
   test("should handle errors gracefully", async () => {
     const errorStrategy: IRepoSettingsStrategy = {
-      getSettings: async () => {
+      get: async () => {
         throw new Error("API Error");
       },
-      updateSettings: async () => {},
-      setVulnerabilityAlerts: async () => {},
+      update: async () => {},
+      updateVulnerabilityAlerts: async () => {},
       setAutomatedSecurityFixes: async () => {},
       setPrivateVulnerabilityReporting: async () => {},
       branchExists: async () => true,

--- a/test/unit/settings/repo-settings/repo-settings-strategy.test.ts
+++ b/test/unit/settings/repo-settings/repo-settings-strategy.test.ts
@@ -6,16 +6,16 @@ describe("IRepoSettingsStrategy interface", () => {
   test("should define required methods", () => {
     // Type-level test - if this compiles, the interface is correct
     const mockStrategy: IRepoSettingsStrategy = {
-      getSettings: async () => ({}),
-      updateSettings: async () => {},
-      setVulnerabilityAlerts: async () => {},
+      get: async () => ({}),
+      update: async () => {},
+      updateVulnerabilityAlerts: async () => {},
       setAutomatedSecurityFixes: async () => {},
       setPrivateVulnerabilityReporting: async () => {},
       branchExists: async () => true,
     };
-    assert.ok(mockStrategy.getSettings);
-    assert.ok(mockStrategy.updateSettings);
-    assert.ok(mockStrategy.setVulnerabilityAlerts);
+    assert.ok(mockStrategy.get);
+    assert.ok(mockStrategy.update);
+    assert.ok(mockStrategy.updateVulnerabilityAlerts);
     assert.ok(mockStrategy.setAutomatedSecurityFixes);
     assert.ok(mockStrategy.setPrivateVulnerabilityReporting);
     assert.ok(mockStrategy.branchExists);

--- a/test/unit/vcs/ado-pr-strategy.test.ts
+++ b/test/unit/vcs/ado-pr-strategy.test.ts
@@ -43,7 +43,7 @@ describe("AdoPRStrategy with mock executor", () => {
     }
   });
 
-  describe("checkExistingPR", () => {
+  describe("findExistingPRUrl", () => {
     test("returns PR URL when PR exists", async () => {
       mockExecutor.responses.set("az repos pr list", "456");
 
@@ -58,7 +58,7 @@ describe("AdoPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
 
       assert.ok(result?.includes("dev.azure.com"));
       assert.ok(result?.includes("pullrequest/456"));
@@ -80,7 +80,7 @@ describe("AdoPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
 
       assert.equal(result, null);
     });
@@ -101,7 +101,7 @@ describe("AdoPRStrategy with mock executor", () => {
       };
 
       await assert.rejects(
-        () => strategy.checkExistingPR(options),
+        () => strategy.findExistingPRUrl(options),
         /401 Unauthorized/
       );
     });
@@ -121,7 +121,7 @@ describe("AdoPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
       assert.equal(result, null);
     });
 
@@ -142,7 +142,7 @@ describe("AdoPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
       assert.equal(result, null);
     });
   });
@@ -984,7 +984,7 @@ describe("AdoPRStrategy logger coverage", () => {
     }
   });
 
-  test("checkExistingPR logs debug on error with stderr", async () => {
+  test("findExistingPRUrl logs debug on error with stderr", async () => {
     const debugMessages: string[] = [];
     const mockLogger = {
       debug(msg: string) {
@@ -1000,7 +1000,7 @@ describe("AdoPRStrategy logger coverage", () => {
     mockExecutor.responses.set("az repos pr list", errorWithStderr);
 
     const strategy = new AdoPRStrategy(mockExecutor.mock, mockLogger);
-    const result = await strategy.checkExistingPR({
+    const result = await strategy.findExistingPRUrl({
       repoInfo: azureRepoInfo,
       branchName: "test-branch",
       baseBranch: "main",
@@ -1075,5 +1075,5 @@ describe("AdoPRStrategy logger coverage", () => {
 });
 
 // Note: "unparseable URL" test removed — closeExistingPR now uses findExistingPRId
-// directly instead of going through checkExistingPR → parsePRUrl, eliminating
+// directly instead of going through findExistingPRUrl → parsePRUrl, eliminating
 // the URL roundtrip that could produce unparseable results.

--- a/test/unit/vcs/github-pr-strategy.test.ts
+++ b/test/unit/vcs/github-pr-strategy.test.ts
@@ -39,7 +39,7 @@ describe("GitHubPRStrategy with mock executor", () => {
     }
   });
 
-  describe("checkExistingPR", () => {
+  describe("findExistingPRUrl", () => {
     test("returns PR URL when PR exists", async () => {
       mockExecutor.responses.set(
         "gh pr list",
@@ -57,7 +57,7 @@ describe("GitHubPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
 
       assert.equal(result, "https://github.com/owner/repo/pull/123");
       assert.equal(mockExecutor.calls.length, 1);
@@ -79,7 +79,7 @@ describe("GitHubPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
 
       assert.equal(result, null);
     });
@@ -100,7 +100,7 @@ describe("GitHubPRStrategy with mock executor", () => {
       };
 
       await assert.rejects(
-        () => strategy.checkExistingPR(options),
+        () => strategy.findExistingPRUrl(options),
         /401 Unauthorized/
       );
     });
@@ -120,7 +120,7 @@ describe("GitHubPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
       assert.equal(result, null);
     });
 
@@ -141,7 +141,7 @@ describe("GitHubPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
       assert.equal(result, null);
     });
   });
@@ -346,7 +346,7 @@ describe("GitHubPRStrategy with mock executor", () => {
       assert.equal(result.success, true);
       assert.equal(result.url, "https://github.com/owner/repo/pull/existing");
       assert.ok(result.message.includes("already exists"));
-      // Should only call checkExistingPR, not create
+      // Should only call findExistingPRUrl, not create
       assert.equal(mockExecutor.calls.length, 1);
     });
 
@@ -372,7 +372,7 @@ describe("GitHubPRStrategy with mock executor", () => {
 
       assert.equal(result.success, true);
       assert.equal(result.url, "https://github.com/owner/repo/pull/999");
-      // Should call both checkExistingPR and create
+      // Should call both findExistingPRUrl and create
       assert.equal(mockExecutor.calls.length, 2);
     });
 
@@ -714,7 +714,7 @@ describe("GitHubPRStrategy closeExistingPR", () => {
   });
 
   test("returns false when PR number cannot be extracted from URL (issue #93)", async () => {
-    // When checkExistingPR returns a URL but we can't extract the PR number,
+    // When findExistingPRUrl returns a URL but we can't extract the PR number,
     // we return false with a warning (consistent with other error handling)
     mockExecutor.responses.set(
       "gh pr list",
@@ -811,7 +811,7 @@ describe("GitHubPRStrategy with GitHub Enterprise Server", () => {
       retries: 0,
     };
 
-    await strategy.checkExistingPR(options);
+    await strategy.findExistingPRUrl(options);
 
     assert.ok(mockExecutor.calls[0].command.includes("--repo"));
     assert.ok(
@@ -1198,7 +1198,7 @@ describe("GitHubPRStrategy with token parameter", () => {
     }
   });
 
-  test("checkExistingPR uses GH_TOKEN env prefix when token is provided", async () => {
+  test("findExistingPRUrl uses GH_TOKEN env prefix when token is provided", async () => {
     mockExecutor.responses.set(
       "gh pr list",
       "https://github.com/owner/repo/pull/123"
@@ -1216,7 +1216,7 @@ describe("GitHubPRStrategy with token parameter", () => {
       token: "ghs_test_token_12345",
     };
 
-    await strategy.checkExistingPR(options);
+    await strategy.findExistingPRUrl(options);
 
     assert.ok(mockExecutor.calls[0].command.startsWith("gh pr list"));
     assert.equal(
@@ -1342,7 +1342,7 @@ describe("GitHubPRStrategy with token parameter", () => {
       // No token provided
     };
 
-    await strategy.checkExistingPR(options);
+    await strategy.findExistingPRUrl(options);
 
     assert.ok(
       mockExecutor.calls[0].command.startsWith("gh pr list"),
@@ -1381,7 +1381,7 @@ describe("GitHubPRStrategy logger coverage", () => {
     }
   });
 
-  test("checkExistingPR logs debug on error with stderr", async () => {
+  test("findExistingPRUrl logs debug on error with stderr", async () => {
     const debugMessages: string[] = [];
     const mockLogger = {
       debug(msg: string) {
@@ -1397,7 +1397,7 @@ describe("GitHubPRStrategy logger coverage", () => {
     mockExecutor.responses.set("gh pr list", errorWithStderr);
 
     const strategy = new GitHubPRStrategy(mockExecutor.mock, mockLogger);
-    const result = await strategy.checkExistingPR({
+    const result = await strategy.findExistingPRUrl({
       repoInfo: githubRepoInfo,
       branchName: "test-branch",
       baseBranch: "main",

--- a/test/unit/vcs/gitlab-pr-strategy.test.ts
+++ b/test/unit/vcs/gitlab-pr-strategy.test.ts
@@ -43,7 +43,7 @@ describe("GitLabPRStrategy with mock executor", () => {
     }
   });
 
-  describe("checkExistingPR", () => {
+  describe("findExistingPRUrl", () => {
     test("returns MR URL when MR exists", async () => {
       mockExecutor.responses.set(
         "glab mr list",
@@ -61,7 +61,7 @@ describe("GitLabPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
 
       assert.equal(
         result,
@@ -86,7 +86,7 @@ describe("GitLabPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
 
       assert.equal(result, null);
     });
@@ -105,7 +105,7 @@ describe("GitLabPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
 
       assert.equal(result, null);
     });
@@ -126,7 +126,7 @@ describe("GitLabPRStrategy with mock executor", () => {
       };
 
       await assert.rejects(
-        () => strategy.checkExistingPR(options),
+        () => strategy.findExistingPRUrl(options),
         /401 Unauthorized/
       );
     });
@@ -146,7 +146,7 @@ describe("GitLabPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
       assert.equal(result, null);
     });
 
@@ -167,7 +167,7 @@ describe("GitLabPRStrategy with mock executor", () => {
         retries: 0,
       };
 
-      const result = await strategy.checkExistingPR(options);
+      const result = await strategy.findExistingPRUrl(options);
       assert.equal(result, null);
     });
   });
@@ -321,7 +321,7 @@ describe("GitLabPRStrategy with mock executor", () => {
         "https://gitlab.com/myorg/myrepo/-/merge_requests/999"
       );
       assert.ok(result.message.includes("already exists"));
-      // Should only call checkExistingPR, not create
+      // Should only call findExistingPRUrl, not create
       assert.equal(mockExecutor.calls.length, 1);
     });
 
@@ -350,7 +350,7 @@ describe("GitLabPRStrategy with mock executor", () => {
         result.url,
         "https://gitlab.com/myorg/myrepo/-/merge_requests/888"
       );
-      // Should call both checkExistingPR and create
+      // Should call both findExistingPRUrl and create
       assert.equal(mockExecutor.calls.length, 2);
     });
 
@@ -423,7 +423,7 @@ describe("GitLabPRStrategy with nested groups", () => {
       retries: 0,
     };
 
-    const result = await strategy.checkExistingPR(options);
+    const result = await strategy.findExistingPRUrl(options);
 
     assert.equal(
       result,
@@ -445,7 +445,7 @@ describe("GitLabPRStrategy with nested groups", () => {
       retries: 0,
     };
 
-    await strategy.checkExistingPR(options);
+    await strategy.findExistingPRUrl(options);
 
     assert.ok(
       mockExecutor.calls[0].command.includes("org/group/subgroup/repo")
@@ -982,7 +982,7 @@ describe("GitLabPRStrategy type guards", () => {
     }
   });
 
-  test("checkExistingPR throws for non-GitLab repo", async () => {
+  test("findExistingPRUrl throws for non-GitLab repo", async () => {
     const strategy = new GitLabPRStrategy(mockExecutor.mock);
     const options: PRStrategyOptions = {
       repoInfo: azureRepoInfo,
@@ -995,7 +995,7 @@ describe("GitLabPRStrategy type guards", () => {
     };
 
     await assert.rejects(
-      () => strategy.checkExistingPR(options),
+      () => strategy.findExistingPRUrl(options),
       /requires GitLab repositories/
     );
   });
@@ -1078,7 +1078,7 @@ describe("GitLabPRStrategy self-hosted", () => {
       retries: 0,
     };
 
-    const result = await strategy.checkExistingPR(options);
+    const result = await strategy.findExistingPRUrl(options);
 
     assert.equal(
       result,
@@ -1140,7 +1140,7 @@ describe("GitLabPRStrategy logger coverage", () => {
     }
   });
 
-  test("checkExistingPR logs debug on error with stderr", async () => {
+  test("findExistingPRUrl logs debug on error with stderr", async () => {
     const debugMessages: string[] = [];
     const mockLogger = {
       debug(msg: string) {
@@ -1156,7 +1156,7 @@ describe("GitLabPRStrategy logger coverage", () => {
     mockExecutor.responses.set("glab mr list", errorWithStderr);
 
     const strategy = new GitLabPRStrategy(mockExecutor.mock, mockLogger);
-    const result = await strategy.checkExistingPR({
+    const result = await strategy.findExistingPRUrl({
       repoInfo: gitlabRepoInfo,
       branchName: "test-branch",
       baseBranch: "main",
@@ -1244,9 +1244,9 @@ describe("GitLabPRStrategy closeExistingPR with unparseable URL", () => {
     host: "gitlab.com",
   };
 
-  test("returns false when checkExistingPR returns unparseable URL", async () => {
+  test("returns false when findExistingPRUrl returns unparseable URL", async () => {
     class TestableGitLabPRStrategy extends GitLabPRStrategy {
-      override async checkExistingPR(): Promise<string | null> {
+      override async findExistingPRUrl(): Promise<string | null> {
         return "https://not-a-gitlab-url.com/invalid";
       }
     }

--- a/test/unit/vcs/pr-strategy.test.ts
+++ b/test/unit/vcs/pr-strategy.test.ts
@@ -78,7 +78,7 @@ describe("createPRStrategy", () => {
 });
 
 describe("GitHubPRStrategy type guards", () => {
-  test("checkExistingPR throws for non-GitHub repo", async () => {
+  test("findExistingPRUrl throws for non-GitHub repo", async () => {
     const strategy = new GitHubPRStrategy(mockExecutor);
     const azureRepoInfo: AzureDevOpsRepoInfo = {
       type: "azure-devops",
@@ -99,7 +99,7 @@ describe("GitHubPRStrategy type guards", () => {
     };
 
     await assert.rejects(
-      () => strategy.checkExistingPR(options),
+      () => strategy.findExistingPRUrl(options),
       /requires GitHub repositories/
     );
   });
@@ -132,7 +132,7 @@ describe("GitHubPRStrategy type guards", () => {
 });
 
 describe("AdoPRStrategy type guards", () => {
-  test("checkExistingPR throws for non-Azure repo", async () => {
+  test("findExistingPRUrl throws for non-Azure repo", async () => {
     const strategy = new AdoPRStrategy(mockExecutor);
     const githubRepoInfo: GitHubRepoInfo = {
       type: "github",
@@ -152,7 +152,7 @@ describe("AdoPRStrategy type guards", () => {
     };
 
     await assert.rejects(
-      () => strategy.checkExistingPR(options),
+      () => strategy.findExistingPRUrl(options),
       /requires Azure DevOps repositories/
     );
   });
@@ -185,26 +185,26 @@ describe("AdoPRStrategy type guards", () => {
 
 // Mock strategy for testing PRWorkflowExecutor
 class MockPRStrategy implements IPRStrategy {
-  checkExistingPRResult: string | null = null;
+  findExistingPRUrlResult: string | null = null;
   createResult: PRResult = {
     success: true,
     url: "https://example.com/pr/1",
     message: "PR created",
   };
-  checkExistingPRCalled = false;
+  findExistingPRUrlCalled = false;
   createCalled = false;
   shouldThrowOnCheck = false;
   shouldThrowOnCreate = false;
   throwMessage = "Mock error";
 
-  async checkExistingPR(
+  async findExistingPRUrl(
     _options: CloseExistingPROptions
   ): Promise<string | null> {
-    this.checkExistingPRCalled = true;
+    this.findExistingPRUrlCalled = true;
     if (this.shouldThrowOnCheck) {
       throw new Error(this.throwMessage);
     }
-    return this.checkExistingPRResult;
+    return this.findExistingPRUrlResult;
   }
 
   async create(_options: PRStrategyOptions): Promise<PRResult> {
@@ -249,18 +249,18 @@ describe("PRWorkflowExecutor", () => {
     workDir: "/tmp/test",
   };
 
-  test("delegates to strategy.checkExistingPR", async () => {
+  test("delegates to strategy.findExistingPRUrl", async () => {
     const mockStrategy = new MockPRStrategy();
     const executor = new PRWorkflowExecutor(mockStrategy);
 
     await executor.execute(defaultOptions);
 
-    assert.equal(mockStrategy.checkExistingPRCalled, true);
+    assert.equal(mockStrategy.findExistingPRUrlCalled, true);
   });
 
   test("returns existing PR if found without calling create", async () => {
     const mockStrategy = new MockPRStrategy();
-    mockStrategy.checkExistingPRResult = "https://example.com/pr/existing";
+    mockStrategy.findExistingPRUrlResult = "https://example.com/pr/existing";
     const executor = new PRWorkflowExecutor(mockStrategy);
 
     const result = await executor.execute(defaultOptions);
@@ -268,13 +268,13 @@ describe("PRWorkflowExecutor", () => {
     assert.equal(result.success, true);
     assert.equal(result.url, "https://example.com/pr/existing");
     assert.ok(result.message.includes("already exists"));
-    assert.equal(mockStrategy.checkExistingPRCalled, true);
+    assert.equal(mockStrategy.findExistingPRUrlCalled, true);
     assert.equal(mockStrategy.createCalled, false);
   });
 
   test("delegates to strategy.create when no existing PR", async () => {
     const mockStrategy = new MockPRStrategy();
-    mockStrategy.checkExistingPRResult = null;
+    mockStrategy.findExistingPRUrlResult = null;
     mockStrategy.createResult = {
       success: true,
       url: "https://example.com/pr/new",
@@ -286,11 +286,11 @@ describe("PRWorkflowExecutor", () => {
 
     assert.equal(result.success, true);
     assert.equal(result.url, "https://example.com/pr/new");
-    assert.equal(mockStrategy.checkExistingPRCalled, true);
+    assert.equal(mockStrategy.findExistingPRUrlCalled, true);
     assert.equal(mockStrategy.createCalled, true);
   });
 
-  test("handles errors from checkExistingPR and returns failure", async () => {
+  test("handles errors from findExistingPRUrl and returns failure", async () => {
     const mockStrategy = new MockPRStrategy();
     mockStrategy.shouldThrowOnCheck = true;
     mockStrategy.throwMessage = "Network timeout";
@@ -305,7 +305,7 @@ describe("PRWorkflowExecutor", () => {
 
   test("handles errors from create and returns failure", async () => {
     const mockStrategy = new MockPRStrategy();
-    mockStrategy.checkExistingPRResult = null;
+    mockStrategy.findExistingPRUrlResult = null;
     mockStrategy.shouldThrowOnCreate = true;
     mockStrategy.throwMessage = "API rate limit exceeded";
     const executor = new PRWorkflowExecutor(mockStrategy);
@@ -319,8 +319,8 @@ describe("PRWorkflowExecutor", () => {
 
   test("handles non-Error throws", async () => {
     const mockStrategy = new MockPRStrategy();
-    // Override checkExistingPR to throw a string
-    mockStrategy.checkExistingPR = async () => {
+    // Override findExistingPRUrl to throw a string
+    mockStrategy.findExistingPRUrl = async () => {
       throw "string error";
     };
     const executor = new PRWorkflowExecutor(mockStrategy);


### PR DESCRIPTION
## Summary

Continuation of round 8. 4 clusters executed (16 review issues resolved) on top of PR #706.

### Clusters completed
- **low-elegance-helper-extraction** (5 issues): extracted \`resolveContentInFilesMap\`, applied grouped-record idiom in labels formatter + extracted \`mergeNamedEntries\`, extracted \`enrichSettingsContext\` and \`pushFailure\`
- **design-coherence-factory-consolidation** (3 issues): \`SettingsProcessorFactories\` record collapsing 4 flat factory fields; split \`validateSettings\` into 5 per-concern dispatchers
- **cross-module-architecture-layering** (2 issues): inverted \`gh-api-utils\`/\`xfg-template\` dependency via local types to restore shared-as-leaf; madge confirms no cycles
- **api-and-contract-coherence** (5 issues): \`classifyCommitError\` + \`findExistingPRUrl\` renames; \`IRepoSettingsStrategy\` verb alignment; \`IRepoLifecycleProvider\` options-bag migration; \`GitOps.commit\` dry-run JSDoc clarification

### Remaining (3 clusters)
- initialization-coupling-fixes (2 issues)
- error-consistency-newly-surfaced (2 issues)
- mid-elegance-settings-report-delta (1 issue)

## Test plan

- [x] \`npm test\` — 2600/2600 passing
- [x] \`npm run test:typecheck\` — clean
- [x] \`./lint.sh\` — clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)