### PR TITLE
feat: add $arrayMerge merge strategy for key-based array merging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
         additional_dependencies:
           - "mdformat-gfm"
           - "mdformat-frontmatter"
+          - "mdformat-admon"
   - repo: "https://github.com/igorshubovych/markdownlint-cli"
     rev: "v0.48.0"
     hooks:

--- a/config-schema.json
+++ b/config-schema.json
@@ -809,13 +809,13 @@
     },
     "arrayMergeDirective": {
       "type": "object",
-      "description": "Merge directive for arrays. Instead of replacing the base array, append or prepend values to the inherited array.",
+      "description": "Merge directive for arrays. Instead of replacing the base array, append, prepend, or deep-merge values with the inherited array.",
       "required": ["$arrayMerge", "$values"],
       "properties": {
         "$arrayMerge": {
           "type": "string",
-          "enum": ["replace", "append", "prepend"],
-          "description": "How to merge with the base array: 'append' adds after, 'prepend' adds before, 'replace' replaces entirely"
+          "enum": ["replace", "append", "prepend", "merge"],
+          "description": "How to merge with the base array: 'append' adds after, 'prepend' adds before, 'replace' replaces entirely, 'merge' deep-merges items matched by identity key (type, actor_id)"
         },
         "$values": {
           "type": "array",
@@ -832,7 +832,7 @@
       "properties": {
         "$arrayMerge": {
           "type": "string",
-          "enum": ["replace", "append", "prepend"],
+          "enum": ["replace", "append", "prepend", "merge"],
           "description": "How to merge with the base array"
         },
         "$values": {
@@ -852,7 +852,7 @@
       "properties": {
         "$arrayMerge": {
           "type": "string",
-          "enum": ["replace", "append", "prepend"],
+          "enum": ["replace", "append", "prepend", "merge"],
           "description": "How to merge with the base array"
         },
         "$values": {

--- a/config-schema.json
+++ b/config-schema.json
@@ -98,10 +98,11 @@
           "enum": [
             "replace",
             "append",
-            "prepend"
+            "prepend",
+            "merge"
           ],
           "default": "replace",
-          "description": "Array merge strategy for this file. 'replace' replaces arrays, 'append' adds overlay after base, 'prepend' adds overlay before base. Default: replace"
+          "description": "Array merge strategy for this file. 'replace' replaces arrays, 'append' adds overlay after base, 'prepend' adds overlay before base, 'merge' deep-merges items matched by identity key (type, actor_id). Default: replace"
         },
         "createOnly": {
           "type": "boolean",

--- a/docs/ci-cd/github-actions.md
+++ b/docs/ci-cd/github-actions.md
@@ -130,7 +130,7 @@ See [GitHub App Authentication](../platforms/github-app.md) for full setup instr
 - Requires a Personal Access Token with `api` scope
 - Or a Project Access Token with `api` scope for single-project access
 
----
+______________________________________________________________________
 
 ## Workflow Example
 
@@ -160,9 +160,9 @@ jobs:
 ## Creating a PAT
 
 1. Go to **Settings** > **Developer settings** > **Personal access tokens** > **Tokens (classic)**
-2. Click **Generate new token (classic)**
-3. Select the `repo` scope
-4. Copy the token and add it as a repository secret named `GH_PAT`
+1. Click **Generate new token (classic)**
+1. Select the `repo` scope
+1. Copy the token and add it as a repository secret named `GH_PAT`
 
 ## Multiple Config Files
 

--- a/docs/ci-cd/index.md
+++ b/docs/ci-cd/index.md
@@ -10,9 +10,9 @@ Run xfg automatically when your config file changes.
 ## General Pattern
 
 1. Trigger on changes to your config file
-2. Install Node.js and xfg
-3. Authenticate with the target platform
-4. Run xfg
+1. Install Node.js and xfg
+1. Authenticate with the target platform
+1. Run xfg
 
 ## Environment Variables
 

--- a/docs/configuration/code-scanning.md
+++ b/docs/configuration/code-scanning.md
@@ -29,25 +29,25 @@ xfg sync -c config.yaml
 
 ## Configuration Fields
 
-| Property     | Required | Description                                                                                      |
-| ------------ | -------- | ------------------------------------------------------------------------------------------------ |
-| `state`      | Yes      | `configured` to enable code scanning, `not-configured` to disable                                |
-| `querySuite` | No       | `default` for standard queries, `extended` for additional queries. Omit to let GitHub decide.    |
-| `languages`  | No       | Array of languages to analyze. Omit to let GitHub auto-detect languages in the repository.       |
+| Property     | Required | Description                                                                                   |
+| ------------ | -------- | --------------------------------------------------------------------------------------------- |
+| `state`      | Yes      | `configured` to enable code scanning, `not-configured` to disable                             |
+| `querySuite` | No       | `default` for standard queries, `extended` for additional queries. Omit to let GitHub decide. |
+| `languages`  | No       | Array of languages to analyze. Omit to let GitHub auto-detect languages in the repository.    |
 
 ## Supported Languages
 
-| Language                   | Value                      |
-| -------------------------- | -------------------------- |
-| GitHub Actions             | `actions`                  |
-| C / C++                    | `c-cpp`                    |
-| C#                         | `csharp`                   |
-| Go                         | `go`                       |
-| Java / Kotlin              | `java-kotlin`              |
-| JavaScript / TypeScript    | `javascript-typescript`    |
-| Python                     | `python`                   |
-| Ruby                       | `ruby`                     |
-| Swift                      | `swift`                    |
+| Language                | Value                   |
+| ----------------------- | ----------------------- |
+| GitHub Actions          | `actions`               |
+| C / C++                 | `c-cpp`                 |
+| C#                      | `csharp`                |
+| Go                      | `go`                    |
+| Java / Kotlin           | `java-kotlin`           |
+| JavaScript / TypeScript | `javascript-typescript` |
+| Python                  | `python`                |
+| Ruby                    | `ruby`                  |
+| Swift                   | `swift`                 |
 
 ## Full Example
 

--- a/docs/configuration/groups.md
+++ b/docs/configuration/groups.md
@@ -42,20 +42,20 @@ repos:
 
 Groups support the same override capabilities as repos:
 
-| Field        | Description                                           |
-| ------------ | ----------------------------------------------------- |
-| `extends`    | Parent group name(s) to inherit from                  |
-| `files`      | File definitions or overrides (same syntax as repos)  |
-| `prOptions`  | PR merge options (merged into chain)                  |
-| `settings`   | Repository settings like rulesets, labels             |
+| Field       | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| `extends`   | Parent group name(s) to inherit from                 |
+| `files`     | File definitions or overrides (same syntax as repos) |
+| `prOptions` | PR merge options (merged into chain)                 |
+| `settings`  | Repository settings like rulesets, labels            |
 
 ## Merge Chain
 
 When a repo references groups, the merge chain is:
 
 1. **Root files** — base layer
-2. **Group layers** — applied left-to-right in array order (when groups use `extends`, parent groups are automatically included before the child)
-3. **Repo overrides** — final layer
+1. **Group layers** — applied left-to-right in array order (when groups use `extends`, parent groups are automatically included before the child)
+1. **Repo overrides** — final layer
 
 Each layer deep-merges onto the previous. Later values win for conflicting keys.
 
@@ -334,9 +334,7 @@ repos:
 
 ## Conditional Groups
 
-Conditional groups activate automatically based on which groups a repo has.
-They are defined in a top-level `conditionalGroups` array, separate from
-regular groups.
+Conditional groups activate automatically based on which groups a repo has. They are defined in a top-level `conditionalGroups` array, separate from regular groups.
 
 ### `allOf` — Intersection
 
@@ -353,8 +351,7 @@ conditionalGroups:
           description: ""
 ```
 
-The `renovate/terraform` label is only added to repos that have both
-`terraform` and `renovate` in their `groups` array.
+The `renovate/terraform` label is only added to repos that have both `terraform` and `renovate` in their `groups` array.
 
 ### `anyOf` — Union
 
@@ -386,13 +383,11 @@ conditionalGroups:
                 - id: trailing-whitespace
 ```
 
-This applies the default pre-commit config to all repos except those with the
-`custom-pre-commit` group, which can define their own variant.
+This applies the default pre-commit config to all repos except those with the `custom-pre-commit` group, which can define their own variant.
 
 ### Combined Conditions
 
-All operators in a `when` clause must be satisfied (AND logic). Any
-combination of `allOf`, `anyOf`, and `noneOf` can be used together:
+All operators in a `when` clause must be satisfied (AND logic). Any combination of `allOf`, `anyOf`, and `noneOf` can be used together:
 
 ```yaml
 conditionalGroups:
@@ -415,9 +410,9 @@ This matches repos that have `pre-commit` but **not** `pre-commit-custom-exclude
 Conditional groups merge **after** explicit groups and **before** repo overrides:
 
 1. **Root files/settings** — base layer
-2. **Explicit group layers** — applied left-to-right
-3. **Conditional group layers** — applied in array order
-4. **Repo overrides** — final layer
+1. **Explicit group layers** — applied left-to-right
+1. **Conditional group layers** — applied in array order
+1. **Repo overrides** — final layer
 
 Later conditional groups override earlier ones when they conflict.
 
@@ -432,14 +427,9 @@ Conditional groups support the same capabilities as regular groups:
 
 ### Restrictions
 
-- Group names in `allOf`/`anyOf`/`noneOf` must reference groups defined in
-  the `groups` map
-- Group names in `noneOf` must not overlap with `allOf` or `anyOf` in the
-  same `when` clause
+- Group names in `allOf`/`anyOf`/`noneOf` must reference groups defined in the `groups` map
+- Group names in `noneOf` must not overlap with `allOf` or `anyOf` in the same `when` clause
 - Conditional groups cannot be listed in a repo's `groups` array
 - Conditional groups cannot reference other conditional groups
-- A repo with no `groups` field or `groups: []` has an empty effective group
-  set — only `noneOf` conditions can match it
-- Conditional groups do not expand the effective group set — one conditional
-  group matching cannot cause another conditional group to match. All
-  conditions are evaluated against the same frozen set of explicit groups.
+- A repo with no `groups` field or `groups: []` has an empty effective group set — only `noneOf` conditions can match it
+- Conditional groups do not expand the effective group set — one conditional group matching cannot cause another conditional group to match. All conditions are evaluated against the same frozen set of explicit groups.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -22,22 +22,24 @@ repos: # List of repositories
 
 ## Root-Level Fields
 
-| Field                | Description                                                                                     | Required |
-| -------------------- | ----------------------------------------------------------------------------------------------- | -------- |
-| `id`                 | Unique identifier for this config. Used to namespace managed files in `.xfg.json` manifest.     | Yes      |
-| `files`              | Map of target filenames to configs                                                              | *        |
-| `repos`              | Array of repository configurations                                                              | Yes      |
-| `settings`           | Global settings. See [Repo Settings](repo-settings.md) and [Rulesets](rulesets.md)              | *        |
-| `groups`             | Named config groups. See [Groups](groups.md)                                                    | No       |
-| `conditionalGroups`  | Condition-based groups. See [Conditional Groups](groups.md#conditional-groups)                  | No       |
-| `prOptions`          | Global PR merge options (can be overridden per-repo)                                            | No       |
-| `prTemplate`         | Custom PR body template (inline or `@path/to/file` reference)                                   | No       |
-| `deleteOrphaned`     | Global default for orphan deletion. Files/rulesets removed from config are deleted.             | No       |
-| `githubHosts`        | Array of GitHub Enterprise hostnames (e.g., `github.mycompany.com`)                             | No       |
+| Field               | Description                                                                                 | Required |
+| ------------------- | ------------------------------------------------------------------------------------------- | -------- |
+| `id`                | Unique identifier for this config. Used to namespace managed files in `.xfg.json` manifest. | Yes      |
+| `files`             | Map of target filenames to configs                                                          | \*       |
+| `repos`             | Array of repository configurations                                                          | Yes      |
+| `settings`          | Global settings. See [Repo Settings](repo-settings.md) and [Rulesets](rulesets.md)          | \*       |
+| `groups`            | Named config groups. See [Groups](groups.md)                                                | No       |
+| `conditionalGroups` | Condition-based groups. See [Conditional Groups](groups.md#conditional-groups)              | No       |
+| `prOptions`         | Global PR merge options (can be overridden per-repo)                                        | No       |
+| `prTemplate`        | Custom PR body template (inline or `@path/to/file` reference)                               | No       |
+| `deleteOrphaned`    | Global default for orphan deletion. Files/rulesets removed from config are deleted.         | No       |
+| `githubHosts`       | Array of GitHub Enterprise hostnames (e.g., `github.mycompany.com`)                         | No       |
 
 <!-- markdownlint-disable MD046 -->
+
 !!! note "files/settings/groups requirement"
     At least one of `files`, `settings`, `groups`, or `conditionalGroups` must be present. The `xfg sync` command handles both file synchronization and settings management in a single run.
+
 <!-- markdownlint-enable MD046 -->
 
 ## Per-File Fields
@@ -56,15 +58,15 @@ repos: # List of repositories
 
 ## Per-Repo Fields
 
-| Field       | Description                                                                           | Required |
-| ----------- | ------------------------------------------------------------------------------------- | -------- |
-| `git`       | Git URL (string) or array of URLs                                                     | Yes      |
-| `groups`    | Array of group names to apply (in order). See [Groups](groups.md)                     | No       |
-| `files`     | Per-repo file overrides (optional)                                                    | No       |
-| `settings`  | Per-repo settings like `rulesets` (merged with root settings)                         | No       |
-| `prOptions` | Per-repo PR merge options (overrides global)                                          | No       |
-| `upstream`  | Fork from this repo if target doesn't exist. See [Lifecycle](lifecycle.md).           | No       |
-| `source`    | Migrate from this repo if target doesn't exist. See [Lifecycle](lifecycle.md).        | No       |
+| Field       | Description                                                                    | Required |
+| ----------- | ------------------------------------------------------------------------------ | -------- |
+| `git`       | Git URL (string) or array of URLs                                              | Yes      |
+| `groups`    | Array of group names to apply (in order). See [Groups](groups.md)              | No       |
+| `files`     | Per-repo file overrides (optional)                                             | No       |
+| `settings`  | Per-repo settings like `rulesets` (merged with root settings)                  | No       |
+| `prOptions` | Per-repo PR merge options (overrides global)                                   | No       |
+| `upstream`  | Fork from this repo if target doesn't exist. See [Lifecycle](lifecycle.md).    | No       |
+| `source`    | Migrate from this repo if target doesn't exist. See [Lifecycle](lifecycle.md). | No       |
 
 ## Per-Repo File Override Fields
 
@@ -111,8 +113,8 @@ repos:
 `deleteOrphaned` follows the standard inheritance pattern:
 
 1. **Global default** - Set at root level applies to all files
-2. **Per-file** - Overrides global default for specific files
-3. **Per-repo** - Overrides both global and per-file for specific repos
+1. **Per-file** - Overrides global default for specific files
+1. **Per-repo** - Overrides both global and per-file for specific repos
 
 ```yaml
 deleteOrphaned: true # Global: track all files by default

--- a/docs/configuration/inheritance.md
+++ b/docs/configuration/inheritance.md
@@ -1,10 +1,7 @@
 # Content Inheritance
 
-xfg uses a multi-level inheritance system that lets you define base configurations once and customize them per-repository.
-The basic chain is **root → repo overrides**. With [groups](groups.md), the chain becomes **root → group1 → group2 → repo overrides**.
-With [conditional groups](groups.md#conditional-groups), matching conditional groups merge after explicit groups:
-**root → groups → conditional groups → repo overrides**.
-When groups use [`extends`](groups.md#group-inheritance), parent groups are automatically included in the chain before the child group.
+xfg uses a multi-level inheritance system that lets you define base configurations once and customize them per-repository. The basic chain is **root → repo overrides**. With [groups](groups.md), the chain becomes **root → group1 → group2 → repo overrides**. With [conditional groups](groups.md#conditional-groups), matching conditional groups merge after explicit groups: **root → groups →
+conditional groups → repo overrides**. When groups use [`extends`](groups.md#group-inheritance), parent groups are automatically included in the chain before the child group.
 
 ## Inheritance Levels
 

--- a/docs/configuration/labels.md
+++ b/docs/configuration/labels.md
@@ -36,11 +36,11 @@ xfg sync -c config.yaml
 
 ## Label Properties
 
-| Property      | Required | Description                                                          |
-| ------------- | -------- | -------------------------------------------------------------------- |
-| `color`       | Yes      | Hex color code, with or without `#` (e.g., `d73a4a` or `#d73a4a`)    |
-| `description` | No       | Label description (max 100 characters)                               |
-| `new_name`    | No       | Rename the label to this value                                       |
+| Property      | Required | Description                                                       |
+| ------------- | -------- | ----------------------------------------------------------------- |
+| `color`       | Yes      | Hex color code, with or without `#` (e.g., `d73a4a` or `#d73a4a`) |
+| `description` | No       | Label description (max 100 characters)                            |
+| `new_name`    | No       | Rename the label to this value                                    |
 
 ## Color Format
 
@@ -133,9 +133,9 @@ repos:
 The `xfg sync` command:
 
 1. Fetches current labels from the GitHub API
-2. Compares them against the desired state in config (case-insensitive matching)
-3. Shows a Terraform-style plan of changes
-4. Applies changes in order: deletes, then updates/renames, then creates
+1. Compares them against the desired state in config (case-insensitive matching)
+1. Shows a Terraform-style plan of changes
+1. Applies changes in order: deletes, then updates/renames, then creates
 
 Label name matching is **case-insensitive** (GitHub treats label names as case-insensitive).
 

--- a/docs/configuration/lifecycle.md
+++ b/docs/configuration/lifecycle.md
@@ -7,27 +7,29 @@ xfg can automatically create, fork, or migrate repositories before syncing files
 Before processing each repo, xfg checks if the target repository exists:
 
 1. **Exists** - Proceed normally with sync/settings
-2. **Missing** - Create an empty repo
-3. **Missing + `upstream`** - Fork from the upstream repo
-4. **Missing + `source`** - Clone source with `--mirror` and push to new target
+1. **Missing** - Create an empty repo
+1. **Missing + `upstream`** - Fork from the upstream repo
+1. **Missing + `source`** - Clone source with `--mirror` and push to new target
 
 ## Fields
 
-| Field      | Type   | Description                                                      |
-| ---------- | ------ | ---------------------------------------------------------------- |
-| `upstream` | string | Git URL of repo to fork from (GitHub only)                       |
-| `source`   | string | Git URL of repo to migrate from (e.g., Azure DevOps to GitHub)   |
+| Field      | Type   | Description                                                    |
+| ---------- | ------ | -------------------------------------------------------------- |
+| `upstream` | string | Git URL of repo to fork from (GitHub only)                     |
+| `source`   | string | Git URL of repo to migrate from (e.g., Azure DevOps to GitHub) |
 
 <!-- markdownlint-disable MD046 -->
+
 !!! warning "Mutually exclusive"
-    `upstream` and `source` cannot be used together on the same repo.
-    Use `upstream` for forking within GitHub, or `source` for cross-platform migration.
+    `upstream` and `source` cannot be used together on the same repo. Use `upstream` for forking within GitHub, or `source` for cross-platform migration.
+
 <!-- markdownlint-enable MD046 -->
 
 <!-- markdownlint-disable MD046 -->
+
 !!! note "Forking is GitHub-only"
-    Both the `upstream` and target repos must be on GitHub (or GitHub Enterprise).
-    Cross-platform forking is not supported. For cross-platform transfers, use `source` (migration) instead.
+    Both the `upstream` and target repos must be on GitHub (or GitHub Enterprise). Cross-platform forking is not supported. For cross-platform transfers, use `source` (migration) instead.
+
 <!-- markdownlint-enable MD046 -->
 
 ## Forking (`upstream`)
@@ -48,12 +50,13 @@ repos:
 When the target repo doesn't exist, xfg will:
 
 1. Detect whether the target owner is an organization or user
-2. Fork the upstream repo accordingly
-3. Continue with normal sync/settings
+1. Fork the upstream repo accordingly
+1. Continue with normal sync/settings
 
 If the repo already exists, the `upstream` field is ignored.
 
 <!-- markdownlint-disable MD046 -->
+
 !!! note "Git array expansion"
     When using a `git` array with `upstream`, the same upstream is applied to all expanded repos:
 
@@ -66,12 +69,14 @@ If the repo already exists, the `upstream` field is ignored.
     ```
 
     This creates two forks of `opensource/tool` with different names (`fork-a` and `fork-b`).
+
 <!-- markdownlint-enable MD046 -->
 
 <!-- markdownlint-disable MD046 -->
+
 !!! note "Fork settings"
-    After forking, xfg will apply `settings.repo.visibility` and `settings.repo.description`
-    if configured. This allows you to fork a public repo and make it private, or vice versa.
+    After forking, xfg will apply `settings.repo.visibility` and `settings.repo.description` if configured. This allows you to fork a public repo and make it private, or vice versa.
+
 <!-- markdownlint-enable MD046 -->
 
 ## Migration (`source`)
@@ -87,17 +92,16 @@ repos:
 When `my-org/migrated-app` doesn't exist, xfg will:
 
 1. Clone `legacy-app` from Azure DevOps with `--mirror` (all branches and tags)
-2. Create `migrated-app` on GitHub
-3. Push the mirrored content to the new repo
-4. Clean up the temporary clone
-5. Continue with normal sync/settings
+1. Create `migrated-app` on GitHub
+1. Push the mirrored content to the new repo
+1. Clean up the temporary clone
+1. Continue with normal sync/settings
 
 If the repo already exists, the `source` field is ignored.
 
 ## Creation Settings
 
-When creating a new repo (via create, fork, or migrate), xfg applies settings from `settings.repo` if configured.
-Repos are created as **private** by default. Set `visibility: public` explicitly if needed.
+When creating a new repo (via create, fork, or migrate), xfg applies settings from `settings.repo` if configured. Repos are created as **private** by default. Set `visibility: public` explicitly if needed.
 
 ```yaml
 settings:
@@ -163,12 +167,12 @@ In dry-run mode (`--dry-run`), lifecycle operations are reported but not execute
 
 ## Supported Platforms
 
-| Operation         | GitHub | Azure DevOps | GitLab |
-| ----------------- | ------ | ------------ | ------ |
-| Create (target)   | Yes    | -            | -      |
-| Fork (target)     | Yes    | -            | -      |
-| Migrate (target)  | Yes    | -            | -      |
-| Migrate (source)  | -      | Yes          | -      |
+| Operation        | GitHub | Azure DevOps | GitLab |
+| ---------------- | ------ | ------------ | ------ |
+| Create (target)  | Yes    | -            | -      |
+| Fork (target)    | Yes    | -            | -      |
+| Migrate (target) | Yes    | -            | -      |
+| Migrate (source) | -      | Yes          | -      |
 
 ## Example: Full Lifecycle Config
 

--- a/docs/configuration/merge-strategies.md
+++ b/docs/configuration/merge-strategies.md
@@ -122,7 +122,8 @@ rules:
 # Result: [{type: "pull_request", parameters: {requiredApprovingReviewCount: 2}}]
 ```
 
-!!! note "Directives are stripped" Both `$arrayMerge` and `$values` are internal directives and do not appear in the final output.
+!!! note "Directives are stripped"
+    Both `$arrayMerge` and `$values` are internal directives and do not appear in the final output.
 
 ### Merge by Key
 
@@ -199,7 +200,8 @@ dist/
 coverage/
 ```
 
-!!! note String content (not lines array) always uses replace strategy - the entire string is replaced.
+!!! note
+    String content (not lines array) always uses replace strategy - the entire string is replaced.
 
 ## Settings Array Merge
 
@@ -264,7 +266,8 @@ conditionalGroups:
 
 Repos with the `github-ci` group get both the `pull_request` rule and the `required_status_checks` rule. Repos without `github-ci` only get the `pull_request` rule.
 
-!!! note "Same syntax as file content" The `$arrayMerge` directive uses the same `$arrayMerge` + `$values` syntax in settings as in file content (see Inline Array Merge Directive above). Strategies: `append`, `prepend`, `replace`, `merge`.
+!!! note "Same syntax as file content"
+    The `$arrayMerge` directive uses the same `$arrayMerge` + `$values` syntax in settings as in file content (see Inline Array Merge Directive above). Strategies: `append`, `prepend`, `replace`, `merge`.
 
 ## Example: Different Strategies per File
 

--- a/docs/configuration/merge-strategies.md
+++ b/docs/configuration/merge-strategies.md
@@ -4,11 +4,12 @@ Control how arrays and text lines merge when combining base content with per-rep
 
 ## Strategies
 
-| Strategy  | Behavior                              |
-| --------- | ------------------------------------- |
-| `replace` | Overlay completely replaces base      |
-| `append`  | Overlay items added after base items  |
-| `prepend` | Overlay items added before base items |
+| Strategy  | Behavior                                                                                       |
+| --------- | ---------------------------------------------------------------------------------------------- |
+| `replace` | Overlay completely replaces base                                                               |
+| `append`  | Overlay items added after base items                                                           |
+| `prepend` | Overlay items added before base items                                                          |
+| `merge`   | Deep-merges array items matched by identity key (`type`, `actor_id`); unmatched items appended |
 
 ## File-Level Strategy
 
@@ -109,10 +110,66 @@ features:
   $arrayMerge: replace
   $values: ["new-item"]
 # Base ["a", "b"] + overlay ["c"] = ["c"]
+
+# merge — deep-merge items matched by identity key
+rules:
+  $arrayMerge: merge
+  $values:
+    - type: pull_request
+      parameters:
+        requiredApprovingReviewCount: 2
+# Base [{type: "pull_request", parameters: {requiredApprovingReviewCount: 1}}]
+# Result: [{type: "pull_request", parameters: {requiredApprovingReviewCount: 2}}]
 ```
 
-!!! note "Directives are stripped"
-    Both `$arrayMerge` and `$values` are internal directives and do not appear in the final output.
+!!! note "Directives are stripped" Both `$arrayMerge` and `$values` are internal directives and do not appear in the final output.
+
+### Merge by Key
+
+The `merge` strategy matches array items by an identity key and deep-merges matched pairs. This is useful when multiple conditional groups need to modify properties of the same item rather than duplicating it.
+
+**How it works:**
+
+1. xfg auto-detects the identity key by checking candidates in order: `type`, `actor_id`
+1. The first candidate key present in every item of both arrays wins
+1. For each overlay item: if a base item shares the same key value, the two are deep-merged; otherwise the overlay item is appended
+1. Unmatched base items are preserved in their original position
+1. Nested `$arrayMerge` directives inside matched items are honored (deep-merge recurses)
+
+**When no match key is found** (e.g. primitive arrays or objects without `type`/`actor_id`), the strategy falls back to `append` behavior.
+
+```yaml
+# Example: merging required_status_checks across conditional groups
+settings:
+  rulesets:
+    pr-rules:
+      rules:
+        - type: pull_request
+          parameters:
+            requiredApprovingReviewCount: 1
+        - type: required_status_checks
+          parameters:
+            requiredStatusChecks:
+              - context: "ci / build"
+
+conditionalGroups:
+  - when:
+      allOf: [has-mergify]
+    settings:
+      rulesets:
+        pr-rules:
+          rules:
+            $arrayMerge: merge
+            $values:
+              - type: required_status_checks
+                parameters:
+                  requiredStatusChecks:
+                    $arrayMerge: append
+                    $values:
+                      - context: "mergify / queue"
+```
+
+Result for repos with `has-mergify`: the `required_status_checks` rule has both `ci / build` and `mergify / queue` checks — no duplication of the rule itself, and the nested `$arrayMerge: append` adds the check inside the matched item.
 
 ## Text File Merge Strategies
 
@@ -142,8 +199,7 @@ dist/
 coverage/
 ```
 
-!!! note
-    String content (not lines array) always uses replace strategy - the entire string is replaced.
+!!! note String content (not lines array) always uses replace strategy - the entire string is replaced.
 
 ## Settings Array Merge
 
@@ -208,8 +264,7 @@ conditionalGroups:
 
 Repos with the `github-ci` group get both the `pull_request` rule and the `required_status_checks` rule. Repos without `github-ci` only get the `pull_request` rule.
 
-!!! note "Same syntax as file content"
-    The `$arrayMerge` directive uses the same `$arrayMerge` + `$values` syntax in settings as in file content (see Inline Array Merge Directive above). Strategies: `append`, `prepend`, `replace`.
+!!! note "Same syntax as file content" The `$arrayMerge` directive uses the same `$arrayMerge` + `$values` syntax in settings as in file content (see Inline Array Merge Directive above). Strategies: `append`, `prepend`, `replace`, `merge`.
 
 ## Example: Different Strategies per File
 

--- a/docs/configuration/multi-file.md
+++ b/docs/configuration/multi-file.md
@@ -20,12 +20,12 @@ xfg-config/
 
 ## Merge Rules
 
-| Key | Behavior |
-| --- | --- |
-| `groups` | Merged by name — group names must be unique across files |
-| `conditionalGroups` | Concatenated in alphabetical file order |
-| `repos` | Concatenated in alphabetical file order |
-| All other keys | Must appear in exactly one file |
+| Key                 | Behavior                                                 |
+| ------------------- | -------------------------------------------------------- |
+| `groups`            | Merged by name — group names must be unique across files |
+| `conditionalGroups` | Concatenated in alphabetical file order                  |
+| `repos`             | Concatenated in alphabetical file order                  |
+| All other keys      | Must appear in exactly one file                          |
 
 ### Single-file keys
 
@@ -82,9 +82,9 @@ repos:
 
 Common errors when using directory-based config:
 
-| Error | Cause |
-| --- | --- |
-| `'id' is defined in both base.yaml and team.yaml` | A single-file key appears in multiple files |
-| `group 'X' is defined in both base.yaml and team.yaml` | Duplicate group name across files |
-| `no 'id' found in any file in directory ./xfg-config/` | No file defines `id` |
-| `no .yaml or .yml files found in directory ./xfg-config/` | Directory is empty or has no YAML files |
+| Error                                                     | Cause                                       |
+| --------------------------------------------------------- | ------------------------------------------- |
+| `'id' is defined in both base.yaml and team.yaml`         | A single-file key appears in multiple files |
+| `group 'X' is defined in both base.yaml and team.yaml`    | Duplicate group name across files           |
+| `no 'id' found in any file in directory ./xfg-config/`    | No file defines `id`                        |
+| `no .yaml or .yml files found in directory ./xfg-config/` | Directory is empty or has no YAML files     |

--- a/docs/configuration/pr-options.md
+++ b/docs/configuration/pr-options.md
@@ -4,13 +4,13 @@ Configure how PRs are handled after creation.
 
 ## PR Options Fields
 
-| Field           | Description                                                                            | Default  |
-| --------------- | -------------------------------------------------------------------------------------- | -------- |
-| `merge`         | Merge mode: `manual` (leave open), `auto` (merge when checks pass), `force`, `direct`  | `auto`   |
-| `mergeStrategy` | How to merge: `merge`, `squash`, `rebase`                                              | `squash` |
-| `deleteBranch`  | Delete source branch after merge                                                       | `true`   |
-| `bypassReason`  | Reason for bypassing policies (Azure DevOps only, required for `force`)                | -        |
-| `labels`        | Labels to apply to created PRs (GitHub only, more platforms coming)                    | -        |
+| Field           | Description                                                                           | Default  |
+| --------------- | ------------------------------------------------------------------------------------- | -------- |
+| `merge`         | Merge mode: `manual` (leave open), `auto` (merge when checks pass), `force`, `direct` | `auto`   |
+| `mergeStrategy` | How to merge: `merge`, `squash`, `rebase`                                             | `squash` |
+| `deleteBranch`  | Delete source branch after merge                                                      | `true`   |
+| `bypassReason`  | Reason for bypassing policies (Azure DevOps only, required for `force`)               | -        |
+| `labels`        | Labels to apply to created PRs (GitHub only, more platforms coming)                   | -        |
 
 ## Merge Modes
 
@@ -122,8 +122,8 @@ gh repo edit org/repo --enable-auto-merge
 ## Priority Order
 
 1. CLI flags (highest)
-2. Per-repo `prOptions`
-3. Conditional group `prOptions` (applied in array order)
-4. Group `prOptions` (applied in order, later groups override earlier ones)
-5. Global `prOptions`
-6. Built-in defaults (lowest)
+1. Per-repo `prOptions`
+1. Conditional group `prOptions` (applied in array order)
+1. Group `prOptions` (applied in order, later groups override earlier ones)
+1. Global `prOptions`
+1. Built-in defaults (lowest)

--- a/docs/configuration/pr-templates.md
+++ b/docs/configuration/pr-templates.md
@@ -41,15 +41,15 @@ repos:
 
 PR templates support all [templating variables](templating.md), plus PR-specific variables:
 
-| Variable                | Description                         | Example Output                                           |
-| ----------------------- | ----------------------------------- | -------------------------------------------------------- |
-| `${xfg:pr.fileChanges}` | Bulleted list of files with actions | `- Created \`config.json\`\n- Updated \`settings.yaml\`` |
-| `${xfg:pr.fileCount}`   | Number of changed files             | `3`                                                      |
-| `${xfg:pr.title}`       | The generated PR title              | `chore: sync config.json, settings.yaml`                 |
-| `${xfg:repo.name}`      | Repository name                     | `my-repo`                                                |
-| `${xfg:repo.owner}`     | Repository owner                    | `my-org`                                                 |
-| `${xfg:repo.fullName}`  | Full repository path                | `my-org/my-repo`                                         |
-| `${xfg:repo.platform}`  | Platform type                       | `github`, `azure-devops`, `gitlab`                       |
+| Variable                | Description                         | Example Output                                             |
+| ----------------------- | ----------------------------------- | ---------------------------------------------------------- |
+| `${xfg:pr.fileChanges}` | Bulleted list of files with actions | `- Created \`config.json\`\\n- Updated \`settings.yaml\`\` |
+| `${xfg:pr.fileCount}`   | Number of changed files             | `3`                                                        |
+| `${xfg:pr.title}`       | The generated PR title              | `chore: sync config.json, settings.yaml`                   |
+| `${xfg:repo.name}`      | Repository name                     | `my-repo`                                                  |
+| `${xfg:repo.owner}`     | Repository owner                    | `my-org`                                                   |
+| `${xfg:repo.fullName}`  | Full repository path                | `my-org/my-repo`                                           |
+| `${xfg:repo.platform}`  | Platform type                       | `github`, `azure-devops`, `gitlab`                         |
 
 ## Default Template
 

--- a/docs/configuration/repo-settings.md
+++ b/docs/configuration/repo-settings.md
@@ -37,43 +37,43 @@ xfg sync -c config.yaml
 
 ### Features
 
-| Setting | Type | Description |
-| ------- | ---- | ----------- |
-| `description` | string | Repository description |
-| `hasIssues` | boolean | Enable/disable GitHub Issues |
-| `hasProjects` | boolean | Enable/disable GitHub Projects |
-| `hasWiki` | boolean | Enable/disable the repository wiki |
-| `hasDiscussions` | boolean | Enable/disable GitHub Discussions |
-| `isTemplate` | boolean | Mark as a template repository |
-| `allowForking` | boolean | Allow forking (private repos) |
-| `visibility` | string | `public`, `private`, or `internal` |
-| `archived` | boolean | Archive the repository |
+| Setting                    | Type    | Description                           |
+| -------------------------- | ------- | ------------------------------------- |
+| `description`              | string  | Repository description                |
+| `hasIssues`                | boolean | Enable/disable GitHub Issues          |
+| `hasProjects`              | boolean | Enable/disable GitHub Projects        |
+| `hasWiki`                  | boolean | Enable/disable the repository wiki    |
+| `hasDiscussions`           | boolean | Enable/disable GitHub Discussions     |
+| `isTemplate`               | boolean | Mark as a template repository         |
+| `allowForking`             | boolean | Allow forking (private repos)         |
+| `visibility`               | string  | `public`, `private`, or `internal`    |
+| `archived`                 | boolean | Archive the repository                |
 | `webCommitSignoffRequired` | boolean | Require sign-off on web-based commits |
-| `defaultBranch` | string | Set the default branch |
+| `defaultBranch`            | string  | Set the default branch                |
 
 ### Merge Options
 
-| Setting | Type | Description |
-| ------- | ---- | ----------- |
-| `allowSquashMerge` | boolean | Allow squash merging |
-| `allowMergeCommit` | boolean | Allow merge commits |
-| `allowRebaseMerge` | boolean | Allow rebase merging |
-| `allowAutoMerge` | boolean | Allow auto-merge |
-| `deleteBranchOnMerge` | boolean | Auto-delete head branches |
-| `allowUpdateBranch` | boolean | Show "Update branch" button |
-| `squashMergeCommitTitle` | string | `PR_TITLE` or `COMMIT_OR_PR_TITLE` |
-| `squashMergeCommitMessage` | string | `PR_BODY`, `COMMIT_MESSAGES`, or `BLANK` |
-| `mergeCommitTitle` | string | `PR_TITLE` or `MERGE_MESSAGE` |
-| `mergeCommitMessage` | string | `PR_BODY`, `PR_TITLE`, or `BLANK` |
+| Setting                    | Type    | Description                              |
+| -------------------------- | ------- | ---------------------------------------- |
+| `allowSquashMerge`         | boolean | Allow squash merging                     |
+| `allowMergeCommit`         | boolean | Allow merge commits                      |
+| `allowRebaseMerge`         | boolean | Allow rebase merging                     |
+| `allowAutoMerge`           | boolean | Allow auto-merge                         |
+| `deleteBranchOnMerge`      | boolean | Auto-delete head branches                |
+| `allowUpdateBranch`        | boolean | Show "Update branch" button              |
+| `squashMergeCommitTitle`   | string  | `PR_TITLE` or `COMMIT_OR_PR_TITLE`       |
+| `squashMergeCommitMessage` | string  | `PR_BODY`, `COMMIT_MESSAGES`, or `BLANK` |
+| `mergeCommitTitle`         | string  | `PR_TITLE` or `MERGE_MESSAGE`            |
+| `mergeCommitMessage`       | string  | `PR_BODY`, `PR_TITLE`, or `BLANK`        |
 
 ### Security
 
-| Setting | Type | Description |
-| ------- | ---- | ----------- |
-| `vulnerabilityAlerts` | boolean | Dependabot vulnerability alerts |
-| `automatedSecurityFixes` | boolean | Dependabot security updates |
-| `secretScanning` | boolean | Secret scanning |
-| `secretScanningPushProtection` | boolean | Push protection for secrets |
+| Setting                         | Type    | Description                     |
+| ------------------------------- | ------- | ------------------------------- |
+| `vulnerabilityAlerts`           | boolean | Dependabot vulnerability alerts |
+| `automatedSecurityFixes`        | boolean | Dependabot security updates     |
+| `secretScanning`                | boolean | Secret scanning                 |
+| `secretScanningPushProtection`  | boolean | Push protection for secrets     |
 | `privateVulnerabilityReporting` | boolean | Private vulnerability reporting |
 
 ## Inheritance
@@ -147,12 +147,12 @@ repos:
 
 xfg displays warnings for potentially destructive operations:
 
-| Operation | Warning |
-| --------- | ------- |
-| Change `visibility` | "visibility change may expose or hide repository" |
-| Set `archived: true` | "archiving makes repository read-only" |
-| Disable `hasIssues`, `hasWiki`, `hasProjects` | "may hide existing content" |
-| Change `defaultBranch` | "may affect existing PRs, CI workflows, and branch protections" |
+| Operation                                     | Warning                                                         |
+| --------------------------------------------- | --------------------------------------------------------------- |
+| Change `visibility`                           | "visibility change may expose or hide repository"               |
+| Set `archived: true`                          | "archiving makes repository read-only"                          |
+| Disable `hasIssues`, `hasWiki`, `hasProjects` | "may hide existing content"                                     |
+| Change `defaultBranch`                        | "may affect existing PRs, CI workflows, and branch protections" |
 
 Example output:
 

--- a/docs/configuration/rulesets.md
+++ b/docs/configuration/rulesets.md
@@ -180,12 +180,12 @@ Require specific GitHub Actions workflows to pass:
 
 All pattern rules support the same parameters:
 
-| Parameter  | Type    | Description                                                |
-| ---------- | ------- | ---------------------------------------------------------- |
-| `name`     | string  | Display name for the rule (optional)                       |
-| `operator` | string  | `starts_with`, `ends_with`, `contains`, or `regex`         |
-| `pattern`  | string  | The pattern to match                                       |
-| `negate`   | boolean | If true, the rule applies when the pattern does NOT match  |
+| Parameter  | Type    | Description                                               |
+| ---------- | ------- | --------------------------------------------------------- |
+| `name`     | string  | Display name for the rule (optional)                      |
+| `operator` | string  | `starts_with`, `ends_with`, `contains`, or `regex`        |
+| `pattern`  | string  | The pattern to match                                      |
+| `negate`   | boolean | If true, the rule applies when the pattern does NOT match |
 
 ```yaml
 - type: commit_message_pattern

--- a/docs/examples/delete-orphaned.md
+++ b/docs/examples/delete-orphaned.md
@@ -28,8 +28,8 @@ When you remove `.prettierrc.json` from this config and run xfg again, the file 
 `deleteOrphaned` follows the standard inheritance pattern:
 
 1. **Global default** - Set at root level applies to all files
-2. **Per-file** - Overrides global default for specific files
-3. **Per-repo** - Overrides both global and per-file for specific repos
+1. **Per-file** - Overrides global default for specific files
+1. **Per-repo** - Overrides both global and per-file for specific repos
 
 ### Global Default
 

--- a/docs/examples/merge-strategies.md
+++ b/docs/examples/merge-strategies.md
@@ -53,11 +53,12 @@ repos:
 
 ## Available Strategies
 
-| Strategy  | Behavior                                   |
-| --------- | ------------------------------------------ |
-| `replace` | Overlay completely replaces base (default) |
-| `append`  | Overlay items added after base items       |
-| `prepend` | Overlay items added before base items      |
+| Strategy  | Behavior                                                                                       |
+| --------- | ---------------------------------------------------------------------------------------------- |
+| `replace` | Overlay completely replaces base (default)                                                     |
+| `append`  | Overlay items added after base items                                                           |
+| `prepend` | Overlay items added before base items                                                          |
+| `merge`   | Deep-merges array items matched by identity key (`type`, `actor_id`); unmatched items appended |
 
 ## Inline `$arrayMerge` Directive
 
@@ -112,3 +113,66 @@ repos:
 ### Per-Array Control
 
 Each array field specifies its own `$arrayMerge` + `$values`, so sibling arrays can use different strategies independently.
+
+## Merge by Key
+
+The `merge` strategy matches items by identity key and deep-merges matched pairs. This avoids duplicating items when multiple conditional groups modify the same entry.
+
+```yaml
+id: my-org-config
+settings:
+  rulesets:
+    branch-protection:
+      rules:
+        - type: pull_request
+          parameters:
+            requiredApprovingReviewCount: 1
+            dismissStaleReviewsOnPush: true
+        - type: required_status_checks
+          parameters:
+            requiredStatusChecks:
+              - context: "ci / build"
+
+conditionalGroups:
+  - when:
+      allOf: [has-mergify]
+    settings:
+      rulesets:
+        branch-protection:
+          rules:
+            $arrayMerge: merge
+            $values:
+              - type: required_status_checks
+                parameters:
+                  requiredStatusChecks:
+                    $arrayMerge: append
+                    $values:
+                      - context: "mergify / queue"
+```
+
+**Result for repos with `has-mergify`:**
+
+The `required_status_checks` rule is matched by `type` and deep-merged — no duplicate rule entry. The nested `$arrayMerge: append` adds the extra check:
+
+```json
+{
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "requiredApprovingReviewCount": 1,
+        "dismissStaleReviewsOnPush": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "requiredStatusChecks": [
+          { "context": "ci / build" },
+          { "context": "mergify / queue" }
+        ]
+      }
+    }
+  ]
+}
+```

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -17,6 +17,7 @@ gh auth login --hostname github.mycompany.com
 ```
 
 !!! note "Required Scopes"
+
 Your token needs the `repo` scope to create PRs in target repositories.
 
 ## Azure DevOps Authentication
@@ -29,6 +30,7 @@ az devops configure --defaults organization=https://dev.azure.com/YOUR_ORG proje
 ```
 
 !!! note "Required Permissions"
+
 Ensure the user/service account has "Contribute to pull requests" permission.
 
 ## GitLab Authentication
@@ -46,4 +48,5 @@ glab auth login --hostname gitlab.example.com
 ```
 
 !!! note "Required Permissions"
+
 Ensure the user has at least "Developer" role on the project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,12 +158,12 @@ repos:
 
 Control how changes are delivered with [PR options](configuration/pr-options.md):
 
-| Mode | Behavior |
-| ---- | -------- |
-| `auto` | Enable auto-merge — merge when checks pass (default) |
-| `manual` | Leave PR open for manual review |
-| `force` | Merge immediately, bypassing checks |
-| `direct` | Push directly to default branch, no PR |
+| Mode     | Behavior                                             |
+| -------- | ---------------------------------------------------- |
+| `auto`   | Enable auto-merge — merge when checks pass (default) |
+| `manual` | Leave PR open for manual review                      |
+| `force`  | Merge immediately, bypassing checks                  |
+| `direct` | Push directly to default branch, no PR               |
 
 Merge strategies: `squash` (default), `merge`, `rebase`. Set globally, override per-repo, or override via CLI.
 
@@ -171,15 +171,15 @@ Customize PR descriptions with [PR templates](configuration/pr-templates.md) usi
 
 ### Platform Support
 
-| Feature | GitHub | Azure DevOps | GitLab |
-| ------- | ------ | ------------ | ------ |
-| File sync | Yes | Yes | Yes |
-| Self-hosted | Yes (GHE) | Yes | Yes |
-| Repo settings | Yes | - | - |
-| Rulesets | Yes | - | - |
-| Repo lifecycle | Yes | Source only | - |
-| Auto-merge PRs | Yes | Yes | Yes |
-| Direct push | Yes | Yes | Yes |
+| Feature        | GitHub    | Azure DevOps | GitLab |
+| -------------- | --------- | ------------ | ------ |
+| File sync      | Yes       | Yes          | Yes    |
+| Self-hosted    | Yes (GHE) | Yes          | Yes    |
+| Repo settings  | Yes       | -            | -      |
+| Rulesets       | Yes       | -            | -      |
+| Repo lifecycle | Yes       | Source only  | -      |
+| Auto-merge PRs | Yes       | Yes          | Yes    |
+| Direct push    | Yes       | Yes          | Yes    |
 
 ### Enterprise & CI/CD
 

--- a/docs/platforms/azure-devops.md
+++ b/docs/platforms/azure-devops.md
@@ -45,7 +45,7 @@ repos:
 xfg uses the `az repos pr` CLI commands to:
 
 1. Create the PR
-2. Enable auto-complete or bypass policies as configured
+1. Enable auto-complete or bypass policies as configured
 
 ## Direct Push Mode
 

--- a/docs/platforms/github-app.md
+++ b/docs/platforms/github-app.md
@@ -15,22 +15,22 @@ For enterprises that prefer GitHub Apps over personal access tokens (PATs).
 ### 1. Create a GitHub App
 
 1. Go to your organization's settings > Developer settings > GitHub Apps
-2. Click "New GitHub App"
-3. Configure permissions:
+1. Click "New GitHub App"
+1. Configure permissions:
    - **Repository permissions:**
      - Administration: Read and write _(required for repo lifecycle: create, archive, fork, etc.)_
      - Contents: Read and write
      - Pull requests: Read and write
      - Workflows: Read and write _(required if syncing `.github/workflows/` files)_
    - **Where can this GitHub App be installed?** Any account
-4. Create the app and note the **Client ID** (starts with `Iv23`)
-5. Generate a **private key** (downloads a .pem file)
+1. Create the app and note the **Client ID** (starts with `Iv23`)
+1. Generate a **private key** (downloads a .pem file)
 
 ### 2. Install the App
 
 1. Go to your app's settings > Install App
-2. Install the app in each organization where xfg will sync configs
-3. Select the repositories the app can access (all or specific repos)
+1. Install the app in each organization where xfg will sync configs
+1. Select the repositories the app can access (all or specific repos)
 
 ### 3. Store Credentials
 
@@ -67,9 +67,9 @@ This approach:
 When GitHub App credentials are provided, xfg:
 
 1. **Generates a JWT** using your Client ID and private key
-2. **Discovers installations** by calling GitHub's API to list all installations
-3. **Generates installation tokens** per-installation (tokens are cached for 55 minutes)
-4. **Uses GraphQL API** for commits with the installation token, creating verified commits
+1. **Discovers installations** by calling GitHub's API to list all installations
+1. **Generates installation tokens** per-installation (tokens are cached for 55 minutes)
+1. **Uses GraphQL API** for commits with the installation token, creating verified commits
 
 This uses GitHub's `createCommitOnBranch` mutation instead of git commands, which:
 
@@ -92,9 +92,9 @@ When `XFG_GITHUB_CLIENT_ID` and `XFG_GITHUB_APP_PRIVATE_KEY` are set, xfg uses G
 ## Limitations
 
 1. **Commit author** - Commits appear as the GitHub App, not a custom user
-2. **File size** - Large files (>50MB) should use PAT flow instead
-3. **GHE compatibility** - Requires GitHub Enterprise Server 3.6+
-4. **Atomic commits** - All file changes in a single commit (executable file mode changes use a follow-up commit)
+1. **File size** - Large files (>50MB) should use PAT flow instead
+1. **GHE compatibility** - Requires GitHub Enterprise Server 3.6+
+1. **Atomic commits** - All file changes in a single commit (executable file mode changes use a follow-up commit)
 
 ## Troubleshooting
 

--- a/docs/platforms/github.md
+++ b/docs/platforms/github.md
@@ -112,8 +112,8 @@ If auto-merge is not enabled, xfg will warn and leave the PR open for manual rev
 xfg uses the `gh` CLI to:
 
 1. Create the PR with `gh pr create`
-2. Enable auto-merge with `gh pr merge --auto` (if configured)
-3. Force merge with `gh pr merge --admin` (if `merge: force`)
+1. Enable auto-merge with `gh pr merge --auto` (if configured)
+1. Force merge with `gh pr merge --admin` (if `merge: force`)
 
 ## Direct Push Mode
 

--- a/docs/platforms/gitlab.md
+++ b/docs/platforms/gitlab.md
@@ -55,7 +55,7 @@ The user needs at least "Developer" role on the project.
 xfg uses the `glab` CLI to:
 
 1. Create the merge request with `glab mr create`
-2. Configure merge behavior based on `prOptions`
+1. Configure merge behavior based on `prOptions`
 
 ## Direct Push Mode
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -4,11 +4,11 @@ xfg supports GitHub, Azure DevOps, and GitLab (including self-hosted instances).
 
 ## Supported Platforms
 
-| Platform     | SSH URLs | HTTPS URLs | Self-Hosted                                                    |
-| ------------ | -------- | ---------- | -------------------------------------------------------------- |
-| GitHub       | Yes      | Yes        | Yes (via [`githubHosts`](github.md#github-enterprise-server))  |
-| Azure DevOps | Yes      | Yes        | -                                                              |
-| GitLab       | Yes      | Yes        | Yes                                                            |
+| Platform     | SSH URLs | HTTPS URLs | Self-Hosted                                                   |
+| ------------ | -------- | ---------- | ------------------------------------------------------------- |
+| GitHub       | Yes      | Yes        | Yes (via [`githubHosts`](github.md#github-enterprise-server)) |
+| Azure DevOps | Yes      | Yes        | -                                                             |
+| GitLab       | Yes      | Yes        | Yes                                                           |
 
 ## Platform-Specific Details
 

--- a/docs/reference/cli-options.md
+++ b/docs/reference/cli-options.md
@@ -12,17 +12,17 @@ xfg sync --config <path> [options]
 
 ### Options
 
-| Option             | Alias | Description                                           | Default                                         |
-| ------------------ | ----- | ----------------------------------------------------- | ----------------------------------------------- |
-| `--config`         | `-c`  | Path to YAML config file                              | **Required**                                    |
-| `--dry-run`        | `-d`  | Show what would be done without making changes        | `false`                                         |
-| `--work-dir`       | `-w`  | Temporary directory for cloning                       | `./tmp`                                         |
-| `--retries`        | `-r`  | Number of retries for network operations              | `3`                                             |
-| `--branch`         | `-b`  | Override branch name                                  | `chore/sync-{filename}` or `chore/sync-config`  |
-| `--merge`          | `-m`  | PR merge mode: `manual`, `auto`, `force`, `direct`    | `auto`                                          |
-| `--merge-strategy` |       | Merge strategy: `merge`, `squash`, `rebase`           | `squash`                                        |
-| `--delete-branch`  |       | Delete source branch after merge                      | `true`                                          |
-| `--no-delete`      |       | Skip deletion of orphaned files, rulesets, and labels | `false`                                         |
+| Option             | Alias | Description                                           | Default                                        |
+| ------------------ | ----- | ----------------------------------------------------- | ---------------------------------------------- |
+| `--config`         | `-c`  | Path to YAML config file                              | **Required**                                   |
+| `--dry-run`        | `-d`  | Show what would be done without making changes        | `false`                                        |
+| `--work-dir`       | `-w`  | Temporary directory for cloning                       | `./tmp`                                        |
+| `--retries`        | `-r`  | Number of retries for network operations              | `3`                                            |
+| `--branch`         | `-b`  | Override branch name                                  | `chore/sync-{filename}` or `chore/sync-config` |
+| `--merge`          | `-m`  | PR merge mode: `manual`, `auto`, `force`, `direct`    | `auto`                                         |
+| `--merge-strategy` |       | Merge strategy: `merge`, `squash`, `rebase`           | `squash`                                       |
+| `--delete-branch`  |       | Delete source branch after merge                      | `true`                                         |
+| `--no-delete`      |       | Skip deletion of orphaned files, rulesets, and labels | `false`                                        |
 
 !!! note "GitHub-Only Settings"
     Repository settings, rulesets, and labels management only works with GitHub repositories. Azure DevOps and GitLab repos are skipped for settings.
@@ -72,11 +72,11 @@ Completed: 3 succeeded, 0 skipped, 0 failed
 CLI flags override config file settings:
 
 1. CLI flags (highest priority)
-2. Per-repo settings (e.g., `prOptions`, `settings.rulesets`)
-3. Conditional group settings (applied in array order)
-4. Group settings (applied in order, later groups override earlier ones)
-5. Global settings
-6. Built-in defaults (lowest priority)
+1. Per-repo settings (e.g., `prOptions`, `settings.rulesets`)
+1. Conditional group settings (applied in array order)
+1. Group settings (applied in order, later groups override earlier ones)
+1. Global settings
+1. Built-in defaults (lowest priority)
 
 ## Exit Codes
 

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -37,18 +37,18 @@ Or configure in `.vscode/settings.json`:
 
 ### Root Object
 
-| Field                | Type        | Required | Description                                         |
-| -------------------- | ----------- | -------- | --------------------------------------------------- |
-| `id`                 | `string`    | Yes      | Unique config identifier (alphanumeric, `-`, `_`)   |
-| `files`              | `object`    | *        | Map of filenames to file configs                    |
-| `groups`             | `object`    | *        | Named config groups referenced by repos             |
-| `conditionalGroups`  | `array`     | *        | Groups that activate based on repo group membership |
-| `repos`              | `array`     | Yes      | List of repository configurations                   |
-| `settings`           | `object`    | *        | Repository settings (rulesets, labels, etc.)        |
-| `prOptions`          | `PROptions` | No       | Global PR merge options                             |
-| `prTemplate`         | `string`    | No       | Custom PR body template                             |
-| `githubHosts`        | `array`     | No       | GitHub Enterprise Server hostnames                  |
-| `deleteOrphaned`     | `boolean`   | No       | Global default for orphan file deletion             |
+| Field               | Type        | Required | Description                                         |
+| ------------------- | ----------- | -------- | --------------------------------------------------- |
+| `id`                | `string`    | Yes      | Unique config identifier (alphanumeric, `-`, `_`)   |
+| `files`             | `object`    | \*       | Map of filenames to file configs                    |
+| `groups`            | `object`    | \*       | Named config groups referenced by repos             |
+| `conditionalGroups` | `array`     | \*       | Groups that activate based on repo group membership |
+| `repos`             | `array`     | Yes      | List of repository configurations                   |
+| `settings`          | `object`    | \*       | Repository settings (rulesets, labels, etc.)        |
+| `prOptions`         | `PROptions` | No       | Global PR merge options                             |
+| `prTemplate`        | `string`    | No       | Custom PR body template                             |
+| `githubHosts`       | `array`     | No       | GitHub Enterprise Server hostnames                  |
+| `deleteOrphaned`    | `boolean`   | No       | Global default for orphan file deletion             |
 
 !!! note "files/settings/groups requirement"
     At least one of `files`, `settings`, `groups`, or `conditionalGroups` must be present. The `sync` command requires files defined in root `files`, in a group, or in a conditional group. The `settings` command requires `settings` at root, repo, group, or conditional group level.
@@ -69,44 +69,44 @@ Or configure in `.vscode/settings.json`:
 
 ### Group Config
 
-| Field       | Type                 | Required | Description                                                  |
-| ----------- | -------------------- | -------- | ------------------------------------------------------------ |
-| `extends`   | `string \| string[]` | No       | Parent group name(s) to inherit from                         |
-| `files`     | `object`             | No       | Files defined or overridden by this group                    |
-| `prOptions` | `PROptions`          | No       | PR options for repos using this group                        |
-| `settings`  | `object`             | No       | Settings for repos using this group (supports `inherit`)     |
+| Field       | Type                 | Required | Description                                              |
+| ----------- | -------------------- | -------- | -------------------------------------------------------- |
+| `extends`   | `string \| string[]` | No       | Parent group name(s) to inherit from                     |
+| `files`     | `object`             | No       | Files defined or overridden by this group                |
+| `prOptions` | `PROptions`          | No       | PR options for repos using this group                    |
+| `settings`  | `object`             | No       | Settings for repos using this group (supports `inherit`) |
 
 Groups support `extends` (inherit from parent groups), `inherit: false` (discard accumulated files), `file: false` (remove a file), and full file config or override objects.
 
 ### Conditional Group Config
 
-| Field       | Type        | Required | Description                                              |
-| ----------- | ----------- | -------- | -------------------------------------------------------- |
-| `when`      | `object`    | Yes      | Condition that determines when this group activates      |
-| `files`     | `object`    | No       | Files defined or overridden (same capabilities as groups)|
-| `prOptions` | `PROptions` | No       | PR options for matching repos                            |
-| `settings`  | `object`    | No       | Settings for matching repos (supports `inherit`)         |
+| Field       | Type        | Required | Description                                               |
+| ----------- | ----------- | -------- | --------------------------------------------------------- |
+| `when`      | `object`    | Yes      | Condition that determines when this group activates       |
+| `files`     | `object`    | No       | Files defined or overridden (same capabilities as groups) |
+| `prOptions` | `PROptions` | No       | PR options for matching repos                             |
+| `settings`  | `object`    | No       | Settings for matching repos (supports `inherit`)          |
 
 The `when` clause:
 
-| Field   | Type       | Required | Description                                  |
-| ------- | ---------- | -------- | -------------------------------------------- |
-| `allOf` | `string[]` | *        | All listed groups must be present on the repo|
-| `anyOf` | `string[]` | *        | At least one listed group must be present    |
+| Field   | Type       | Required | Description                                   |
+| ------- | ---------- | -------- | --------------------------------------------- |
+| `allOf` | `string[]` | \*       | All listed groups must be present on the repo |
+| `anyOf` | `string[]` | \*       | At least one listed group must be present     |
 
 At least one of `allOf` or `anyOf` is required. When both are specified, both conditions must be satisfied. See [Groups — Conditional Groups](../configuration/groups.md#conditional-groups).
 
 ### Repo Config
 
-| Field       | Type           | Required | Description                                                 |
-| ----------- | -------------- | -------- | ----------------------------------------------------------- |
-| `git`       | `string/array` | Yes      | Git URL(s)                                                  |
-| `files`     | `object`       | No       | Per-repo file overrides                                     |
-| `groups`    | `string[]`     | No       | Group names to apply (merged in order)                      |
-| `settings`  | `object`       | No       | Per-repo settings (rulesets, labels, repo settings)         |
-| `prOptions` | `PROptions`    | No       | Per-repo PR options                                         |
-| `upstream`  | `string`       | No       | Fork from this URL if target doesn't exist                  |
-| `source`    | `string`       | No       | Migrate from this URL if target doesn't exist               |
+| Field       | Type           | Required | Description                                         |
+| ----------- | -------------- | -------- | --------------------------------------------------- |
+| `git`       | `string/array` | Yes      | Git URL(s)                                          |
+| `files`     | `object`       | No       | Per-repo file overrides                             |
+| `groups`    | `string[]`     | No       | Group names to apply (merged in order)              |
+| `settings`  | `object`       | No       | Per-repo settings (rulesets, labels, repo settings) |
+| `prOptions` | `PROptions`    | No       | Per-repo PR options                                 |
+| `upstream`  | `string`       | No       | Fork from this URL if target doesn't exist          |
+| `source`    | `string`       | No       | Migrate from this URL if target doesn't exist       |
 
 !!! note "`upstream` and `source` are mutually exclusive"
     See [Repo Lifecycle](../configuration/lifecycle.md) for details.
@@ -127,13 +127,13 @@ At least one of `allOf` or `anyOf` is required. When both are specified, both co
 
 ### PR Options
 
-| Field           | Type       | Default  | Description                                      |
-| --------------- | ---------- | -------- | ------------------------------------------------ |
-| `merge`         | `string`   | `auto`   | `manual`, `auto`, `force`, `direct`              |
-| `mergeStrategy` | `string`   | `squash` | `merge`, `squash`, `rebase`                      |
-| `deleteBranch`  | `boolean`  | `true`   | Delete branch after merge                        |
-| `bypassReason`  | `string`   | -        | Reason for bypass (Azure DevOps only)            |
-| `labels`        | `string[]` | -        | Labels to apply to created PRs (GitHub only)     |
+| Field           | Type       | Default  | Description                                  |
+| --------------- | ---------- | -------- | -------------------------------------------- |
+| `merge`         | `string`   | `auto`   | `manual`, `auto`, `force`, `direct`          |
+| `mergeStrategy` | `string`   | `squash` | `merge`, `squash`, `rebase`                  |
+| `deleteBranch`  | `boolean`  | `true`   | Delete branch after merge                    |
+| `bypassReason`  | `string`   | -        | Reason for bypass (Azure DevOps only)        |
+| `labels`        | `string[]` | -        | Labels to apply to created PRs (GitHub only) |
 
 ## Validation
 

--- a/docs/security/secret-rotation.md
+++ b/docs/security/secret-rotation.md
@@ -4,37 +4,37 @@ Rotate credentials used by xfg regularly to limit the blast radius of a compromi
 
 ## Recommended Schedules
 
-| Credential | Recommended Schedule |
-| --- | --- |
-| GH_TOKEN (GitHub PAT) | Every 90 days |
-| GitHub App private key (.pem) | Every 6 months |
-| Azure DevOps PAT / service principal | Every 90 days |
-| GitLab PAT / project access token | Every 90 days |
-| CONTEXT7_API_KEY / MCP keys | Per provider policy |
+| Credential                           | Recommended Schedule |
+| ------------------------------------ | -------------------- |
+| GH_TOKEN (GitHub PAT)                | Every 90 days        |
+| GitHub App private key (.pem)        | Every 6 months       |
+| Azure DevOps PAT / service principal | Every 90 days        |
+| GitLab PAT / project access token    | Every 90 days        |
+| CONTEXT7_API_KEY / MCP keys          | Per provider policy  |
 
 ## GitHub PAT (GH_TOKEN)
 
 1. Generate a new classic token at [GitHub Settings > Personal access tokens (classic)](https://github.com/settings/tokens) with `repo` and `workflow` scopes.
 
-2. Update the secret in your CI environment:
+1. Update the secret in your CI environment:
 
    - **GitHub Actions:** Repository > Settings > Secrets and variables > Actions > Update `GH_TOKEN`
    - **Azure Pipelines:** Pipeline > Edit > Variables > Update `GH_TOKEN`
    - **GitLab CI:** Settings > CI/CD > Variables > Update `GH_TOKEN`
 
-3. Trigger a test run to verify the new token works.
+1. Trigger a test run to verify the new token works.
 
 ## GitHub App Private Key
 
 1. Go to your GitHub App settings > General > Private keys.
 
-2. Click **Generate a private key** to create a new `.pem` file.
+1. Click **Generate a private key** to create a new `.pem` file.
 
-3. Update the `APP_PRIVATE_KEY` secret in your CI environment with the contents of the new `.pem` file.
+1. Update the `APP_PRIVATE_KEY` secret in your CI environment with the contents of the new `.pem` file.
 
-4. Trigger a test run to confirm xfg can authenticate with the new key.
+1. Trigger a test run to confirm xfg can authenticate with the new key.
 
-5. Delete the old private key from the GitHub App settings page.
+1. Delete the old private key from the GitHub App settings page.
 
 See [GitHub App Authentication](../platforms/github-app.md) for full setup details.
 
@@ -44,15 +44,15 @@ See [GitHub App Authentication](../platforms/github-app.md) for full setup detai
 
 1. Generate a new PAT in Azure DevOps > User Settings > Personal access tokens.
 
-2. Update the token in your CI environment variables.
+1. Update the token in your CI environment variables.
 
-3. Verify with a test run.
+1. Verify with a test run.
 
 ### Service Principal
 
 1. Rotate the client secret in Azure AD > App registrations > your app > Certificates & secrets.
 
-2. Update the secret in your CI pipeline variables.
+1. Update the secret in your CI pipeline variables.
 
 ## GitLab
 
@@ -60,15 +60,15 @@ See [GitHub App Authentication](../platforms/github-app.md) for full setup detai
 
 1. Generate a new PAT in GitLab > User Settings > Access Tokens.
 
-2. Update the token in your CI environment variables.
+1. Update the token in your CI environment variables.
 
-3. Verify with a test run.
+1. Verify with a test run.
 
 ### Project Access Token
 
 1. Generate a new token in your project > Settings > Access Tokens.
 
-2. Update the token in your CI/CD variables.
+1. Update the token in your CI/CD variables.
 
 ## Dev Environment Keys
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -37,7 +37,7 @@ repos:
 
 Run `xfg` whenever standards change—PRs are created automatically for review.
 
----
+______________________________________________________________________
 
 ## CI/CD Workflow Standardization
 
@@ -78,7 +78,7 @@ repos:
       - git@github.com:your-org/shared-libs.git
 ```
 
----
+______________________________________________________________________
 
 ## Security & Compliance Governance
 
@@ -114,7 +114,7 @@ repos:
 
 Use [file references](configuration/file-references.md) to load complex templates from external files.
 
----
+______________________________________________________________________
 
 ## Branch Protection at Scale
 
@@ -183,7 +183,7 @@ repos:
                 requiredApprovingReviewCount: 3 # Override default
 ```
 
----
+______________________________________________________________________
 
 ## Repository Settings at Scale
 
@@ -259,7 +259,7 @@ repos:
         hasWiki: true
 ```
 
----
+______________________________________________________________________
 
 ## Developer Experience Consistency
 
@@ -305,7 +305,7 @@ repos:
 
 New team members get the same experience in every repo from day one.
 
----
+______________________________________________________________________
 
 ## Open Source Project Maintainers
 
@@ -337,7 +337,7 @@ repos:
       - git@github.com:your-name/project-plugins.git
 ```
 
----
+______________________________________________________________________
 
 ## Configuration Drift Prevention
 
@@ -369,7 +369,7 @@ jobs:
 
 Drift is detected weekly, and PRs are created to bring repos back into compliance.
 
----
+______________________________________________________________________
 
 ## Migrating to New Standards
 
@@ -401,7 +401,7 @@ repos:
       - git@github.com:your-org/repo-2.git
 ```
 
----
+______________________________________________________________________
 
 ## Hybrid Teams (Multi-Platform)
 
@@ -427,7 +427,7 @@ repos:
   - git: git@gitlab.example.com:your-org/internal-tool.git
 ```
 
----
+______________________________________________________________________
 
 ## Why xfg vs. Alternatives
 

--- a/plans/array-merge-by-key/2026-05-10-array-merge-by-key.md
+++ b/plans/array-merge-by-key/2026-05-10-array-merge-by-key.md
@@ -1,0 +1,169 @@
+# Implementation Plan: `$arrayMerge: merge` (key-based array merging)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `merge` strategy to `$arrayMerge` that matches array items by identity key (`type`, `actor_id`) and deep-merges matched pairs. Solves [#737](https://github.com/anthony-spruyt/xfg/issues/737) and [#730](https://github.com/anthony-spruyt/xfg/issues/730).
+
+**Architecture:** Extends existing `ArrayMergeStrategy` union and `arrayMergeStrategies` map in `src/config/merge.ts`. Extracts `MATCH_KEY_CANDIDATES` from `src/settings/rulesets/diff.ts` into shared location. No new modules — all changes in existing files.
+
+**Branch:** `feat/array-merge-by-key`
+
+## Background
+
+When multiple conditional groups both use `$arrayMerge: append` to add rules with the same `type` to a ruleset, xfg produces duplicate entries. Users must use `noneOf` workarounds with combinatorial explosion. Even if items were matched by type, nested `$arrayMerge` directives inside matched items are not honored.
+
+The `merge` strategy solves both: match items by key → `deepMerge()` matched pairs → nested `$arrayMerge` honored naturally.
+
+## Tasks
+
+### Task 1: Extract MATCH_KEY_CANDIDATES to shared location
+
+**Files:**
+
+- Modify: `src/config/merge.ts`
+- Modify: `src/settings/rulesets/diff.ts`
+
+**Steps:**
+
+- [ ] Add `MATCH_KEY_CANDIDATES` constant to `src/config/merge.ts`: `["type", "actor_id"] as const`
+- [ ] Add `findMatchKey(base: unknown[], overlay: unknown[]): string | undefined` to `src/config/merge.ts` — port logic from `diff.ts` `findMatchKey()`
+- [ ] Export both from `merge.ts`
+- [ ] Update `src/settings/rulesets/diff.ts` to import `MATCH_KEY_CANDIDATES` and `findMatchKey` from `merge.ts` instead of defining locally
+- [ ] Run `npm test` — all existing tests pass
+
+### Task 2: Add `merge` strategy to ArrayMergeStrategy
+
+**Files:**
+
+- Modify: `src/config/merge.ts`
+
+**Steps:**
+
+- [ ] Add `"merge"` to `ArrayMergeStrategy` type union: `"replace" | "append" | "prepend" | "merge"`
+- [ ] Update `ArrayMergeHandler` signature to accept optional `MergeContext`: `(base: unknown[], overlay: unknown[], ctx?: MergeContext) => unknown[]`
+- [ ] Update existing handlers (`replace`, `append`, `prepend`) to accept the extra parameter (unused)
+- [ ] Add `mergeByKey` function:
+  ```typescript
+  function mergeByKey(
+    base: unknown[],
+    overlay: unknown[],
+    matchKey: string,
+    ctx: MergeContext
+  ): unknown[]
+  ```
+  Logic:
+  - Build map of base items by key value
+  - For each overlay item: if base has matching key → `deepMerge(baseItem, overlayItem, ctx)`, else append
+  - Preserve unmatched base items in original position
+  - Return merged array
+- [ ] Register `merge` handler in `arrayMergeStrategies` map — when match key found, use `mergeByKey()`; when no match key found, fall back to append behavior
+- [ ] Update `isUnresolvedDirective()` to recognize `"merge"` as valid strategy (it already uses `arrayMergeStrategies.has()`, so this should be automatic after map registration)
+- [ ] Update `mergeArrays()` to pass `ctx` to handler
+- [ ] Update `deepMerge()` call to `mergeArrays()` to pass `ctx`
+- [ ] Run `npm test` — all existing tests still pass
+
+### Task 3: Unit tests for `merge` strategy
+
+**Files:**
+
+- Modify: `test/unit/config/merge.test.ts`
+
+**Steps:**
+
+- [ ] Test: `merge` with matching `type` keys deep-merges items
+  - base: `[{type: "a", x: 1}, {type: "b", x: 2}]`
+  - overlay: `[{type: "a", y: 3}]`
+  - result: `[{type: "a", x: 1, y: 3}, {type: "b", x: 2}]`
+- [ ] Test: `merge` with no matching keys falls back to append
+  - base: `[{name: "a"}, {name: "b"}]`
+  - overlay: `[{name: "c"}]`
+  - result: `[{name: "a"}, {name: "b"}, {name: "c"}]`
+- [ ] Test: `merge` with mixed matched/unmatched items
+  - base: `[{type: "a", x: 1}, {type: "b", x: 2}]`
+  - overlay: `[{type: "a", y: 3}, {type: "c", z: 4}]`
+  - result: `[{type: "a", x: 1, y: 3}, {type: "b", x: 2}, {type: "c", z: 4}]`
+- [ ] Test: nested `$arrayMerge: append` inside matched items honored (#730 regression test)
+  - base: `[{type: "rsc", parameters: {checks: ["ci"]}}]`
+  - overlay: `[{type: "rsc", parameters: {checks: {$arrayMerge: "append", $values: ["mergify"]}}}]`
+  - result: `[{type: "rsc", parameters: {checks: ["ci", "mergify"]}}]`
+- [ ] Test: `merge` with `actor_id` match key
+- [ ] Test: `merge` with primitive arrays (no keys) falls back to append
+- [ ] Test: `merge` via `$arrayMerge` directive in `deepMerge()`
+  - base: `{rules: [{type: "a", x: 1}]}`
+  - overlay: `{rules: {$arrayMerge: "merge", $values: [{type: "a", y: 2}]}}`
+  - result: `{rules: [{type: "a", x: 1, y: 2}]}`
+- [ ] Test: stacked directives — base has `$arrayMerge: merge` directive, overlay also has one
+- [ ] Test: overlay item overwrites scalar in matched base item
+- [ ] Test: `merge` with empty base array → returns overlay items
+- [ ] Test: `merge` with empty overlay array → returns base items
+- [ ] Run `npm test` — all tests pass
+
+### Task 4: Update JSON schema
+
+**Files:**
+
+- Modify: `config-schema.json`
+
+**Steps:**
+
+- [ ] Update `arrayMergeDirective` definition: add `"merge"` to `$arrayMerge` enum
+- [ ] Update `bypassActorsArrayMergeDirective` definition: add `"merge"` to `$arrayMerge` enum
+- [ ] Update `rulesArrayMergeDirective` definition: add `"merge"` to `$arrayMerge` enum
+- [ ] Update description strings to mention merge strategy
+- [ ] Verify schema is valid JSON
+
+### Task 5: Update documentation
+
+**Files:**
+
+- Modify: `docs/configuration/merge-strategies.md`
+- Modify: `docs/examples/merge-strategies.md`
+
+**Steps:**
+
+- [ ] Update strategy table in `docs/configuration/merge-strategies.md` — add `merge` row: "Deep-merges array items matched by identity key (`type`, `actor_id`); unmatched items appended"
+- [ ] Add "Merge by Key" section after "All Strategies" with:
+  - Explanation of how match keys are auto-detected
+  - Which keys are candidates (`type`, `actor_id`)
+  - Behavior when no match key found (falls back to append)
+  - Example: ruleset rules merged by `type` across conditional groups (the #737 use case)
+  - Example: nested `$arrayMerge` within matched items (#730 use case)
+- [ ] Update `docs/examples/merge-strategies.md` — add `merge` to "Available Strategies" table
+- [ ] Add practical example showing conditional groups merging `required_status_checks` without `noneOf`
+
+### Task 6: Verification
+
+**Steps:**
+
+- [ ] `npm run build` — compiles clean
+- [ ] `npm test` — all unit tests pass
+- [ ] `npm run test:typecheck` — test type checking passes
+- [ ] `./lint.sh` — linting passes
+- [ ] Commit and push
+
+## Design Decisions
+
+### Match key auto-detection vs explicit `$matchKey`
+
+Auto-detect using `MATCH_KEY_CANDIDATES` (`type`, `actor_id`). Same logic already used in `diff.ts` for comparing config against GitHub API. Keeps config concise. Can add explicit `$matchKey` later if needed — backward-compatible extension.
+
+### Fallback when no match key found
+
+Fall back to `append` behavior. If array items don't all share a candidate key, there's no way to match them, so concatenation is the safest default.
+
+### Duplicate keys within same array
+
+Match first occurrence. This matches how `findMatchKey()` in `diff.ts` already works — it doesn't validate uniqueness, just checks key presence.
+
+### Handler signature change
+
+Add optional `MergeContext` to `ArrayMergeHandler` so `merge` handler can call `deepMerge()` recursively. Existing handlers ignore it — no behavior change.
+
+## References
+
+- [Issue #737](https://github.com/anthony-spruyt/xfg/issues/737)
+- [Issue #730](https://github.com/anthony-spruyt/xfg/issues/730)
+- `src/config/merge.ts` — core merge logic
+- `src/settings/rulesets/diff.ts` — existing `MATCH_KEY_CANDIDATES` and `findMatchKey()`
+- `docs/configuration/merge-strategies.md` — merge strategy docs
+- `config-schema.json` — JSON schema definitions

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -61,35 +61,24 @@ function mergeByKey(
     unknown,
     { item: Record<string, unknown>; index: number }
   >();
+  // findMatchKey guarantees every item in both arrays is a plain object with matchKey
   for (let i = 0; i < base.length; i++) {
-    const item = base[i];
-    if (isPlainObject(item)) {
-      const keyValue = (item as Record<string, unknown>)[matchKey];
-      if (keyValue !== undefined && !baseByKey.has(keyValue)) {
-        baseByKey.set(keyValue, {
-          item: item as Record<string, unknown>,
-          index: i,
-        });
-      }
+    const item = base[i] as Record<string, unknown>;
+    const keyValue = item[matchKey];
+    if (keyValue !== undefined && !baseByKey.has(keyValue)) {
+      baseByKey.set(keyValue, { item, index: i });
     }
   }
 
   const appended: unknown[] = [];
 
   for (const overlayItem of overlay) {
-    if (!isPlainObject(overlayItem)) {
-      appended.push(overlayItem);
-      continue;
-    }
-    const keyValue = (overlayItem as Record<string, unknown>)[matchKey];
+    const item = overlayItem as Record<string, unknown>;
+    const keyValue = item[matchKey];
     const baseEntry = baseByKey.get(keyValue);
     if (baseEntry) {
       baseByKey.set(keyValue, {
-        item: deepMerge(
-          baseEntry.item,
-          overlayItem as Record<string, unknown>,
-          ctx
-        ),
+        item: deepMerge(baseEntry.item, item, ctx),
         index: baseEntry.index,
       });
     } else {
@@ -99,15 +88,11 @@ function mergeByKey(
 
   const result: unknown[] = [];
   for (let i = 0; i < base.length; i++) {
-    const item = base[i];
-    if (isPlainObject(item)) {
-      const keyValue = (item as Record<string, unknown>)[matchKey];
-      const entry = baseByKey.get(keyValue);
-      if (entry && entry.index === i) {
-        result.push(entry.item);
-      } else {
-        result.push(item);
-      }
+    const item = base[i] as Record<string, unknown>;
+    const keyValue = item[matchKey];
+    const entry = baseByKey.get(keyValue);
+    if (entry && entry.index === i) {
+      result.push(entry.item);
     } else {
       result.push(item);
     }

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -6,21 +6,131 @@
 import { isPlainObject } from "../shared/type-guards.js";
 
 /**
+ * Candidate keys for matching array items by identity rather than index.
+ * Order matters — first key found across all items wins.
+ */
+export const MATCH_KEY_CANDIDATES = ["type", "actor_id"] as const;
+
+/**
+ * Finds a key that uniquely identifies items in both arrays.
+ * Returns the first candidate key present in every item of both arrays, or undefined.
+ */
+export function findMatchKey(
+  base: unknown[],
+  overlay: unknown[]
+): string | undefined {
+  const allItems = [...base, ...overlay];
+  if (allItems.length === 0) return undefined;
+
+  for (const candidate of MATCH_KEY_CANDIDATES) {
+    const everyItemHasKey = allItems.every(
+      (item) =>
+        isPlainObject(item) && candidate in (item as Record<string, unknown>)
+    );
+    if (everyItemHasKey) return candidate;
+  }
+
+  return undefined;
+}
+
+/**
  * Keys reserved for xfg merge directives.
  * Only these are stripped during merge — standard $-prefixed keys
  * like $schema, $id, $ref, $generated are preserved.
  */
 const XFG_DIRECTIVES = new Set(["$arrayMerge", "$values"]);
 
-export type ArrayMergeStrategy = "replace" | "append" | "prepend";
+export type ArrayMergeStrategy = "replace" | "append" | "prepend" | "merge";
 
-type ArrayMergeHandler = (base: unknown[], overlay: unknown[]) => unknown[];
+type ArrayMergeHandler = (
+  base: unknown[],
+  overlay: unknown[],
+  ctx?: MergeContext
+) => unknown[];
+
+function mergeByKey(
+  base: unknown[],
+  overlay: unknown[],
+  matchKey: string,
+  ctx: MergeContext
+): unknown[] {
+  const baseByKey = new Map<
+    unknown,
+    { item: Record<string, unknown>; index: number }
+  >();
+  for (let i = 0; i < base.length; i++) {
+    const item = base[i];
+    if (isPlainObject(item)) {
+      const keyValue = (item as Record<string, unknown>)[matchKey];
+      if (keyValue !== undefined && !baseByKey.has(keyValue)) {
+        baseByKey.set(keyValue, {
+          item: item as Record<string, unknown>,
+          index: i,
+        });
+      }
+    }
+  }
+
+  const matched = new Set<unknown>();
+  const appended: unknown[] = [];
+
+  for (const overlayItem of overlay) {
+    if (!isPlainObject(overlayItem)) {
+      appended.push(overlayItem);
+      continue;
+    }
+    const keyValue = (overlayItem as Record<string, unknown>)[matchKey];
+    const baseEntry = baseByKey.get(keyValue);
+    if (baseEntry) {
+      matched.add(keyValue);
+      baseByKey.set(keyValue, {
+        item: deepMerge(
+          baseEntry.item,
+          overlayItem as Record<string, unknown>,
+          ctx
+        ),
+        index: baseEntry.index,
+      });
+    } else {
+      appended.push(overlayItem);
+    }
+  }
+
+  const result: unknown[] = [];
+  for (let i = 0; i < base.length; i++) {
+    const item = base[i];
+    if (isPlainObject(item)) {
+      const keyValue = (item as Record<string, unknown>)[matchKey];
+      const entry = baseByKey.get(keyValue);
+      if (entry && entry.index === i) {
+        result.push(entry.item);
+      } else {
+        result.push(item);
+      }
+    } else {
+      result.push(item);
+    }
+  }
+
+  result.push(...appended);
+  return result;
+}
 
 const arrayMergeStrategies: Map<ArrayMergeStrategy, ArrayMergeHandler> =
   new Map([
     ["replace", (_base, overlay) => overlay],
     ["append", (base, overlay) => [...base, ...overlay]],
     ["prepend", (base, overlay) => [...overlay, ...base]],
+    [
+      "merge",
+      (base, overlay, ctx) => {
+        const matchKey = findMatchKey(base, overlay);
+        if (!matchKey) {
+          return [...base, ...overlay];
+        }
+        return mergeByKey(base, overlay, matchKey, ctx!);
+      },
+    ],
   ]);
 
 /**
@@ -48,13 +158,13 @@ export interface MergeContext {
 function mergeArrays(
   base: unknown[],
   overlay: unknown[],
-  strategy: ArrayMergeStrategy
+  strategy: ArrayMergeStrategy,
+  ctx: MergeContext
 ): unknown[] {
   const handler = arrayMergeStrategies.get(strategy);
   if (handler) {
-    return handler(base, overlay);
+    return handler(base, overlay, ctx);
   }
-  // Fallback to replace for unknown strategies
   return overlay;
 }
 
@@ -92,11 +202,12 @@ export function deepMerge(
       if (
         (strategy === "replace" ||
           strategy === "append" ||
-          strategy === "prepend") &&
+          strategy === "prepend" ||
+          strategy === "merge") &&
         Array.isArray(values) &&
         Array.isArray(resolvedBase)
       ) {
-        result[key] = mergeArrays(resolvedBase, values, strategy);
+        result[key] = mergeArrays(resolvedBase, values, strategy, ctx);
         continue;
       }
     }
@@ -106,7 +217,8 @@ export function deepMerge(
       result[key] = mergeArrays(
         resolvedBase,
         overlayValue,
-        ctx.defaultArrayStrategy
+        ctx.defaultArrayStrategy,
+        ctx
       );
       continue;
     }

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -19,15 +19,18 @@ export function findMatchKey(
   base: unknown[],
   overlay: unknown[]
 ): string | undefined {
-  const allItems = [...base, ...overlay];
-  if (allItems.length === 0) return undefined;
+  if (base.length === 0 && overlay.length === 0) return undefined;
+
+  const hasKey = (item: unknown, key: string): boolean =>
+    isPlainObject(item) && key in (item as Record<string, unknown>);
 
   for (const candidate of MATCH_KEY_CANDIDATES) {
-    const everyItemHasKey = allItems.every(
-      (item) =>
-        isPlainObject(item) && candidate in (item as Record<string, unknown>)
-    );
-    if (everyItemHasKey) return candidate;
+    if (
+      base.every((item) => hasKey(item, candidate)) &&
+      overlay.every((item) => hasKey(item, candidate))
+    ) {
+      return candidate;
+    }
   }
 
   return undefined;
@@ -45,7 +48,7 @@ export type ArrayMergeStrategy = "replace" | "append" | "prepend" | "merge";
 type ArrayMergeHandler = (
   base: unknown[],
   overlay: unknown[],
-  ctx?: MergeContext
+  ctx: MergeContext
 ) => unknown[];
 
 function mergeByKey(
@@ -71,7 +74,6 @@ function mergeByKey(
     }
   }
 
-  const matched = new Set<unknown>();
   const appended: unknown[] = [];
 
   for (const overlayItem of overlay) {
@@ -82,7 +84,6 @@ function mergeByKey(
     const keyValue = (overlayItem as Record<string, unknown>)[matchKey];
     const baseEntry = baseByKey.get(keyValue);
     if (baseEntry) {
-      matched.add(keyValue);
       baseByKey.set(keyValue, {
         item: deepMerge(
           baseEntry.item,
@@ -128,7 +129,7 @@ const arrayMergeStrategies: Map<ArrayMergeStrategy, ArrayMergeHandler> =
         if (!matchKey) {
           return [...base, ...overlay];
         }
-        return mergeByKey(base, overlay, matchKey, ctx!);
+        return mergeByKey(base, overlay, matchKey, ctx);
       },
     ],
   ]);
@@ -315,6 +316,7 @@ export function mergeTextContent(
   if (Array.isArray(base)) {
     switch (strategy) {
       case "append":
+      case "merge":
         return [...base, ...overlay];
       case "prepend":
         return [...overlay, ...base];

--- a/src/config/validators/file-validator.ts
+++ b/src/config/validators/file-validator.ts
@@ -16,6 +16,7 @@ const VALID_STRATEGIES = validValues<ArrayMergeStrategy>([
   "replace",
   "append",
   "prepend",
+  "merge",
 ]);
 
 /**

--- a/src/config/validators/ruleset-validator.ts
+++ b/src/config/validators/ruleset-validator.ts
@@ -74,7 +74,7 @@ const VALID_RULE_TYPES = validValues<RulesetRule["type"]>([
 ]);
 
 // Intentionally duplicated from merge.ts — validator should not depend on merge internals
-const VALID_MERGE_STRATEGIES = ["replace", "append", "prepend"];
+const VALID_MERGE_STRATEGIES = ["replace", "append", "prepend", "merge"];
 
 /**
  * Checks if a value is an $arrayMerge directive: { $arrayMerge: strategy, $values: [...] }

--- a/src/settings/rulesets/diff.ts
+++ b/src/settings/rulesets/diff.ts
@@ -1,4 +1,5 @@
 import { RULESET_COMPARABLE_FIELDS, type Ruleset } from "../../config/index.js";
+import { MATCH_KEY_CANDIDATES, findMatchKey } from "../../config/merge.js";
 import { isPlainObject } from "../../shared/type-guards.js";
 import { camelToSnake } from "../../shared/string-utils.js";
 import { countActions, type SettingsAction } from "../base-processor.js";
@@ -132,34 +133,6 @@ function projectObjects(
     // If key not in current, skip — diff will handle it as an addition
   }
   return result;
-}
-
-/**
- * Candidate keys for matching array items by identity rather than index.
- * Order matters — first key found across all items wins.
- */
-const MATCH_KEY_CANDIDATES = ["type", "actor_id"] as const;
-
-/**
- * Finds a key that uniquely identifies items in both arrays.
- * Returns the first candidate key present in every item of both arrays, or undefined.
- */
-function findMatchKey(
-  current: unknown[],
-  desired: unknown[]
-): string | undefined {
-  const allItems = [...current, ...desired];
-  if (allItems.length === 0) return undefined;
-
-  for (const candidate of MATCH_KEY_CANDIDATES) {
-    const everyItemHasKey = allItems.every(
-      (item) =>
-        isPlainObject(item) && candidate in (item as Record<string, unknown>)
-    );
-    if (everyItemHasKey) return candidate;
-  }
-
-  return undefined;
 }
 
 function projectArrays(current: unknown[], desired: unknown[]): unknown[] {

--- a/test/unit/config/merge.test.ts
+++ b/test/unit/config/merge.test.ts
@@ -500,6 +500,49 @@ describe("$arrayMerge: merge strategy", () => {
     const result = deepMerge(base, overlay, createContext());
     assert.deepEqual(result, { rules: [{ type: "a", x: 1 }] });
   });
+
+  test("duplicate keys in base — first occurrence wins", () => {
+    const base = {
+      rules: [
+        { type: "a", x: 1 },
+        { type: "a", x: 2 },
+        { type: "b", x: 3 },
+      ],
+    };
+    const overlay = {
+      rules: {
+        $arrayMerge: "merge",
+        $values: [{ type: "a", y: 10 }],
+      },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, {
+      rules: [
+        { type: "a", x: 1, y: 10 },
+        { type: "a", x: 2 },
+        { type: "b", x: 3 },
+      ],
+    });
+  });
+
+  test("merge as default mergeStrategy via context", () => {
+    const base = {
+      rules: [
+        { type: "a", x: 1 },
+        { type: "b", x: 2 },
+      ],
+    };
+    const overlay = {
+      rules: [{ type: "a", y: 3 }],
+    };
+    const result = deepMerge(base, overlay, createContext("merge"));
+    assert.deepEqual(result, {
+      rules: [
+        { type: "a", x: 1, y: 3 },
+        { type: "b", x: 2 },
+      ],
+    });
+  });
 });
 
 describe("stripMergeDirectives", () => {
@@ -768,6 +811,18 @@ describe("mergeTextContent", () => {
     test("prepend empty overlay returns base", () => {
       const result = mergeTextContent(["base"], [], "prepend");
       assert.deepEqual(result, ["base"]);
+    });
+  });
+
+  describe("array overlay with merge strategy", () => {
+    test("merge strategy falls back to append for text arrays", () => {
+      const result = mergeTextContent(["base1", "base2"], ["overlay"], "merge");
+      assert.deepEqual(result, ["base1", "base2", "overlay"]);
+    });
+
+    test("merge strategy on string overlay still replaces", () => {
+      const result = mergeTextContent(["base"], "overlay", "merge");
+      assert.equal(result, "overlay");
     });
   });
 });

--- a/test/unit/config/merge.test.ts
+++ b/test/unit/config/merge.test.ts
@@ -5,6 +5,8 @@ import {
   stripMergeDirectives,
   isTextContent,
   mergeTextContent,
+  findMatchKey,
+  MATCH_KEY_CANDIDATES,
   type ArrayMergeStrategy,
   type MergeContext,
 } from "../../../src/config/merge.js";
@@ -287,6 +289,216 @@ describe("deepMerge", () => {
     const result = deepMerge(base, overlay, createContext("replace"));
     // Plain array overlay replaces (default strategy) the resolved base
     assert.deepEqual(result, { items: [3, 4] });
+  });
+});
+
+describe("findMatchKey", () => {
+  test("returns 'type' when all items have type field", () => {
+    const base = [{ type: "a" }, { type: "b" }];
+    const overlay = [{ type: "c" }];
+    assert.equal(findMatchKey(base, overlay), "type");
+  });
+
+  test("returns 'actor_id' when all items have actor_id field", () => {
+    const base = [{ actor_id: 1 }, { actor_id: 2 }];
+    const overlay = [{ actor_id: 3 }];
+    assert.equal(findMatchKey(base, overlay), "actor_id");
+  });
+
+  test("prefers 'type' over 'actor_id' when both present", () => {
+    const base = [{ type: "a", actor_id: 1 }];
+    const overlay = [{ type: "b", actor_id: 2 }];
+    assert.equal(findMatchKey(base, overlay), "type");
+  });
+
+  test("returns undefined for primitive arrays", () => {
+    assert.equal(findMatchKey([1, 2], [3]), undefined);
+  });
+
+  test("returns undefined when not all items share key", () => {
+    const base = [{ type: "a" }, { name: "b" }];
+    const overlay = [{ type: "c" }];
+    assert.equal(findMatchKey(base, overlay), undefined);
+  });
+
+  test("returns undefined for empty arrays", () => {
+    assert.equal(findMatchKey([], []), undefined);
+  });
+
+  test("exports MATCH_KEY_CANDIDATES", () => {
+    assert.deepEqual([...MATCH_KEY_CANDIDATES], ["type", "actor_id"]);
+  });
+});
+
+describe("$arrayMerge: merge strategy", () => {
+  test("deep-merges items matched by type key", () => {
+    const base = {
+      rules: [
+        { type: "a", x: 1 },
+        { type: "b", x: 2 },
+      ],
+    };
+    const overlay = {
+      rules: { $arrayMerge: "merge", $values: [{ type: "a", y: 3 }] },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, {
+      rules: [
+        { type: "a", x: 1, y: 3 },
+        { type: "b", x: 2 },
+      ],
+    });
+  });
+
+  test("falls back to append when no match key found", () => {
+    const base = { items: [{ name: "a" }, { name: "b" }] };
+    const overlay = {
+      items: { $arrayMerge: "merge", $values: [{ name: "c" }] },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, {
+      items: [{ name: "a" }, { name: "b" }, { name: "c" }],
+    });
+  });
+
+  test("handles mixed matched and unmatched items", () => {
+    const base = {
+      rules: [
+        { type: "a", x: 1 },
+        { type: "b", x: 2 },
+      ],
+    };
+    const overlay = {
+      rules: {
+        $arrayMerge: "merge",
+        $values: [
+          { type: "a", y: 3 },
+          { type: "c", z: 4 },
+        ],
+      },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, {
+      rules: [
+        { type: "a", x: 1, y: 3 },
+        { type: "b", x: 2 },
+        { type: "c", z: 4 },
+      ],
+    });
+  });
+
+  test("nested $arrayMerge: append inside matched items honored", () => {
+    const base = {
+      rules: [{ type: "rsc", parameters: { checks: ["ci"] } }],
+    };
+    const overlay = {
+      rules: {
+        $arrayMerge: "merge",
+        $values: [
+          {
+            type: "rsc",
+            parameters: {
+              checks: { $arrayMerge: "append", $values: ["mergify"] },
+            },
+          },
+        ],
+      },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, {
+      rules: [{ type: "rsc", parameters: { checks: ["ci", "mergify"] } }],
+    });
+  });
+
+  test("matches by actor_id key", () => {
+    const base = {
+      actors: [
+        { actor_id: 1, bypass_mode: "always" },
+        { actor_id: 2, bypass_mode: "pull_request" },
+      ],
+    };
+    const overlay = {
+      actors: {
+        $arrayMerge: "merge",
+        $values: [{ actor_id: 1, bypass_mode: "pull_request" }],
+      },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, {
+      actors: [
+        { actor_id: 1, bypass_mode: "pull_request" },
+        { actor_id: 2, bypass_mode: "pull_request" },
+      ],
+    });
+  });
+
+  test("primitive arrays (no keys) fall back to append", () => {
+    const base = { tags: [1, 2, 3] };
+    const overlay = {
+      tags: { $arrayMerge: "merge", $values: [4, 5] },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, { tags: [1, 2, 3, 4, 5] });
+  });
+
+  test("stacked directives — base has $arrayMerge: merge directive", () => {
+    const base = {
+      rules: {
+        $arrayMerge: "merge",
+        $values: [
+          { type: "a", x: 1 },
+          { type: "b", x: 2 },
+        ],
+      },
+    };
+    const overlay = {
+      rules: {
+        $arrayMerge: "merge",
+        $values: [{ type: "a", y: 3 }],
+      },
+    };
+    const result = deepMerge(base, overlay, createContext("replace"));
+    assert.deepEqual(result, {
+      rules: [
+        { type: "a", x: 1, y: 3 },
+        { type: "b", x: 2 },
+      ],
+    });
+  });
+
+  test("overlay item overwrites scalar in matched base item", () => {
+    const base = { rules: [{ type: "a", value: "old", keep: true }] };
+    const overlay = {
+      rules: {
+        $arrayMerge: "merge",
+        $values: [{ type: "a", value: "new" }],
+      },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, {
+      rules: [{ type: "a", value: "new", keep: true }],
+    });
+  });
+
+  test("empty base array returns overlay items", () => {
+    const base = { rules: [] as unknown[] };
+    const overlay = {
+      rules: {
+        $arrayMerge: "merge",
+        $values: [{ type: "a", x: 1 }],
+      },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, { rules: [{ type: "a", x: 1 }] });
+  });
+
+  test("empty overlay array returns base items", () => {
+    const base = { rules: [{ type: "a", x: 1 }] };
+    const overlay = {
+      rules: { $arrayMerge: "merge", $values: [] as unknown[] },
+    };
+    const result = deepMerge(base, overlay, createContext());
+    assert.deepEqual(result, { rules: [{ type: "a", x: 1 }] });
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `merge` strategy to `$arrayMerge` that matches array items by identity key (`type`, `actor_id`) and deep-merges matched pairs. Unmatched items are appended.
- Nested `$arrayMerge` directives inside matched items are honored, enabling composable conditional group overlays without duplication.
- Extracts `MATCH_KEY_CANDIDATES` and `findMatchKey` from `src/settings/rulesets/diff.ts` into `src/config/merge.ts` as shared utilities.

Closes #737, closes #730

## Changes

| File | What |
|------|------|
| `src/config/merge.ts` | `mergeByKey`, `findMatchKey`, `MATCH_KEY_CANDIDATES`, updated handler signature |
| `src/settings/rulesets/diff.ts` | Import shared `findMatchKey`/`MATCH_KEY_CANDIDATES` instead of local copy |
| `src/config/validators/file-validator.ts` | Add `merge` to `VALID_STRATEGIES` |
| `src/config/validators/ruleset-validator.ts` | Add `merge` to `VALID_MERGE_STRATEGIES` |
| `config-schema.json` | Add `merge` to all `$arrayMerge` enums + file-level `mergeStrategy` |
| `docs/configuration/merge-strategies.md` | Strategy table, merge-by-key section with examples |
| `docs/examples/merge-strategies.md` | Practical ruleset merge example |
| `test/unit/config/merge.test.ts` | 30 new tests covering all merge paths |

## Test plan

- [x] `npm run build` — clean compile
- [x] `npm test` — 2766 tests pass (30 new)
- [x] `npm run test:typecheck` — test type checking passes
- [x] `./lint.sh` — linting passes
- [x] Integration tests (`npm run test:integration:github`) — verify merge strategy works end-to-end with conditional groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
