### PR TITLE
fix: allow per-repo standalone file definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Thumbs.db
 .desloppify/subagents/
 
 docs/plans
+.desloppify/

--- a/src/config/normalizer.ts
+++ b/src/config/normalizer.ts
@@ -691,6 +691,17 @@ export function normalizeConfig(
 
     const fileNames = Object.keys(effectiveRootFiles);
 
+    // Collect repo-only file names (defined at repo level but not in root/groups)
+    const repoOnlyFileNames: string[] = [];
+    if (rawRepo.files) {
+      for (const name of Object.keys(rawRepo.files)) {
+        if (name === "inherit") continue;
+        if (!effectiveRootFiles[name]) {
+          repoOnlyFileNames.push(name);
+        }
+      }
+    }
+
     for (const gitUrl of gitUrls) {
       const files: FileContent[] = [];
 
@@ -705,6 +716,22 @@ export function normalizeConfig(
           effectiveRootFiles[fileName],
           rawRepo.files?.[fileName],
           inheritFiles,
+          raw.deleteOrphaned,
+          env
+        );
+        if (entry) files.push(entry);
+      }
+
+      // Process repo-only files (standalone definitions not in root/groups)
+      for (const fileName of repoOnlyFileNames) {
+        const repoOverride = rawRepo.files![fileName];
+        if (repoOverride === false) continue;
+
+        const entry = resolveFileEntry(
+          fileName,
+          {} as RawFileConfig,
+          repoOverride,
+          true,
           raw.deleteOrphaned,
           env
         );

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -905,9 +905,18 @@ function validateRepoFiles(
     }
 
     if (!knownFiles.has(fileName)) {
-      throw new ValidationError(
-        `Repo at index ${index} references undefined file '${fileName}'. File must be defined in root 'files' object or in a referenced group.`
-      );
+      const fileEntry = (repo.files as Record<string, unknown>)[fileName];
+      const isStandaloneDefinition =
+        fileEntry != null &&
+        fileEntry !== false &&
+        typeof fileEntry === "object" &&
+        "content" in (fileEntry as Record<string, unknown>) &&
+        (fileEntry as Record<string, unknown>).content !== undefined;
+      if (!isStandaloneDefinition) {
+        throw new ValidationError(
+          `Repo at index ${index} references undefined file '${fileName}'. File must be defined in root 'files' object or in a referenced group, or provide content inline.`
+        );
+      }
     }
 
     const fileOverride = repo.files[fileName];

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -917,6 +917,7 @@ function validateRepoFiles(
           `Repo at index ${index} references undefined file '${fileName}'. File must be defined in root 'files' object or in a referenced group, or provide content inline.`
         );
       }
+      validateFileName(fileName);
     }
 
     const fileOverride = repo.files[fileName];

--- a/test/unit/config/normalizer.test.ts
+++ b/test/unit/config/normalizer.test.ts
@@ -5839,4 +5839,119 @@ describe("conditional group configuration", () => {
       "noneOf matched: repo with empty groups array"
     );
   });
+
+  describe("per-repo standalone file definitions", () => {
+    test("includes repo-only file not defined in root or groups", () => {
+      const raw: RawConfig = {
+        id: "test-config",
+        files: { "shared.json": { content: { shared: true } } },
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "repo-only.json": { content: { local: true } },
+            },
+          },
+        ],
+      };
+
+      const result = normalizeConfig(raw, {});
+      const fileNames = result.repos[0].files.map((f) => f.fileName);
+      assert.ok(fileNames.includes("shared.json"));
+      assert.ok(fileNames.includes("repo-only.json"));
+    });
+
+    test("repo-only file resolves content correctly", () => {
+      const raw: RawConfig = {
+        id: "test-config",
+        files: {},
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              ".github/renovate-overrides.json5": {
+                content: { extends: ["config:base"] },
+              },
+            },
+          },
+        ],
+      };
+
+      const result = normalizeConfig(raw, {});
+      assert.equal(result.repos[0].files.length, 1);
+      assert.equal(
+        result.repos[0].files[0].fileName,
+        ".github/renovate-overrides.json5"
+      );
+      assert.deepEqual(result.repos[0].files[0].content, {
+        extends: ["config:base"],
+      });
+    });
+
+    test("repo-only file does not leak to other repos", () => {
+      const raw: RawConfig = {
+        id: "test-config",
+        files: { "shared.json": { content: { shared: true } } },
+        repos: [
+          {
+            git: "git@github.com:org/repo-a.git",
+            files: {
+              "only-a.json": { content: { a: true } },
+            },
+          },
+          {
+            git: "git@github.com:org/repo-b.git",
+          },
+        ],
+      };
+
+      const result = normalizeConfig(raw, {});
+      const repoAFiles = result.repos[0].files.map((f) => f.fileName);
+      const repoBFiles = result.repos[1].files.map((f) => f.fileName);
+      assert.ok(repoAFiles.includes("only-a.json"));
+      assert.ok(repoAFiles.includes("shared.json"));
+      assert.ok(!repoBFiles.includes("only-a.json"));
+      assert.ok(repoBFiles.includes("shared.json"));
+    });
+
+    test("repo-only file with false is excluded", () => {
+      const raw: RawConfig = {
+        id: "test-config",
+        files: {},
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "excluded.json": false,
+              "included.json": { content: { yes: true } },
+            },
+          },
+        ],
+      };
+
+      const result = normalizeConfig(raw, {});
+      const fileNames = result.repos[0].files.map((f) => f.fileName);
+      assert.ok(!fileNames.includes("excluded.json"));
+      assert.ok(fileNames.includes("included.json"));
+    });
+
+    test("repo-only file inherits deleteOrphaned from root", () => {
+      const raw: RawConfig = {
+        id: "test-config",
+        files: {},
+        deleteOrphaned: true,
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "local.json": { content: { x: 1 } },
+            },
+          },
+        ],
+      };
+
+      const result = normalizeConfig(raw, {});
+      assert.equal(result.repos[0].files[0].deleteOrphaned, true);
+    });
+  });
 });

--- a/test/unit/config/validator.test.ts
+++ b/test/unit/config/validator.test.ts
@@ -455,6 +455,24 @@ describe("validateRawConfig", () => {
       );
     });
 
+    test("rejects standalone per-repo file with path traversal", () => {
+      const config = createValidConfig({
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "../../../etc/passwd": { content: "malicious" },
+            },
+          },
+        ],
+      });
+
+      assert.throws(
+        () => validateRawConfig(config),
+        /Invalid fileName '..\/..\/..\/etc\/passwd'/
+      );
+    });
+
     test("throws when per-repo file override has true but no content", () => {
       const config = createValidConfig({
         repos: [

--- a/test/unit/config/validator.test.ts
+++ b/test/unit/config/validator.test.ts
@@ -372,13 +372,13 @@ describe("validateRawConfig", () => {
   });
 
   describe("per-repo file override validation", () => {
-    test("throws when repo references undefined file", () => {
+    test("throws when repo references undefined file without content", () => {
       const config = createValidConfig({
         repos: [
           {
             git: "git@github.com:org/repo.git",
             files: {
-              "nonexistent.json": { content: {} },
+              "nonexistent.json": { createOnly: true },
             },
           },
         ],
@@ -403,6 +403,56 @@ describe("validateRawConfig", () => {
       });
 
       assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("allows standalone per-repo file with content not in root or groups", () => {
+      const config = createValidConfig({
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              ".github/renovate-overrides.json5": {
+                content: { extends: ["config:base"] },
+              },
+            },
+          },
+        ],
+      });
+
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("allows standalone per-repo text file with string content", () => {
+      const config = createValidConfig({
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "custom-script.sh": { content: "#!/bin/bash\necho hello" },
+            },
+          },
+        ],
+      });
+
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("rejects standalone per-repo file without content", () => {
+      const config = createValidConfig({
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "unknown.json": { executable: true },
+            },
+          },
+        ],
+      });
+
+      assert.throws(
+        () => validateRawConfig(config),
+        /Repo at index 0 references undefined file 'unknown.json'/
+      );
     });
 
     test("throws when per-repo file override has true but no content", () => {


### PR DESCRIPTION
## Summary

- Per-repo `files` entries with `content` now work standalone — no need to pre-declare in root `files` or a group
- Validator only rejects repo-level files that lack `content` and aren't defined in root/groups (pure references to undefined files)
- Normalizer now iterates repo-only file names so they get resolved into the final config

Closes #741

## Test plan

- [x] Existing test updated: repo file with `content` no longer rejected as "undefined"
- [x] New validator tests: standalone per-repo JSON file, text file, rejection without content
- [x] New normalizer tests: repo-only file included, content resolved, no leakage to other repos, `false` exclusion, `deleteOrphaned` inheritance
- [x] Full test suite: 2642 pass, 0 fail
- [x] TypeScript build passes
- [x] Test typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)