### PR TITLE
fix(ci): skip CI when non-integration labels are added

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   check-changes:
+    if: github.event.action != 'labeled' || github.event.label.name == 'run-integration'
     runs-on: ubuntu-latest
     outputs:
       build-needed: ${{ steps.filter.outputs.build-needed }}
@@ -81,7 +82,7 @@ jobs:
           echo "$CHANGED"
 
   lint:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && (github.event.action != 'labeled' || github.event.label.name == 'run-integration')
     uses: "anthony-spruyt/repo-operator/.github/workflows/_lint.yaml@main"
     secrets: "inherit"
 


### PR DESCRIPTION
## Summary

- Gate `check-changes` and `lint` jobs to skip when a `labeled` event fires for any label other than `run-integration`
- Prevents Mergify's `queued` label from triggering full 17-minute CI builds that time out

## Test plan

- [ ] Add a non-integration label to a PR — CI should not trigger
- [ ] Add `run-integration` label to a PR — CI should trigger with integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)