### PR TITLE
fix: detect removal of individual items in index-matched arrays

### DIFF
--- a/src/settings/rulesets/diff.ts
+++ b/src/settings/rulesets/diff.ts
@@ -262,6 +262,11 @@ function matchByIndex(current: unknown[], desired: unknown[]): unknown[] {
   for (let i = 0; i < Math.min(current.length, desired.length); i++) {
     result.push(projectToDesiredShape(current[i], desired[i]));
   }
+  // Append extra current items so deepEqual detects length mismatch (removals).
+  // Mirrors matchByKey behavior added for #549.
+  for (let i = desired.length; i < current.length; i++) {
+    result.push(current[i]);
+  }
   return result;
 }
 

--- a/test/unit/settings/rulesets/diff.test.ts
+++ b/test/unit/settings/rulesets/diff.test.ts
@@ -584,6 +584,54 @@ describe("diffRulesets", () => {
 
       assert.equal(changes[0].action, "update");
     });
+
+    test("detects removal of individual requiredStatusChecks item (#731)", () => {
+      const current: GitHubRuleset[] = [
+        {
+          id: 1,
+          name: "pr-rules",
+          target: "branch",
+          enforcement: "active",
+          rules: [
+            {
+              type: "required_status_checks",
+              parameters: {
+                do_not_enforce_on_create: false,
+                required_status_checks: [
+                  { context: "summary / Check Results" },
+                  { context: "Mergify Merge Protections" },
+                ],
+                strict_required_status_checks_policy: true,
+              },
+            },
+          ],
+        },
+      ];
+      const desired = new Map<string, Ruleset>([
+        [
+          "pr-rules",
+          {
+            target: "branch",
+            enforcement: "active",
+            rules: [
+              {
+                type: "required_status_checks",
+                parameters: {
+                  doNotEnforceOnCreate: false,
+                  requiredStatusChecks: [
+                    { context: "summary / Check Results" },
+                  ],
+                  strictRequiredStatusChecksPolicy: true,
+                },
+              },
+            ],
+          },
+        ],
+      ]);
+      const changes = diffRulesets(current, desired, false);
+
+      assert.equal(changes[0].action, "update");
+    });
   });
 });
 
@@ -1496,6 +1544,46 @@ describe("projectToDesiredShape", () => {
         { actor_id: 2740, actor_type: "Team", bypass_mode: "always" },
       ],
     });
+  });
+
+  test("preserves extra current items when matching by index (no match key)", () => {
+    // Regression: #731 — matchByIndex truncated to min(current, desired) length,
+    // hiding removals of items in arrays without type/actor_id keys
+    // (e.g. requiredStatusChecks which use context as identifier)
+    const current = {
+      rules: [
+        {
+          type: "required_status_checks",
+          parameters: {
+            required_status_checks: [
+              { context: "summary / Check Results" },
+              { context: "Mergify Merge Protections" },
+            ],
+            strict_required_status_checks_policy: true,
+          },
+        },
+      ],
+    };
+    const desired = {
+      rules: [
+        {
+          type: "required_status_checks",
+          parameters: {
+            required_status_checks: [{ context: "summary / Check Results" }],
+            strict_required_status_checks_policy: true,
+          },
+        },
+      ],
+    };
+
+    const result = projectToDesiredShape(current, desired);
+
+    const rules = (result as Record<string, unknown[]>).rules;
+    const params = (rules[0] as Record<string, Record<string, unknown[]>>)
+      .parameters;
+    // Projected current must preserve the extra item so deepEqual
+    // detects the length mismatch and flags an update
+    assert.equal(params.required_status_checks.length, 2);
   });
 
   test("preserves current-only bypass_actors for removal detection", () => {


### PR DESCRIPTION
## Summary

Fixes #731 — `matchByIndex` in `src/settings/rulesets/diff.ts` truncated projected arrays to `min(current, desired)` length, silently hiding removals for arrays of objects without `type`/`actor_id` match keys (e.g. `requiredStatusChecks`).

- Append extra current items beyond desired's length so `deepEqual` detects the length mismatch
- Mirrors the existing `matchByKey` fix from #549
- 3-line production fix, 2 regression tests

## Test plan

- [x] Unit test: `projectToDesiredShape` preserves extra current items when matching by index
- [x] Unit test: `diffRulesets` detects removal of individual `requiredStatusChecks` item
- [x] Full test suite passes (2634/2634, 0 failures)
- [ ] CI passes
- [ ] Integration test: remove a status check from config, verify plan shows update and apply removes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)