### PR TITLE
fix(test): use mkdtempSync for secure temp directory creation

### DIFF
--- a/test/unit/shared/command-executor.test.ts
+++ b/test/unit/shared/command-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "node:test";
 import { strict as assert } from "node:assert";
 import { tmpdir } from "node:os";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   ProcessExecutor,
@@ -11,11 +11,7 @@ import {
 
 describe("ProcessExecutor", () => {
   const executor = new ProcessExecutor(process.env);
-  const testDir = join(tmpdir(), `cmd-exec-test-${Date.now()}`);
-
-  test("setup", () => {
-    mkdirSync(testDir, { recursive: true });
-  });
+  const testDir = mkdtempSync(join(tmpdir(), "cmd-exec-test-"));
 
   test("runs simple command and returns trimmed output", async () => {
     const result = await executor.exec("echo", ["hello"], testDir);


### PR DESCRIPTION
## Summary
- Replace `mkdirSync` with `mkdtempSync` in command-executor tests for secure temp directory creation (mode 0700)
- Remove now-unnecessary "setup" test block — `mkdtempSync` creates the directory inline
- Resolves CodeQL alert [#567](https://github.com/anthony-spruyt/xfg/security/code-scanning/567) (CWE-377: insecure temporary file)

## Test plan
- [x] `npm test` — 2745 pass
- [x] `npm run test:typecheck` — clean
- [x] `./lint.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)