### PR TITLE
feat: support header comments in JSON5 files

### DIFF
--- a/src/config/formatter.ts
+++ b/src/config/formatter.ts
@@ -65,6 +65,11 @@ function buildCommentOnlyYaml(
   return lines.join("\n") + "\n";
 }
 
+function buildJson5HeaderComment(header?: string[]): string | undefined {
+  if (!header || header.length === 0) return undefined;
+  return header.map((h) => `// ${h}`).join("\n") + "\n";
+}
+
 /**
  * Converts content to string in the appropriate format.
  * Handles null content (empty files), text content (string/string[]), and object content (JSON/YAML).
@@ -81,6 +86,12 @@ export function convertContentToString(
         options.header,
         options.schemaUrl
       );
+      if (commentOnly) {
+        return commentOnly;
+      }
+    }
+    if (format === "json5" && options) {
+      const commentOnly = buildJson5HeaderComment(options.header);
       if (commentOnly) {
         return commentOnly;
       }
@@ -137,6 +148,12 @@ export function convertContentToString(
     });
   }
 
-  // JSON and JSON5 — both use standard JSON.stringify (valid JSON5 superset)
+  if (format === "json5" && options) {
+    const headerComment = buildJson5HeaderComment(options.header);
+    if (headerComment) {
+      return headerComment + JSON.stringify(content, null, 2) + "\n";
+    }
+  }
+
   return JSON.stringify(content, null, 2) + "\n";
 }

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -911,7 +911,8 @@ function validateRepoFiles(
         fileEntry !== false &&
         typeof fileEntry === "object" &&
         "content" in (fileEntry as Record<string, unknown>) &&
-        (fileEntry as Record<string, unknown>).content !== undefined;
+        (fileEntry as Record<string, unknown>).content !== undefined &&
+        (fileEntry as Record<string, unknown>).content !== null;
       if (!isStandaloneDefinition) {
         throw new ValidationError(
           `Repo at index ${index} references undefined file '${fileName}'. File must be defined in root 'files' object or in a referenced group, or provide content inline.`

--- a/test/unit/config/formatter.test.ts
+++ b/test/unit/config/formatter.test.ts
@@ -309,15 +309,58 @@ describe("convertContentToString with JSON5 format", () => {
     assert.equal(result, "");
   });
 
-  test("header and schemaUrl are ignored for JSON5 files", () => {
+  test("null content with header returns // comments for JSON5", () => {
+    const result = convertContentToString(null, "config.json5", {
+      header: ["This is a header comment"],
+    });
+    assert.ok(result.includes("// This is a header comment"));
+  });
+
+  test("null content with schemaUrl is ignored for JSON5", () => {
+    const result = convertContentToString(null, "config.json5", {
+      schemaUrl: "https://example.com/schema.json",
+    });
+    assert.equal(result, "");
+  });
+
+  test("header adds // comment lines for JSON5 files", () => {
     const content = { key: "value" };
     const result = convertContentToString(content, "config.json5", {
       header: ["This is a comment"],
+    });
+    assert.ok(
+      result.includes("// This is a comment"),
+      `Expected // comment, got: ${result}`
+    );
+    assert.ok(result.includes('"key"'));
+  });
+
+  test("multi-line header works for JSON5 files", () => {
+    const content = { key: "value" };
+    const result = convertContentToString(content, "config.json5", {
+      header: ["Line 1", "Line 2"],
+    });
+    assert.ok(result.includes("// Line 1"));
+    assert.ok(result.includes("// Line 2"));
+  });
+
+  test("schemaUrl is ignored for JSON5 files", () => {
+    const content = { key: "value" };
+    const result = convertContentToString(content, "config.json5", {
       schemaUrl: "https://example.com/schema.json",
     });
-    assert.ok(!result.includes("comment"));
     assert.ok(!result.includes("schema"));
     assert.ok(result.includes('"key"'));
+  });
+
+  test("header with schemaUrl only emits header for JSON5 files", () => {
+    const content = { key: "value" };
+    const result = convertContentToString(content, "config.json5", {
+      header: ["Custom comment"],
+      schemaUrl: "https://example.com/schema.json",
+    });
+    assert.ok(result.includes("// Custom comment"));
+    assert.ok(!result.includes("schema"));
   });
 });
 

--- a/test/unit/config/normalizer.test.ts
+++ b/test/unit/config/normalizer.test.ts
@@ -5935,6 +5935,30 @@ describe("conditional group configuration", () => {
       assert.ok(fileNames.includes("included.json"));
     });
 
+    test("repo-only file included even with inherit: false", () => {
+      const raw: RawConfig = {
+        id: "test-config",
+        files: { "shared.json": { content: { shared: true } } },
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              inherit: false,
+              "repo-only.json": { content: { local: true } },
+            },
+          },
+        ],
+      };
+
+      const result = normalizeConfig(raw, {});
+      const fileNames = result.repos[0].files.map((f) => f.fileName);
+      assert.ok(!fileNames.includes("shared.json"), "inherited file excluded");
+      assert.ok(
+        fileNames.includes("repo-only.json"),
+        "standalone file included"
+      );
+    });
+
     test("repo-only file inherits deleteOrphaned from root", () => {
       const raw: RawConfig = {
         id: "test-config",

--- a/test/unit/config/validator.test.ts
+++ b/test/unit/config/validator.test.ts
@@ -473,6 +473,54 @@ describe("validateRawConfig", () => {
       );
     });
 
+    test("rejects standalone per-repo file with content: null", () => {
+      const config = createValidConfig({
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "empty.json": { content: null as unknown as string },
+            },
+          },
+        ],
+      });
+
+      assert.throws(
+        () => validateRawConfig(config),
+        /Repo at index 0 references undefined file 'empty.json'/
+      );
+    });
+
+    test("allows standalone per-repo file with empty string content", () => {
+      const config = createValidConfig({
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "empty.sh": { content: "" },
+            },
+          },
+        ],
+      });
+
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("allows standalone per-repo file with empty object content", () => {
+      const config = createValidConfig({
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            files: {
+              "defaults.json": { content: {} },
+            },
+          },
+        ],
+      });
+
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
     test("throws when per-repo file override has true but no content", () => {
       const config = createValidConfig({
         repos: [


### PR DESCRIPTION
## Summary
- Add `//` header comment support for `.json5` files (previously only YAML got `#` headers)
- Fix standalone per-repo file validator accepting `content: null` as valid
- Add missing test coverage for standalone file edge cases (`content: null`, empty string, empty object, `inherit: false` interaction)

Closes #739

## Test plan
- [x] `npm test` — 2652 tests pass (4 new)
- [x] `npm run test:typecheck` — clean
- [x] `./lint.sh` — clean
- [x] Red phase verified: `content: null` test fails without fix, passes with it
- [ ] Integration tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)