### PR TITLE
feat: recursive config directory scanning

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -36,7 +36,7 @@
     },
     "repos": {
       "type": "array",
-      "description": "List of repository configurations. When using directory-based config, repos can be split across multiple files.",
+      "description": "List of repository configurations. When using directory-based config, repos can be split across multiple files. Directory-based config recursively scans subdirectories.",
       "items": {
         "$ref": "#/definitions/repo"
       }

--- a/docs/configuration/multi-file.md
+++ b/docs/configuration/multi-file.md
@@ -9,7 +9,9 @@ xfg sync -c ./xfg-config/   # trailing slash is optional
 
 ## Directory Structure
 
-All `.yaml` and `.yml` files in the directory are loaded and merged. Files are processed in alphabetical order.
+All `.yaml` and `.yml` files in the directory are loaded and merged. Subdirectories are scanned recursively (depth-first, alphabetical per level). Files are processed in alphabetical order within each directory level before descending into subdirectories.
+
+**Flat layout:**
 
 ```text
 xfg-config/
@@ -17,6 +19,23 @@ xfg-config/
   team-alpha.yaml     # team-specific groups and repos
   team-beta.yaml      # team-specific groups and repos
 ```
+
+**Nested layout:**
+
+```text
+xfg-config/
+  base.yaml                 # id, prOptions (shared config)
+  platform/
+    github.yaml             # GitHub-specific settings
+    gitlab.yaml             # GitLab-specific settings
+  teams/
+    alpha/
+      repos.yaml            # alpha team repos
+    beta/
+      repos.yaml            # beta team repos
+```
+
+Processing order: `base.yaml` → `platform/github.yaml` → `platform/gitlab.yaml` → `teams/alpha/repos.yaml` → `teams/beta/repos.yaml`
 
 ## Merge Rules
 
@@ -75,16 +94,21 @@ repos:
 - Exactly one file must define `id`
 - At least one file must define `repos`
 - Group names must be unique across files — use [`extends`](groups.md#group-inheritance) for group composition
-- Only flat directory scanning (no subdirectories)
-- [`@path` file references](file-references.md) resolve relative to the fragment file that contains them
+- Subdirectories are scanned recursively (depth-first, alphabetical per level)
+- Hidden files and directories (names starting with `.`) are skipped
+- Symlinked YAML files are followed; symlinked directories are skipped (cycle safety)
+- Maximum nesting depth of 10 levels
+- [`@path` file references](file-references.md) resolve relative to the fragment file's own directory, not the root config directory
 
 ## Error Messages
 
 Common errors when using directory-based config:
 
-| Error                                                     | Cause                                       |
-| --------------------------------------------------------- | ------------------------------------------- |
-| `'id' is defined in both base.yaml and team.yaml`         | A single-file key appears in multiple files |
-| `group 'X' is defined in both base.yaml and team.yaml`    | Duplicate group name across files           |
-| `no 'id' found in any file in directory ./xfg-config/`    | No file defines `id`                        |
-| `no .yaml or .yml files found in directory ./xfg-config/` | Directory is empty or has no YAML files     |
+| Error                                                            | Cause                                       |
+| ---------------------------------------------------------------- | ------------------------------------------- |
+| `'id' is defined in both base.yaml and team.yaml`                | A single-file key appears in multiple files |
+| `group 'X' is defined in both base.yaml and team.yaml`           | Duplicate group name across files           |
+| `no 'id' found in any file in directory ./xfg-config/`           | No file defines `id`                        |
+| `no .yaml or .yml files found in directory ./xfg-config/`        | Directory is empty or has no YAML files     |
+| `Config directory nesting exceeds maximum depth of 10 at <path>` | Too many nested subdirectories              |
+| `Failed to read config directory <path>: <error>`                | Subdirectory is unreadable                  |

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -54,6 +54,9 @@ Or configure in `.vscode/settings.json`:
 !!! note "files/settings/groups requirement"
     At least one of `files`, `settings`, `groups`, or `conditionalGroups` must be present. The `sync` command requires files defined in root `files`, in a group, or in a conditional group. The `settings` command requires `settings` at root, repo, group, or conditional group level.
 
+!!! tip "Multi-file directory config"
+    When passing a directory to `-c`, xfg recursively scans subdirectories for `.yaml` and `.yml` files. See [Multi-File Configuration](../configuration/multi-file.md) for ordering rules and constraints.
+
 ### Settings Object
 
 The `settings` object (at root, group, or repo level) supports the following fields:

--- a/plans/superpowers/plans/2026-05-18-recursive-config-scan.md
+++ b/plans/superpowers/plans/2026-05-18-recursive-config-scan.md
@@ -93,8 +93,9 @@ function collectYamlFiles(
   try {
     entries = readdirSync(currentDir, { withFileTypes: true });
   } catch (error) {
+    const rel = relative(rootDir, currentDir) || ".";
     throw new ValidationError(
-      `Failed to read config directory ${currentDir}: ${toErrorMessage(error)}`,
+      `Failed to read config directory ${rel}: ${toErrorMessage(error)}`,
       { cause: error }
     );
   }
@@ -158,7 +159,7 @@ function loadRawConfigFromDirectory(dirPath: string): RawConfig {
         content = readFileSync(absolutePath, "utf-8");
       } catch (error) {
         throw new ValidationError(
-          `Failed to read config file ${absolutePath}: ${toErrorMessage(error)}`,
+          `Failed to read config file ${relativePath}: ${toErrorMessage(error)}`,
           { cause: error }
         );
       }
@@ -170,7 +171,7 @@ function loadRawConfigFromDirectory(dirPath: string): RawConfig {
       } catch (error) {
         const message = toErrorMessage(error);
         throw new ValidationError(
-          `Failed to parse YAML config at ${absolutePath}: ${message}`,
+          `Failed to parse YAML config at ${relativePath}: ${message}`,
           { cause: error }
         );
       }
@@ -322,6 +323,10 @@ Add inside `describe("directory loading", ...)`:
           assert.ok(
             err.message.includes("exceeds maximum depth of 10"),
             `Expected depth error, got: ${err.message}`
+          );
+          assert.ok(
+            err.message.includes("level-0"),
+            `Expected relative path in error, got: ${err.message}`
           );
           return true;
         }
@@ -559,7 +564,54 @@ git commit -m "test: verify symlinked YAML files are followed"
 
 ______________________________________________________________________
 
-### Task 8: File reference resolution relative to fragment directory
+### Task 8: .yml extension files are discovered alongside .yaml
+
+Test that files with `.yml` extension are discovered and loaded just like `.yaml` files.
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the test — .yml files discovered**
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("discovers .yml files alongside .yaml files", () => {
+      const configDir = join(tempDir, "yml-extension-test");
+      mkdirSync(configDir);
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: yml-ext-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      writeFileSync(
+        join(configDir, "extra.yml"),
+        `repos:\n  - git: git@github.com:owner/yml-repo.git\n`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "yml-ext-test");
+      assert.equal(result.repos.length, 1);
+      assert.equal(result.repos[0].git, "git@github.com:owner/yml-repo.git");
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "discovers .yml files" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify .yml extension files are discovered"
+```
+
+______________________________________________________________________
+
+### Task 9: File reference resolution relative to fragment directory
 
 Test that `!file` / `@` references in nested fragments resolve relative to the fragment's own directory, not the config root.
 
@@ -611,7 +663,7 @@ git commit -m "test: verify file reference resolution in nested config fragments
 
 ______________________________________________________________________
 
-### Task 9: Relative path in fragment fileName for error messages
+### Task 10: Relative path in fragment fileName for error messages
 
 Test that merger error messages use relative paths (e.g., `teams/alpha.yaml`) when fragments from subdirectories conflict.
 
@@ -673,7 +725,7 @@ git commit -m "test: verify path-style fileName in merger error messages"
 
 ______________________________________________________________________
 
-### Task 10: Unreadable subdirectory fails entire load
+### Task 11: Unreadable subdirectory fails entire load
 
 Test that a permission-denied subdirectory throws `ValidationError` and fails the entire load (not silently skipped).
 
@@ -712,6 +764,10 @@ Add inside `describe("directory loading", ...)`:
             err.message.includes("Failed to read config directory"),
             `Expected 'Failed to read config directory', got: ${err.message}`
           );
+          assert.ok(
+            err.message.includes("blocked"),
+            `Expected relative path 'blocked' in error, got: ${err.message}`
+          );
           return true;
         }
       );
@@ -733,7 +789,7 @@ git commit -m "test: verify unreadable subdirectory fails entire config load"
 
 ______________________________________________________________________
 
-### Task 11: Full test suite, build, and lint verification
+### Task 12: Full test suite, build, and lint verification
 
 Run all checks to ensure no regressions and code quality.
 

--- a/plans/superpowers/plans/2026-05-18-recursive-config-scan.md
+++ b/plans/superpowers/plans/2026-05-18-recursive-config-scan.md
@@ -1,0 +1,763 @@
+# Recursive Config Directory Scanning — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `loadRawConfigFromDirectory` recurse into subdirectories so users can organize multi-file config fragments into nested folders.
+
+**Architecture:** Extract a `collectYamlFiles` helper that walks the directory tree depth-first, alphabetically per level, returning `{ relativePath, absolutePath }` tuples. `loadRawConfigFromDirectory` calls it instead of the flat `readdirSync` scan, then iterates over results to build `ConfigFragment[]` using relative paths as `fileName`. No changes to `ConfigFragment`, `mergeConfigFragments`,
+schema, or validator.
+
+**Tech Stack:** Node.js `fs.readdirSync` with `withFileTypes`, `path.relative`/`path.join`
+
+**Spec:** `plans/superpowers/specs/2026-05-18-recursive-config-scan-design.md`
+
+______________________________________________________________________
+
+## File Map
+
+| File                                     | Action | Responsibility                                                                                                   |
+| ---------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------- |
+| `src/config/loader.ts`                   | Modify | Add `collectYamlFiles` helper, refactor `loadRawConfigFromDirectory` to use it                                   |
+| `test/unit/config/loader.test.ts`        | Modify | Add recursive scanning tests (ordering, depth limit, hidden files, symlinks, empty subdirs, file ref resolution) |
+| `test/unit/config/config-merger.test.ts` | Modify | Add one test: path-style `fileName` in error messages                                                            |
+
+______________________________________________________________________
+
+### Task 1: Add `collectYamlFiles` helper with flat-dir equivalence test
+
+Establish the helper function and verify it produces identical results to the current flat scan for a single-level directory.
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- Modify: `src/config/loader.ts`
+
+- [ ] **Step 1: Write the failing test — flat directory produces same results via recursive scan**
+
+Add this test inside the existing `describe("directory loading", ...)` block in `test/unit/config/loader.test.ts`, after the last existing test (line 346):
+
+```typescript
+    test("flat directory: recursive scan produces same results as before", () => {
+      const configDir = join(tempDir, "flat-recursive");
+      mkdirSync(configDir);
+      writeFileSync(
+        join(configDir, "01-base.yaml"),
+        `id: flat-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      writeFileSync(
+        join(configDir, "02-repos.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-a.git\n  - git: git@github.com:owner/repo-b.git\n`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "flat-test");
+      assert.equal(result.repos.length, 2);
+      assert.equal(result.repos[0].git, "git@github.com:owner/repo-a.git");
+      assert.equal(result.repos[1].git, "git@github.com:owner/repo-b.git");
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes (baseline — flat behavior already works)**
+
+Run: `npm test -- --test-name-pattern "flat directory: recursive scan" 2>&1 | tail -20` Expected: PASS (existing code already handles flat dirs)
+
+- [ ] **Step 3: Implement `collectYamlFiles` and refactor `loadRawConfigFromDirectory`**
+
+In `src/config/loader.ts`, add `relative` to the `path` import, add `symlinkSync` is not needed — add `lstatSync` is not needed. Just add `relative` to imports and the new helper. Replace the body of `loadRawConfigFromDirectory`:
+
+```typescript
+import { readFileSync, statSync, readdirSync } from "node:fs";
+import { dirname, join, extname, relative } from "node:path";
+```
+
+Add the constant and helper function before `loadRawConfigFromDirectory`:
+
+```typescript
+const MAX_CONFIG_DEPTH = 10;
+
+function collectYamlFiles(
+  rootDir: string,
+  currentDir: string,
+  depth: number
+): Array<{ relativePath: string; absolutePath: string }> {
+  if (depth > MAX_CONFIG_DEPTH) {
+    const rel = relative(rootDir, currentDir) || ".";
+    throw new ValidationError(
+      `Config directory nesting exceeds maximum depth of ${MAX_CONFIG_DEPTH} at ${rel}`
+    );
+  }
+
+  let entries;
+  try {
+    entries = readdirSync(currentDir, { withFileTypes: true });
+  } catch (error) {
+    throw new ValidationError(
+      `Failed to read config directory ${currentDir}: ${toErrorMessage(error)}`,
+      { cause: error }
+    );
+  }
+
+  const files: Array<{ relativePath: string; absolutePath: string }> = [];
+  const subdirs: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+
+    const ext = extname(entry.name).toLowerCase();
+    const isYaml = ext === ".yaml" || ext === ".yml";
+
+    if (entry.isFile() && isYaml) {
+      files.push({
+        relativePath: relative(rootDir, join(currentDir, entry.name)),
+        absolutePath: join(currentDir, entry.name),
+      });
+    } else if (entry.isSymbolicLink() && isYaml) {
+      files.push({
+        relativePath: relative(rootDir, join(currentDir, entry.name)),
+        absolutePath: join(currentDir, entry.name),
+      });
+    } else if (entry.isDirectory()) {
+      subdirs.push(entry.name);
+    }
+  }
+
+  files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  subdirs.sort();
+
+  const result = [...files];
+  for (const subdir of subdirs) {
+    result.push(
+      ...collectYamlFiles(rootDir, join(currentDir, subdir), depth + 1)
+    );
+  }
+
+  return result;
+}
+```
+
+Replace the body of `loadRawConfigFromDirectory`:
+
+```typescript
+function loadRawConfigFromDirectory(dirPath: string): RawConfig {
+  const yamlFiles = collectYamlFiles(dirPath, dirPath, 0);
+
+  if (yamlFiles.length === 0) {
+    throw new ValidationError(
+      `No .yaml or .yml files found in directory: ${dirPath}`
+    );
+  }
+
+  const fragments: ConfigFragment[] = yamlFiles.map(
+    ({ relativePath, absolutePath }) => {
+      let content: string;
+      try {
+        content = readFileSync(absolutePath, "utf-8");
+      } catch (error) {
+        throw new ValidationError(
+          `Failed to read config file ${absolutePath}: ${toErrorMessage(error)}`,
+          { cause: error }
+        );
+      }
+      const configDir = dirname(absolutePath);
+
+      let config: Partial<RawConfig>;
+      try {
+        config = parse(content) as Partial<RawConfig>;
+      } catch (error) {
+        const message = toErrorMessage(error);
+        throw new ValidationError(
+          `Failed to parse YAML config at ${absolutePath}: ${message}`,
+          { cause: error }
+        );
+      }
+
+      if (!config || typeof config !== "object") {
+        throw new ValidationError(
+          `Config file ${relativePath} is empty or invalid — expected a YAML mapping`
+        );
+      }
+
+      config = resolveFileReferencesInConfig(config as RawConfig, {
+        configDir,
+      });
+
+      return { fileName: relativePath, config };
+    }
+  );
+
+  const merged = mergeConfigFragments(fragments);
+
+  validateRawConfig(merged);
+
+  return merged;
+}
+```
+
+- [ ] **Step 4: Run test to verify flat-dir equivalence still passes**
+
+Run: `npm test -- --test-name-pattern "flat directory: recursive scan" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 5: Run all existing loader tests to verify no regressions**
+
+Run: `npm test -- --test-name-pattern "loadRawConfig|loadConfig" 2>&1 | tail -30` Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config/loader.ts test/unit/config/loader.test.ts
+git commit -m "feat: add collectYamlFiles helper for recursive directory scanning"
+```
+
+______________________________________________________________________
+
+### Task 2: Recursive discovery and depth-first alphabetical ordering
+
+Test that nested subdirectories are scanned and files appear in the correct depth-first, alphabetical-per-level order matching the spec example.
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the failing test — recursive discovery with correct ordering**
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("recursive: discovers nested YAML files in depth-first alphabetical order", () => {
+      const configDir = join(tempDir, "recursive-order");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, "infra"));
+      mkdirSync(join(configDir, "teams"));
+      mkdirSync(join(configDir, "teams", "beta"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: recursive-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      writeFileSync(
+        join(configDir, "shared.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-1.git\n`
+      );
+      writeFileSync(
+        join(configDir, "infra", "shared.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-2.git\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "alpha.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-3.git\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "beta.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-4.git\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "beta", "overrides.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-5.git\n`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "recursive-test");
+      assert.equal(result.repos.length, 5);
+      assert.equal(result.repos[0].git, "git@github.com:owner/repo-1.git");
+      assert.equal(result.repos[1].git, "git@github.com:owner/repo-2.git");
+      assert.equal(result.repos[2].git, "git@github.com:owner/repo-3.git");
+      assert.equal(result.repos[3].git, "git@github.com:owner/repo-4.git");
+      assert.equal(result.repos[4].git, "git@github.com:owner/repo-5.git");
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails (before implementation this would have passed since we implemented in Task 1 — but this validates correct ordering)**
+
+Run: `npm test -- --test-name-pattern "recursive: discovers nested" 2>&1 | tail -20` Expected: PASS (implementation from Task 1 already handles this)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify recursive directory scanning with depth-first ordering"
+```
+
+______________________________________________________________________
+
+### Task 3: Max depth exceeded error
+
+Test that recursion deeper than 10 levels throws a `ValidationError`.
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the test — depth exceeds MAX_CONFIG_DEPTH**
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("throws ValidationError when directory nesting exceeds maximum depth", () => {
+      const configDir = join(tempDir, "deep-nest");
+      mkdirSync(configDir);
+
+      let current = configDir;
+      for (let i = 0; i < 12; i++) {
+        current = join(current, `level-${i}`);
+        mkdirSync(current);
+      }
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: deep-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(join(current, "deep.yaml"), `repos:\n  - git: git@github.com:owner/deep.git\n`);
+
+      assert.throws(
+        () => loadRawConfig(configDir),
+        (err: unknown) => {
+          assert.ok(
+            err instanceof ValidationError,
+            `Expected ValidationError, got ${String(err)}`
+          );
+          assert.ok(
+            err.message.includes("exceeds maximum depth of 10"),
+            `Expected depth error, got: ${err.message}`
+          );
+          return true;
+        }
+      );
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "exceeds maximum depth" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify max depth validation for recursive config scanning"
+```
+
+______________________________________________________________________
+
+### Task 4: Hidden files and directories are skipped
+
+Test that dotfiles and dotdirs are ignored during scanning.
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the test — hidden entries skipped**
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("skips hidden files and directories (names starting with dot)", () => {
+      const configDir = join(tempDir, "hidden-test");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, ".git"));
+      mkdirSync(join(configDir, "visible"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: hidden-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      writeFileSync(
+        join(configDir, "visible", "repos.yaml"),
+        `repos:\n  - git: git@github.com:owner/visible.git\n`
+      );
+      writeFileSync(
+        join(configDir, ".hidden.yaml"),
+        `repos:\n  - git: git@github.com:owner/hidden-file.git\n`
+      );
+      writeFileSync(
+        join(configDir, ".git", "config.yaml"),
+        `repos:\n  - git: git@github.com:owner/hidden-dir.git\n`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "hidden-test");
+      assert.equal(result.repos.length, 1);
+      assert.equal(result.repos[0].git, "git@github.com:owner/visible.git");
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "skips hidden files" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify hidden files and directories are skipped in recursive scan"
+```
+
+______________________________________________________________________
+
+### Task 5: Empty subdirectories and subdirs without YAML files
+
+Test that empty subdirs or subdirs with non-YAML files don't cause errors — they're simply skipped.
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the test — empty and non-YAML subdirs skipped**
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("empty subdirectories and subdirs with no YAML files are skipped without error", () => {
+      const configDir = join(tempDir, "empty-subdirs");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, "empty"));
+      mkdirSync(join(configDir, "no-yaml"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: empty-sub-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(join(configDir, "no-yaml", "readme.txt"), "not yaml");
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "empty-sub-test");
+      assert.equal(result.repos.length, 1);
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "empty subdirectories" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify empty subdirectories are skipped gracefully"
+```
+
+______________________________________________________________________
+
+### Task 6: Symlinked directories are skipped
+
+Test that symlinked directories are not followed (avoids cycles).
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the test — symlinked directory skipped**
+
+Add `symlinkSync` to the `fs` import at the top of the test file:
+
+```typescript
+import {
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  chmodSync,
+  symlinkSync,
+} from "node:fs";
+```
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("skips symlinked directories", () => {
+      const configDir = join(tempDir, "symlink-dir-test");
+      mkdirSync(configDir);
+      const realDir = join(tempDir, "real-target");
+      mkdirSync(realDir);
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: symlink-dir-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(
+        join(realDir, "extra.yaml"),
+        `repos:\n  - git: git@github.com:owner/symlinked.git\n`
+      );
+      symlinkSync(realDir, join(configDir, "linked-dir"));
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "symlink-dir-test");
+      assert.equal(result.repos.length, 1);
+      assert.equal(result.repos[0].git, "git@github.com:owner/repo.git");
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "skips symlinked directories" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify symlinked directories are skipped"
+```
+
+______________________________________________________________________
+
+### Task 7: Symlinked YAML files are followed
+
+Test that symlinked `.yaml`/`.yml` files are included (since `isFile()` returns `false` for symlinks with `withFileTypes`, the `isSymbolicLink()` fallback is needed).
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the test — symlinked YAML file followed**
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("follows symlinked YAML files via isSymbolicLink fallback", () => {
+      const configDir = join(tempDir, "symlink-file-test");
+      mkdirSync(configDir);
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: symlink-file-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      const realFile = join(tempDir, "real-repos.yaml");
+      writeFileSync(
+        realFile,
+        `repos:\n  - git: git@github.com:owner/symlinked-file.git\n`
+      );
+      symlinkSync(realFile, join(configDir, "linked.yaml"));
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "symlink-file-test");
+      assert.equal(result.repos.length, 1);
+      assert.equal(
+        result.repos[0].git,
+        "git@github.com:owner/symlinked-file.git"
+      );
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "follows symlinked YAML" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify symlinked YAML files are followed"
+```
+
+______________________________________________________________________
+
+### Task 8: File reference resolution relative to fragment directory
+
+Test that `!file` / `@` references in nested fragments resolve relative to the fragment's own directory, not the config root.
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the test — file ref resolves relative to fragment dir**
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("file references in nested fragments resolve relative to fragment directory", () => {
+      const configDir = join(tempDir, "fileref-test");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, "teams"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: fileref-test\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "fragment.yaml"),
+        `files:\n  config.json:\n    content: "@config-data.json"\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "config-data.json"),
+        `{"key": "value"}`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "fileref-test");
+      assert.ok(result.files);
+      assert.deepEqual(result.files["config.json"].content, { key: "value" });
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "file references in nested" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify file reference resolution in nested config fragments"
+```
+
+______________________________________________________________________
+
+### Task 9: Relative path in fragment fileName for error messages
+
+Test that merger error messages use relative paths (e.g., `teams/alpha.yaml`) when fragments from subdirectories conflict.
+
+**Files:**
+
+- Modify: `test/unit/config/config-merger.test.ts`
+
+- [ ] **Step 1: Write the test — path-style fileName in error message**
+
+Add inside `describe("mergeConfigFragments", ...)`:
+
+```typescript
+  test("error messages include path-style fileName for nested fragments", () => {
+    const fragments: ConfigFragment[] = [
+      {
+        fileName: "base.yaml",
+        config: {
+          id: "test",
+          files: { "a.json": { content: {} } },
+          repos: [],
+        },
+      },
+      {
+        fileName: "teams/alpha.yaml",
+        config: {
+          files: { "b.json": { content: {} } },
+          repos: [],
+        },
+      },
+    ];
+
+    assert.throws(
+      () => mergeConfigFragments(fragments),
+      (err: Error) => {
+        assert.ok(
+          err.message.includes("base.yaml"),
+          `Expected 'base.yaml' in message, got: ${err.message}`
+        );
+        assert.ok(
+          err.message.includes("teams/alpha.yaml"),
+          `Expected 'teams/alpha.yaml' in message, got: ${err.message}`
+        );
+        return true;
+      }
+    );
+  });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "path-style fileName" 2>&1 | tail -20` Expected: PASS (merger already uses fileName as-is in error strings)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/config-merger.test.ts
+git commit -m "test: verify path-style fileName in merger error messages"
+```
+
+______________________________________________________________________
+
+### Task 10: Unreadable subdirectory fails entire load
+
+Test that a permission-denied subdirectory throws `ValidationError` and fails the entire load (not silently skipped).
+
+**Files:**
+
+- Modify: `test/unit/config/loader.test.ts`
+
+- [ ] **Step 1: Write the test — unreadable subdirectory**
+
+Add inside `describe("directory loading", ...)`:
+
+```typescript
+    test("throws ValidationError when a subdirectory cannot be read (permission denied)", () => {
+      const configDir = join(tempDir, "unreadable-subdir");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, "blocked"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: unreadable-sub-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(
+        join(configDir, "blocked", "fragment.yaml"),
+        `repos:\n  - git: git@github.com:owner/blocked.git\n`
+      );
+      chmodSync(join(configDir, "blocked"), 0o000);
+
+      assert.throws(
+        () => loadRawConfig(configDir),
+        (err: unknown) => {
+          assert.ok(
+            err instanceof ValidationError,
+            `Expected ValidationError, got ${String(err)}`
+          );
+          assert.ok(
+            err.message.includes("Failed to read config directory"),
+            `Expected 'Failed to read config directory', got: ${err.message}`
+          );
+          return true;
+        }
+      );
+
+      chmodSync(join(configDir, "blocked"), 0o755);
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern "subdirectory cannot be read" 2>&1 | tail -20` Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/loader.test.ts
+git commit -m "test: verify unreadable subdirectory fails entire config load"
+```
+
+______________________________________________________________________
+
+### Task 11: Full test suite, build, and lint verification
+
+Run all checks to ensure no regressions and code quality.
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test 2>&1 | tail -40` Expected: All tests PASS
+
+- [ ] **Step 2: Run typecheck on test files**
+
+Run: `npm run test:typecheck 2>&1 | tail -20` Expected: No type errors
+
+- [ ] **Step 3: Run build**
+
+Run: `npm run build 2>&1 | tail -20` Expected: Clean build
+
+- [ ] **Step 4: Run lint**
+
+Run: `./lint.sh 2>&1 | tail -40` Expected: No lint errors
+
+- [ ] **Step 5: Commit any lint fixes if needed**
+
+```bash
+git add -A
+git commit -m "fix: lint fixes for recursive config scanning"
+```

--- a/plans/superpowers/specs/2026-05-18-recursive-config-scan-design.md
+++ b/plans/superpowers/specs/2026-05-18-recursive-config-scan-design.md
@@ -1,0 +1,108 @@
+# Recursive Subdirectory Scanning for Multi-File Config
+
+**Issue:** #674 **Depends on:** #671 (directory-based multi-file config, already implemented) **Date:** 2026-05-18
+
+## Problem
+
+Directory mode (`--config <dir>`) only scans flat `.yaml`/`.yml` files in the specified directory. Users with large configs want to organize fragments into subdirectories (e.g., `teams/`, `infra/`) but these are silently ignored.
+
+## Solution
+
+Make `loadRawConfigFromDirectory` scan recursively. No new flags, no schema changes, no merger changes.
+
+## Design Decisions
+
+| Decision          | Choice                              | Rationale                                                 |
+| ----------------- | ----------------------------------- | --------------------------------------------------------- |
+| Opt-in vs default | Always recursive                    | No breaking change — subdirs were silently ignored before |
+| Traversal order   | Depth-first, alphabetical per level | Predictable, matches `ls -R` mental model                 |
+| Max depth         | 10 levels                           | Safety net against runaway recursion                      |
+| Symlinked dirs    | Skip                                | Avoid loops                                               |
+| Symlinked files   | Follow                              | Users may symlink shared fragments                        |
+| Fragment fileName | Relative path from config root      | Clear provenance in error messages                        |
+
+## Ordering Specification
+
+At each directory level:
+
+1. Collect `.yaml`/`.yml` files, sort alphabetically
+1. Collect subdirectories, sort alphabetically
+1. Add files to result list
+1. Recurse into each subdirectory (depth-first)
+
+Example:
+
+```text
+xfg-config/
+  base.yaml           ← 1st
+  shared.yaml          ← 2nd
+  infra/
+    shared.yaml        ← 3rd
+  teams/
+    alpha.yaml         ← 4th
+    beta.yaml          ← 5th
+    beta/
+      overrides.yaml   ← 6th
+```
+
+## Affected Code
+
+### Changed
+
+- `src/config/loader.ts` — `loadRawConfigFromDirectory` gains recursive traversal via a helper function that walks the directory tree
+
+### Unchanged
+
+- `ConfigFragment` interface — `fileName` field already accepts any string; now holds relative paths like `teams/alpha.yaml`
+- `mergeConfigFragments` — already works with any `fileName` string for error messages
+- Schema, normalizer, validator — no structural changes
+- Single-file config loading path — untouched
+
+## Implementation Detail
+
+New private helper in `loader.ts`:
+
+```typescript
+function collectYamlFiles(
+  rootDir: string,
+  currentDir: string,
+  depth: number
+): Array<{ relativePath: string; absolutePath: string }>
+```
+
+- `rootDir`: the original config directory (for computing relative paths)
+- `currentDir`: the directory being scanned at this recursion level
+- `depth`: current depth (0 at root, error if > 10)
+- Returns files in depth-first alphabetical order
+- Skips symlinked directories, follows symlinked files
+- Uses `readdirSync` with `withFileTypes: true`
+
+`loadRawConfigFromDirectory` calls `collectYamlFiles` then iterates over the result to build `ConfigFragment[]` using the relative path as `fileName`.
+
+## Error Cases
+
+| Condition                               | Behavior                                                                              |
+| --------------------------------------- | ------------------------------------------------------------------------------------- |
+| Depth exceeds 10                        | `ValidationError`: "Config directory nesting exceeds maximum depth of 10 at `<path>`" |
+| No YAML files found (at any depth)      | Existing error: "No .yaml or .yml files found in directory: `<path>`"                 |
+| Unreadable subdirectory                 | `ValidationError`: "Failed to read config directory `<path>`: `<error>`"              |
+| Duplicate group names across files      | Existing merger error, now with relative paths for clarity                            |
+| Duplicate single-file keys across files | Existing merger error, now with relative paths for clarity                            |
+
+## Testing
+
+### Unit Tests (loader.test.ts)
+
+- Recursive discovery: nested dirs produce correct file list in correct order
+- Depth-first alphabetical ordering verified against spec example
+- Max depth exceeded: throws `ValidationError`
+- Empty subdirectories: skipped, no error
+- Subdirectory with no YAML files: skipped, no error
+- Mixed: some dirs have YAML, some don't
+- Symlinked directory: skipped
+- Relative path in fragment fileName: verified in error messages via config-merger integration
+
+### Unit Tests (config-merger.test.ts)
+
+- Existing tests still pass (fileName format is just a string)
+- Fragment with path-style fileName (e.g., `teams/alpha.yaml`) produces correct error messages

--- a/plans/superpowers/specs/2026-05-18-recursive-config-scan-design.md
+++ b/plans/superpowers/specs/2026-05-18-recursive-config-scan-design.md
@@ -12,18 +12,18 @@ Make `loadRawConfigFromDirectory` scan recursively. No new flags, no schema chan
 
 ## Design Decisions
 
-| Decision            | Choice                              | Rationale                                                 |
-| ------------------- | ----------------------------------- | --------------------------------------------------------- |
-| Opt-in vs default   | Always recursive                    | No breaking change — subdirs were silently ignored before |
-| Traversal order     | Depth-first, alphabetical per level | Predictable, matches `ls -R` mental model                 |
-| Max depth           | 10 levels                           | Safety net against runaway recursion                      |
-| Symlinked dirs      | Skip                                | Avoid loops                                               |
-| Symlinked files     | Follow                              | Users may symlink shared fragments                        |
-| Fragment fileName   | Relative path from config root      | Clear provenance in error messages                        |
-| Hidden files/dirs   | Skip (names starting with `.`)      | Avoid picking up `.git`, `.DS_Store`, editor temp files   |
-| File ref resolution | Relative to fragment's own dir      | Users co-locate referenced files next to their fragments  |
-| Unreadable subdir   | Fail entire load                    | Consistent with current behavior for unreadable root dir  |
-| Windows             | Not supported                       | xfg does not support Windows                              |
+| Decision            | Choice                                    | Rationale                                                 |
+| ------------------- | ----------------------------------------- | --------------------------------------------------------- |
+| Opt-in vs default   | Always recursive                          | No breaking change — subdirs were silently ignored before |
+| Traversal order     | Depth-first, alphabetical per level       | Predictable, matches `ls -R` mental model                 |
+| Max depth           | 10 levels                                 | Safety net against runaway recursion                      |
+| Symlinked dirs      | Skip (implicit via `isDirectory()=false`) | Avoid loops; no explicit check needed                     |
+| Symlinked files     | Follow via `isSymbolicLink()` fallback    | `isFile()=false` for symlinks; need explicit check        |
+| Fragment fileName   | Relative path from config root            | Clear provenance in error messages                        |
+| Hidden files/dirs   | Skip (names starting with `.`)            | Avoid picking up `.git`, `.DS_Store`, editor temp files   |
+| File ref resolution | Relative to fragment's own dir            | Users co-locate referenced files next to their fragments  |
+| Unreadable subdir   | Fail entire load                          | Consistent with current behavior for unreadable root dir  |
+| Windows             | Not supported                             | xfg does not support Windows                              |
 
 ## Ordering Specification
 
@@ -84,12 +84,13 @@ function collectYamlFiles(
 
 - `rootDir`: the original config directory (for computing relative paths via `path.relative`)
 - `currentDir`: the directory being scanned at this recursion level
-- `depth`: current depth (0 at root, error if > 10)
+- `depth`: current depth (0 at root). Check `depth > MAX_DEPTH` at function entry, before `readdirSync`. `MAX_DEPTH = 10`, allowing levels 0–10 (11 total levels)
 - Returns files in depth-first alphabetical order per the ordering specification
 - Skips hidden entries (names starting with `.`)
-- Skips symlinked directories, follows symlinked files
+- Skips symlinked directories (implicit: `entry.isDirectory()` returns `false` for symlinks with `withFileTypes`)
+- Follows symlinked files via explicit fallback: if `entry.isSymbolicLink()` and has `.yaml`/`.yml` extension, include it (`entry.isFile()` returns `false` for symlinks with `withFileTypes`)
 - Uses `readdirSync` with `withFileTypes: true`
-- Uses `entry.isSymbolicLink()` to detect symlinked directories (requires `lstat` behavior from `withFileTypes`)
+- Error paths use relative path from config root (consistent with fragment `fileName`)
 
 `loadRawConfigFromDirectory` calls `collectYamlFiles` then iterates over the result to build `ConfigFragment[]` using the relative path as `fileName`.
 

--- a/plans/superpowers/specs/2026-05-18-recursive-config-scan-design.md
+++ b/plans/superpowers/specs/2026-05-18-recursive-config-scan-design.md
@@ -12,34 +12,40 @@ Make `loadRawConfigFromDirectory` scan recursively. No new flags, no schema chan
 
 ## Design Decisions
 
-| Decision          | Choice                              | Rationale                                                 |
-| ----------------- | ----------------------------------- | --------------------------------------------------------- |
-| Opt-in vs default | Always recursive                    | No breaking change — subdirs were silently ignored before |
-| Traversal order   | Depth-first, alphabetical per level | Predictable, matches `ls -R` mental model                 |
-| Max depth         | 10 levels                           | Safety net against runaway recursion                      |
-| Symlinked dirs    | Skip                                | Avoid loops                                               |
-| Symlinked files   | Follow                              | Users may symlink shared fragments                        |
-| Fragment fileName | Relative path from config root      | Clear provenance in error messages                        |
+| Decision            | Choice                              | Rationale                                                 |
+| ------------------- | ----------------------------------- | --------------------------------------------------------- |
+| Opt-in vs default   | Always recursive                    | No breaking change — subdirs were silently ignored before |
+| Traversal order     | Depth-first, alphabetical per level | Predictable, matches `ls -R` mental model                 |
+| Max depth           | 10 levels                           | Safety net against runaway recursion                      |
+| Symlinked dirs      | Skip                                | Avoid loops                                               |
+| Symlinked files     | Follow                              | Users may symlink shared fragments                        |
+| Fragment fileName   | Relative path from config root      | Clear provenance in error messages                        |
+| Hidden files/dirs   | Skip (names starting with `.`)      | Avoid picking up `.git`, `.DS_Store`, editor temp files   |
+| File ref resolution | Relative to fragment's own dir      | Users co-locate referenced files next to their fragments  |
+| Unreadable subdir   | Fail entire load                    | Consistent with current behavior for unreadable root dir  |
+| Windows             | Not supported                       | xfg does not support Windows                              |
 
 ## Ordering Specification
 
 At each directory level:
 
-1. Collect `.yaml`/`.yml` files, sort alphabetically
-1. Collect subdirectories, sort alphabetically
+1. Collect non-hidden `.yaml`/`.yml` files, sort alphabetically
+1. Collect non-hidden, non-symlinked subdirectories, sort alphabetically
 1. Add files to result list
-1. Recurse into each subdirectory (depth-first)
+1. Recurse into each subdirectory in order
+
+Files at a given level always appear before files from subdirectories of that level. Subdirectories are processed in alphabetical order, and the same rule applies recursively within each subdirectory.
 
 Example:
 
 ```text
 xfg-config/
-  base.yaml           ← 1st
+  base.yaml           ← 1st  (root files first, alphabetical)
   shared.yaml          ← 2nd
   infra/
-    shared.yaml        ← 3rd
+    shared.yaml        ← 3rd  (infra/ before teams/ alphabetically)
   teams/
-    alpha.yaml         ← 4th
+    alpha.yaml         ← 4th  (teams/ files before teams/beta/ subdir)
     beta.yaml          ← 5th
     beta/
       overrides.yaml   ← 6th
@@ -58,6 +64,12 @@ xfg-config/
 - Schema, normalizer, validator — no structural changes
 - Single-file config loading path — untouched
 
+## File Reference Resolution
+
+File references (e.g., `!file ./template.json`) in fragments resolve relative to the fragment's own directory, not the config root. This is the existing behavior from `resolveFileReferencesInConfig` which receives `dirname(filePath)` as `configDir`. No change needed — this naturally works correctly for nested fragments since each fragment's absolute path is known.
+
+Example: a `!file ./shared.json` reference in `teams/alpha.yaml` resolves to `teams/shared.json`.
+
 ## Implementation Detail
 
 New private helper in `loader.ts`:
@@ -70,24 +82,26 @@ function collectYamlFiles(
 ): Array<{ relativePath: string; absolutePath: string }>
 ```
 
-- `rootDir`: the original config directory (for computing relative paths)
+- `rootDir`: the original config directory (for computing relative paths via `path.relative`)
 - `currentDir`: the directory being scanned at this recursion level
 - `depth`: current depth (0 at root, error if > 10)
-- Returns files in depth-first alphabetical order
+- Returns files in depth-first alphabetical order per the ordering specification
+- Skips hidden entries (names starting with `.`)
 - Skips symlinked directories, follows symlinked files
 - Uses `readdirSync` with `withFileTypes: true`
+- Uses `entry.isSymbolicLink()` to detect symlinked directories (requires `lstat` behavior from `withFileTypes`)
 
 `loadRawConfigFromDirectory` calls `collectYamlFiles` then iterates over the result to build `ConfigFragment[]` using the relative path as `fileName`.
 
 ## Error Cases
 
-| Condition                               | Behavior                                                                              |
-| --------------------------------------- | ------------------------------------------------------------------------------------- |
-| Depth exceeds 10                        | `ValidationError`: "Config directory nesting exceeds maximum depth of 10 at `<path>`" |
-| No YAML files found (at any depth)      | Existing error: "No .yaml or .yml files found in directory: `<path>`"                 |
-| Unreadable subdirectory                 | `ValidationError`: "Failed to read config directory `<path>`: `<error>`"              |
-| Duplicate group names across files      | Existing merger error, now with relative paths for clarity                            |
-| Duplicate single-file keys across files | Existing merger error, now with relative paths for clarity                            |
+| Condition                               | Behavior                                                                                     |
+| --------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Depth exceeds 10                        | `ValidationError`: "Config directory nesting exceeds maximum depth of 10 at `<path>`"        |
+| No YAML files found (at any depth)      | Existing error: "No .yaml or .yml files found in directory: `<path>`"                        |
+| Unreadable subdirectory                 | `ValidationError`: "Failed to read config directory `<path>`: `<error>`" — fails entire load |
+| Duplicate group names across files      | Existing merger error, now with relative paths for clarity                                   |
+| Duplicate single-file keys across files | Existing merger error, now with relative paths for clarity                                   |
 
 ## Testing
 
@@ -100,7 +114,9 @@ function collectYamlFiles(
 - Subdirectory with no YAML files: skipped, no error
 - Mixed: some dirs have YAML, some don't
 - Symlinked directory: skipped
+- Hidden files and directories: skipped
 - Relative path in fragment fileName: verified in error messages via config-merger integration
+- File reference resolution: resolves relative to fragment directory, not config root
 
 ### Unit Tests (config-merger.test.ts)
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -90,9 +90,9 @@ function collectYamlFiles(
   try {
     entries = readdirSync(currentDir, { withFileTypes: true });
   } catch (error) {
-    const rel = relative(rootDir, currentDir) || ".";
+    const rel = relative(rootDir, currentDir);
     throw new ValidationError(
-      `Failed to read config directory ${rel}: ${toErrorMessage(error)}`,
+      `Failed to read config directory ${rel || currentDir}: ${toErrorMessage(error)}`,
       { cause: error }
     );
   }
@@ -108,12 +108,7 @@ function collectYamlFiles(
     const ext = extname(entry.name).toLowerCase();
     const isYaml = ext === ".yaml" || ext === ".yml";
 
-    if (entry.isFile() && isYaml) {
-      files.push({
-        relativePath: relative(rootDir, join(currentDir, entry.name)),
-        absolutePath: join(currentDir, entry.name),
-      });
-    } else if (entry.isSymbolicLink() && isYaml) {
+    if ((entry.isFile() || entry.isSymbolicLink()) && isYaml) {
       files.push({
         relativePath: relative(rootDir, join(currentDir, entry.name)),
         absolutePath: join(currentDir, entry.name),

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -91,9 +91,9 @@ function collectYamlFiles(
   try {
     entries = readdirSync(currentDir, { withFileTypes: true });
   } catch (error) {
-    const rel = relative(rootDir, currentDir);
+    const displayPath = relative(rootDir, currentDir) || currentDir;
     throw new ValidationError(
-      `Failed to read config directory ${rel || "."}: ${toErrorMessage(error)}`,
+      `Failed to read config directory ${displayPath}: ${toErrorMessage(error)}`,
       { cause: error }
     );
   }
@@ -120,7 +120,7 @@ function collectYamlFiles(
   }
 
   files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
-  subdirs.sort();
+  subdirs.sort((a, b) => a.localeCompare(b));
 
   const result = [...files];
   for (const subdir of subdirs) {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -92,7 +92,7 @@ function collectYamlFiles(
   } catch (error) {
     const rel = relative(rootDir, currentDir);
     throw new ValidationError(
-      `Failed to read config directory ${rel || currentDir}: ${toErrorMessage(error)}`,
+      `Failed to read config directory ${rel || "."}: ${toErrorMessage(error)}`,
       { cause: error }
     );
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -80,6 +80,7 @@ function collectYamlFiles(
   depth: number
 ): Array<{ relativePath: string; absolutePath: string }> {
   if (depth > MAX_CONFIG_DEPTH) {
+    /* c8 ignore next -- rootDir === currentDir impossible at depth > MAX_CONFIG_DEPTH */
     const rel = relative(rootDir, currentDir) || ".";
     throw new ValidationError(
       `Config directory nesting exceeds maximum depth of ${MAX_CONFIG_DEPTH} at ${rel}`

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,5 +1,5 @@
 import { readFileSync, statSync, readdirSync } from "node:fs";
-import { dirname, join, extname } from "node:path";
+import { dirname, join, extname, relative } from "node:path";
 import { parse } from "yaml";
 import { validateRawConfig } from "./validator.js";
 import { normalizeConfig as normalizeConfigInternal } from "./normalizer.js";
@@ -72,24 +72,72 @@ function loadRawConfigFromFile(filePath: string): RawConfig {
   return rawConfig;
 }
 
-function loadRawConfigFromDirectory(dirPath: string): RawConfig {
+const MAX_CONFIG_DEPTH = 10;
+
+function collectYamlFiles(
+  rootDir: string,
+  currentDir: string,
+  depth: number
+): Array<{ relativePath: string; absolutePath: string }> {
+  if (depth > MAX_CONFIG_DEPTH) {
+    const rel = relative(rootDir, currentDir) || ".";
+    throw new ValidationError(
+      `Config directory nesting exceeds maximum depth of ${MAX_CONFIG_DEPTH} at ${rel}`
+    );
+  }
+
   let entries;
   try {
-    entries = readdirSync(dirPath, { withFileTypes: true });
+    entries = readdirSync(currentDir, { withFileTypes: true });
   } catch (error) {
+    const rel = relative(rootDir, currentDir) || ".";
     throw new ValidationError(
-      `Failed to read config directory ${dirPath}: ${toErrorMessage(error)}`,
+      `Failed to read config directory ${rel}: ${toErrorMessage(error)}`,
       { cause: error }
     );
   }
-  const yamlFiles = entries
-    .filter(
-      (entry) =>
-        entry.isFile() &&
-        [".yaml", ".yml"].includes(extname(entry.name).toLowerCase())
-    )
-    .map((entry) => entry.name)
-    .sort();
+
+  const files: Array<{ relativePath: string; absolutePath: string }> = [];
+  const subdirs: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+
+    const ext = extname(entry.name).toLowerCase();
+    const isYaml = ext === ".yaml" || ext === ".yml";
+
+    if (entry.isFile() && isYaml) {
+      files.push({
+        relativePath: relative(rootDir, join(currentDir, entry.name)),
+        absolutePath: join(currentDir, entry.name),
+      });
+    } else if (entry.isSymbolicLink() && isYaml) {
+      files.push({
+        relativePath: relative(rootDir, join(currentDir, entry.name)),
+        absolutePath: join(currentDir, entry.name),
+      });
+    } else if (entry.isDirectory()) {
+      subdirs.push(entry.name);
+    }
+  }
+
+  files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  subdirs.sort();
+
+  const result = [...files];
+  for (const subdir of subdirs) {
+    result.push(
+      ...collectYamlFiles(rootDir, join(currentDir, subdir), depth + 1)
+    );
+  }
+
+  return result;
+}
+
+function loadRawConfigFromDirectory(dirPath: string): RawConfig {
+  const yamlFiles = collectYamlFiles(dirPath, dirPath, 0);
 
   if (yamlFiles.length === 0) {
     throw new ValidationError(
@@ -97,44 +145,45 @@ function loadRawConfigFromDirectory(dirPath: string): RawConfig {
     );
   }
 
-  const fragments: ConfigFragment[] = yamlFiles.map((fileName) => {
-    const filePath = join(dirPath, fileName);
-    let content: string;
-    try {
-      content = readFileSync(filePath, "utf-8");
-    } catch (error) {
-      throw new ValidationError(
-        `Failed to read config file ${filePath}: ${toErrorMessage(error)}`,
-        { cause: error }
-      );
+  const fragments: ConfigFragment[] = yamlFiles.map(
+    ({ relativePath, absolutePath }) => {
+      let content: string;
+      try {
+        content = readFileSync(absolutePath, "utf-8");
+      } catch (error) {
+        throw new ValidationError(
+          `Failed to read config file ${relativePath}: ${toErrorMessage(error)}`,
+          { cause: error }
+        );
+      }
+      const configDir = dirname(absolutePath);
+
+      let config: Partial<RawConfig>;
+      try {
+        config = parse(content) as Partial<RawConfig>;
+      } catch (error) {
+        const message = toErrorMessage(error);
+        throw new ValidationError(
+          `Failed to parse YAML config at ${relativePath}: ${message}`,
+          { cause: error }
+        );
+      }
+
+      if (!config || typeof config !== "object") {
+        throw new ValidationError(
+          `Config file ${relativePath} is empty or invalid — expected a YAML mapping`
+        );
+      }
+
+      // Safe cast: resolveFileReferencesInConfig only accesses optional fields
+      // (files, groups, etc.), so fragments missing id/repos work correctly.
+      config = resolveFileReferencesInConfig(config as RawConfig, {
+        configDir,
+      });
+
+      return { fileName: relativePath, config };
     }
-    const configDir = dirname(filePath);
-
-    let config: Partial<RawConfig>;
-    try {
-      config = parse(content) as Partial<RawConfig>;
-    } catch (error) {
-      const message = toErrorMessage(error);
-      throw new ValidationError(
-        `Failed to parse YAML config at ${filePath}: ${message}`,
-        { cause: error }
-      );
-    }
-
-    if (!config || typeof config !== "object") {
-      throw new ValidationError(
-        `Config file ${fileName} is empty or invalid — expected a YAML mapping`
-      );
-    }
-
-    // Safe cast: resolveFileReferencesInConfig only accesses optional fields
-    // (files, groups, etc.), so fragments missing id/repos work correctly.
-    config = resolveFileReferencesInConfig(config as RawConfig, {
-      configDir,
-    });
-
-    return { fileName, config };
-  });
+  );
 
   const merged = mergeConfigFragments(fragments);
 

--- a/test/integration/github.test.ts
+++ b/test/integration/github.test.ts
@@ -873,4 +873,63 @@ files:
       }
     );
   });
+
+  test("sync with recursive directory-based multi-file config", async () => {
+    const configDir = join(tmpDir, "recursive-config");
+    const teamsDir = join(configDir, "teams");
+    mkdirSync(teamsDir, { recursive: true });
+
+    writeFileSync(
+      join(configDir, "base.yaml"),
+      `id: integration-test-recursive
+files:
+  ${TARGET_FILE}:
+    content:
+      fromBase: true
+      shared: base-value
+`,
+      "utf-8"
+    );
+
+    writeFileSync(
+      join(teamsDir, "repos.yaml"),
+      `repos:
+  - git: https://github.com/${testRepo}.git
+    files:
+      ${TARGET_FILE}:
+        content:
+          fromNestedDir: true
+`,
+      "utf-8"
+    );
+
+    const output = await exec(`node dist/cli.js sync --config ${configDir}`, {
+      cwd: projectRoot,
+    });
+    console.log(output);
+
+    const pr = await waitForPrVisible(testRepo, BRANCH_NAME);
+    assert.ok(pr.number);
+
+    await withTestRetry(
+      async () => {
+        const raw = await execWithRetry(
+          `gh api repos/${testRepo}/contents/${TARGET_FILE}?ref=${BRANCH_NAME} --jq '.content' | base64 -d`
+        );
+        const json = JSON.parse(raw);
+        assert.equal(json.fromBase, true, "content from root base.yaml");
+        assert.equal(json.shared, "base-value", "shared content from root");
+        assert.equal(
+          json.fromNestedDir,
+          true,
+          "content from teams/repos.yaml subdirectory"
+        );
+      },
+      {
+        description: "verify recursive multi-file config content on PR branch",
+        retries: 5,
+        baseDelayMs: 3000,
+      }
+    );
+  });
 });

--- a/test/unit/config/config-merger.test.ts
+++ b/test/unit/config/config-merger.test.ts
@@ -282,4 +282,39 @@ describe("mergeConfigFragments", () => {
     assert.ok(result.conditionalGroups);
     assert.equal(result.conditionalGroups.length, 2);
   });
+
+  test("error messages include path-style fileName for nested fragments", () => {
+    const fragments: ConfigFragment[] = [
+      {
+        fileName: "base.yaml",
+        config: {
+          id: "test",
+          files: { "a.json": { content: {} } },
+          repos: [],
+        },
+      },
+      {
+        fileName: "teams/alpha.yaml",
+        config: {
+          files: { "b.json": { content: {} } },
+          repos: [],
+        },
+      },
+    ];
+
+    assert.throws(
+      () => mergeConfigFragments(fragments),
+      (err: Error) => {
+        assert.ok(
+          err.message.includes("base.yaml"),
+          `Expected 'base.yaml' in message, got: ${err.message}`
+        );
+        assert.ok(
+          err.message.includes("teams/alpha.yaml"),
+          `Expected 'teams/alpha.yaml' in message, got: ${err.message}`
+        );
+        return true;
+      }
+    );
+  });
 });

--- a/test/unit/config/config.test.ts
+++ b/test/unit/config/config.test.ts
@@ -1276,15 +1276,15 @@ repos:
       );
     });
 
-    test("does not recurse into subdirectories", () => {
-      const configDir = join(testDir, "config-norecurse-" + Date.now());
+    test("recurses into subdirectories", () => {
+      const configDir = join(testDir, "config-recurse-" + Date.now());
       const subDir = join(configDir, "subdir");
       mkdirSync(subDir, { recursive: true });
 
       writeFileSync(
         join(configDir, "base.yaml"),
         `
-id: test-norecurse
+id: test-recurse
 files:
   base.json:
     content:
@@ -1305,7 +1305,7 @@ repos:
       );
 
       const config = loadConfig(configDir, {});
-      assert.equal(config.repos.length, 1);
+      assert.equal(config.repos.length, 2);
     });
 
     test("resolves @path file references relative to each fragment file", () => {

--- a/test/unit/config/loader.test.ts
+++ b/test/unit/config/loader.test.ts
@@ -481,28 +481,40 @@ describe("loadRawConfig", () => {
       mkdirSync(configDir);
       mkdirSync(join(configDir, "empty"));
       mkdirSync(join(configDir, "no-yaml"));
+      mkdirSync(join(configDir, "has-yaml"));
 
       writeFileSync(
         join(configDir, "base.yaml"),
         `id: empty-sub-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
       );
       writeFileSync(join(configDir, "no-yaml", "readme.txt"), "not yaml");
+      writeFileSync(
+        join(configDir, "has-yaml", "extra.yaml"),
+        `repos:\n  - git: git@github.com:owner/from-subdir.git\n`
+      );
 
       const result = loadRawConfig(configDir);
 
       assert.equal(result.id, "empty-sub-test");
-      assert.equal(result.repos.length, 1);
+      assert.equal(result.repos.length, 2);
+      assert.equal(result.repos[0].git, "git@github.com:owner/repo.git");
+      assert.equal(result.repos[1].git, "git@github.com:owner/from-subdir.git");
     });
 
     test("skips symlinked directories", () => {
       const configDir = join(tempDir, "symlink-dir-test");
       mkdirSync(configDir);
+      mkdirSync(join(configDir, "real-subdir"));
       const realDir = join(tempDir, "real-target");
       mkdirSync(realDir);
 
       writeFileSync(
         join(configDir, "base.yaml"),
         `id: symlink-dir-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(
+        join(configDir, "real-subdir", "extra.yaml"),
+        `repos:\n  - git: git@github.com:owner/from-real-subdir.git\n`
       );
       writeFileSync(
         join(realDir, "extra.yaml"),
@@ -513,8 +525,12 @@ describe("loadRawConfig", () => {
       const result = loadRawConfig(configDir);
 
       assert.equal(result.id, "symlink-dir-test");
-      assert.equal(result.repos.length, 1);
+      assert.equal(result.repos.length, 2);
       assert.equal(result.repos[0].git, "git@github.com:owner/repo.git");
+      assert.equal(
+        result.repos[1].git,
+        "git@github.com:owner/from-real-subdir.git"
+      );
     });
 
     test("follows symlinked YAML files via isSymbolicLink fallback", () => {

--- a/test/unit/config/loader.test.ts
+++ b/test/unit/config/loader.test.ts
@@ -184,6 +184,10 @@ describe("loadRawConfig", () => {
             err.message.includes("Failed to read config directory"),
             `Expected 'Failed to read config directory', got: ${err.message}`
           );
+          assert.ok(
+            err.message.includes(configDir),
+            `Expected absolute path '${configDir}' in error, got: ${err.message}`
+          );
           return true;
         }
       );

--- a/test/unit/config/loader.test.ts
+++ b/test/unit/config/loader.test.ts
@@ -438,7 +438,7 @@ describe("loadRawConfig", () => {
             `Expected depth error, got: ${err.message}`
           );
           assert.ok(
-            err.message.includes("level-0"),
+            err.message.includes("level-10"),
             `Expected relative path in error, got: ${err.message}`
           );
           return true;

--- a/test/unit/config/loader.test.ts
+++ b/test/unit/config/loader.test.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
   rmSync,
   chmodSync,
+  symlinkSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -362,6 +363,265 @@ describe("loadRawConfig", () => {
       assert.equal(result.repos.length, 2);
       assert.equal(result.repos[0].git, "git@github.com:owner/repo-a.git");
       assert.equal(result.repos[1].git, "git@github.com:owner/repo-b.git");
+    });
+
+    test("recursive: discovers nested YAML files in depth-first alphabetical order", () => {
+      const configDir = join(tempDir, "recursive-order");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, "infra"));
+      mkdirSync(join(configDir, "teams"));
+      mkdirSync(join(configDir, "teams", "beta"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: recursive-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      writeFileSync(
+        join(configDir, "shared.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-1.git\n`
+      );
+      writeFileSync(
+        join(configDir, "infra", "shared.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-2.git\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "alpha.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-3.git\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "beta.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-4.git\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "beta", "overrides.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-5.git\n`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "recursive-test");
+      assert.equal(result.repos.length, 5);
+      assert.equal(result.repos[0].git, "git@github.com:owner/repo-1.git");
+      assert.equal(result.repos[1].git, "git@github.com:owner/repo-2.git");
+      assert.equal(result.repos[2].git, "git@github.com:owner/repo-3.git");
+      assert.equal(result.repos[3].git, "git@github.com:owner/repo-4.git");
+      assert.equal(result.repos[4].git, "git@github.com:owner/repo-5.git");
+    });
+
+    test("throws ValidationError when directory nesting exceeds maximum depth", () => {
+      const configDir = join(tempDir, "deep-nest");
+      mkdirSync(configDir);
+
+      let current = configDir;
+      for (let i = 0; i < 12; i++) {
+        current = join(current, `level-${i}`);
+        mkdirSync(current);
+      }
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: deep-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(
+        join(current, "deep.yaml"),
+        `repos:\n  - git: git@github.com:owner/deep.git\n`
+      );
+
+      assert.throws(
+        () => loadRawConfig(configDir),
+        (err: unknown) => {
+          assert.ok(
+            err instanceof ValidationError,
+            `Expected ValidationError, got ${String(err)}`
+          );
+          assert.ok(
+            err.message.includes("exceeds maximum depth of 10"),
+            `Expected depth error, got: ${err.message}`
+          );
+          assert.ok(
+            err.message.includes("level-0"),
+            `Expected relative path in error, got: ${err.message}`
+          );
+          return true;
+        }
+      );
+    });
+
+    test("skips hidden files and directories (names starting with dot)", () => {
+      const configDir = join(tempDir, "hidden-test");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, ".git"));
+      mkdirSync(join(configDir, "visible"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: hidden-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      writeFileSync(
+        join(configDir, "visible", "repos.yaml"),
+        `repos:\n  - git: git@github.com:owner/visible.git\n`
+      );
+      writeFileSync(
+        join(configDir, ".hidden.yaml"),
+        `repos:\n  - git: git@github.com:owner/hidden-file.git\n`
+      );
+      writeFileSync(
+        join(configDir, ".git", "config.yaml"),
+        `repos:\n  - git: git@github.com:owner/hidden-dir.git\n`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "hidden-test");
+      assert.equal(result.repos.length, 1);
+      assert.equal(result.repos[0].git, "git@github.com:owner/visible.git");
+    });
+
+    test("empty subdirectories and subdirs with no YAML files are skipped without error", () => {
+      const configDir = join(tempDir, "empty-subdirs");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, "empty"));
+      mkdirSync(join(configDir, "no-yaml"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: empty-sub-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(join(configDir, "no-yaml", "readme.txt"), "not yaml");
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "empty-sub-test");
+      assert.equal(result.repos.length, 1);
+    });
+
+    test("skips symlinked directories", () => {
+      const configDir = join(tempDir, "symlink-dir-test");
+      mkdirSync(configDir);
+      const realDir = join(tempDir, "real-target");
+      mkdirSync(realDir);
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: symlink-dir-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(
+        join(realDir, "extra.yaml"),
+        `repos:\n  - git: git@github.com:owner/symlinked.git\n`
+      );
+      symlinkSync(realDir, join(configDir, "linked-dir"));
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "symlink-dir-test");
+      assert.equal(result.repos.length, 1);
+      assert.equal(result.repos[0].git, "git@github.com:owner/repo.git");
+    });
+
+    test("follows symlinked YAML files via isSymbolicLink fallback", () => {
+      const configDir = join(tempDir, "symlink-file-test");
+      mkdirSync(configDir);
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: symlink-file-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      const realFile = join(tempDir, "real-repos.yaml");
+      writeFileSync(
+        realFile,
+        `repos:\n  - git: git@github.com:owner/symlinked-file.git\n`
+      );
+      symlinkSync(realFile, join(configDir, "linked.yaml"));
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "symlink-file-test");
+      assert.equal(result.repos.length, 1);
+      assert.equal(
+        result.repos[0].git,
+        "git@github.com:owner/symlinked-file.git"
+      );
+    });
+
+    test("discovers .yml files alongside .yaml files", () => {
+      const configDir = join(tempDir, "yml-extension-test");
+      mkdirSync(configDir);
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: yml-ext-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      writeFileSync(
+        join(configDir, "extra.yml"),
+        `repos:\n  - git: git@github.com:owner/yml-repo.git\n`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "yml-ext-test");
+      assert.equal(result.repos.length, 1);
+      assert.equal(result.repos[0].git, "git@github.com:owner/yml-repo.git");
+    });
+
+    test("file references in nested fragments resolve relative to fragment directory", () => {
+      const configDir = join(tempDir, "fileref-test");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, "teams"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: fileref-test\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "fragment.yaml"),
+        `files:\n  config.json:\n    content: "@config-data.json"\n`
+      );
+      writeFileSync(
+        join(configDir, "teams", "config-data.json"),
+        `{"key": "value"}`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "fileref-test");
+      assert.ok(result.files);
+      assert.deepEqual(result.files["config.json"].content, { key: "value" });
+    });
+
+    test("throws ValidationError when a subdirectory cannot be read (permission denied)", () => {
+      const configDir = join(tempDir, "unreadable-subdir");
+      mkdirSync(configDir);
+      mkdirSync(join(configDir, "blocked"));
+
+      writeFileSync(
+        join(configDir, "base.yaml"),
+        `id: unreadable-sub-test\nfiles:\n  .gitkeep:\n    content: ""\nrepos:\n  - git: git@github.com:owner/repo.git\n`
+      );
+      writeFileSync(
+        join(configDir, "blocked", "fragment.yaml"),
+        `repos:\n  - git: git@github.com:owner/blocked.git\n`
+      );
+      chmodSync(join(configDir, "blocked"), 0o000);
+
+      assert.throws(
+        () => loadRawConfig(configDir),
+        (err: unknown) => {
+          assert.ok(
+            err instanceof ValidationError,
+            `Expected ValidationError, got ${String(err)}`
+          );
+          assert.ok(
+            err.message.includes("Failed to read config directory"),
+            `Expected 'Failed to read config directory', got: ${err.message}`
+          );
+          assert.ok(
+            err.message.includes("blocked"),
+            `Expected relative path 'blocked' in error, got: ${err.message}`
+          );
+          return true;
+        }
+      );
+
+      chmodSync(join(configDir, "blocked"), 0o755);
     });
   });
 });

--- a/test/unit/config/loader.test.ts
+++ b/test/unit/config/loader.test.ts
@@ -343,6 +343,26 @@ describe("loadRawConfig", () => {
         }
       );
     });
+
+    test("flat directory: recursive scan produces same results as before", () => {
+      const configDir = join(tempDir, "flat-recursive");
+      mkdirSync(configDir);
+      writeFileSync(
+        join(configDir, "01-base.yaml"),
+        `id: flat-test\nfiles:\n  .gitkeep:\n    content: ""\n`
+      );
+      writeFileSync(
+        join(configDir, "02-repos.yaml"),
+        `repos:\n  - git: git@github.com:owner/repo-a.git\n  - git: git@github.com:owner/repo-b.git\n`
+      );
+
+      const result = loadRawConfig(configDir);
+
+      assert.equal(result.id, "flat-test");
+      assert.equal(result.repos.length, 2);
+      assert.equal(result.repos[0].git, "git@github.com:owner/repo-a.git");
+      assert.equal(result.repos[1].git, "git@github.com:owner/repo-b.git");
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Extract `collectYamlFiles` helper that recursively walks config directories depth-first, alphabetically per level
- Refactor `loadRawConfigFromDirectory` to use the helper — subdirectories are now scanned automatically with no new flags or schema changes
- Skip hidden entries (dotfiles/dotdirs), symlinked directories (cycle safety), and respect max depth of 10 levels
- Follow symlinked YAML files, resolve file references relative to each fragment's own directory
- Error messages use relative paths from config root for clarity

## Test Plan

- [x] Flat directory produces identical results to previous behavior
- [x] Recursive discovery with depth-first alphabetical ordering matches spec example
- [x] Max depth exceeded throws ValidationError
- [x] Hidden files and directories skipped
- [x] Empty subdirectories and non-YAML subdirs skipped gracefully
- [x] Symlinked directories skipped
- [x] Symlinked YAML files followed via isSymbolicLink fallback
- [x] `.yml` extension files discovered alongside `.yaml`
- [x] File references in nested fragments resolve relative to fragment directory
- [x] Path-style fileName in merger error messages
- [x] Unreadable subdirectory fails entire load with ValidationError
- [x] Full test suite (2905 pass), typecheck, build, lint all green

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)