### PR TITLE
feat: add prOptions.branch for custom PR branch names

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -303,6 +303,7 @@
         },
         "branch": {
           "type": "string",
+          "minLength": 1,
           "description": "Branch name for sync PRs. Per-repo overrides group, group overrides global. CLI --branch flag overrides all."
         }
       }

--- a/config-schema.json
+++ b/config-schema.json
@@ -300,6 +300,10 @@
             "minLength": 1
           },
           "description": "Labels to apply to created PRs/MRs. Labels must exist on the target repository."
+        },
+        "branch": {
+          "type": "string",
+          "description": "Branch name for sync PRs. Per-repo overrides group, group overrides global. CLI --branch flag overrides all."
         }
       }
     },

--- a/docs/configuration/pr-options.md
+++ b/docs/configuration/pr-options.md
@@ -4,13 +4,14 @@ Configure how PRs are handled after creation.
 
 ## PR Options Fields
 
-| Field           | Description                                                                           | Default  |
-| --------------- | ------------------------------------------------------------------------------------- | -------- |
-| `merge`         | Merge mode: `manual` (leave open), `auto` (merge when checks pass), `force`, `direct` | `auto`   |
-| `mergeStrategy` | How to merge: `merge`, `squash`, `rebase`                                             | `squash` |
-| `deleteBranch`  | Delete source branch after merge                                                      | `true`   |
-| `bypassReason`  | Reason for bypassing policies (Azure DevOps only, required for `force`)               | -        |
-| `labels`        | Labels to apply to created PRs (GitHub only, more platforms coming)                   | -        |
+| Field           | Description                                                                                                    | Default  |
+| --------------- | -------------------------------------------------------------------------------------------------------------- | -------- |
+| `merge`         | Merge mode: `manual` (leave open), `auto` (merge when checks pass), `force`, `direct`                          | `auto`   |
+| `mergeStrategy` | How to merge: `merge`, `squash`, `rebase`                                                                      | `squash` |
+| `deleteBranch`  | Delete source branch after merge                                                                               | `true`   |
+| `bypassReason`  | Reason for bypassing policies (Azure DevOps only, required for `force`)                                        | -        |
+| `labels`        | Labels to apply to created PRs (GitHub only, more platforms coming)                                            | -        |
+| `branch`        | Branch name for sync PRs. Per-repo overrides group, group overrides global. CLI `--branch` flag overrides all. | -        |
 
 ## Merge Modes
 
@@ -75,6 +76,27 @@ repos:
 ```
 
 **Note:** Labels must already exist on the target repository. If a label doesn't exist, the PR creation will fail. Currently supported on GitHub only.
+
+## PR Branch Name
+
+Set a custom branch name for sync PRs:
+
+```yaml
+# Global branch name
+prOptions:
+  branch: chore/sync-config
+
+repos:
+  # Uses global branch name
+  - git: git@github.com:org/frontend.git
+
+  # Per-repo override
+  - git: git@github.com:org/special.git
+    prOptions:
+      branch: chore/sync-repo-specific
+```
+
+When `branch` is not set, the branch name is auto-generated from the synced file names (e.g., `chore/sync-prettierrc`). The CLI `--branch` flag overrides all config values.
 
 ## CLI Override
 

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -177,6 +177,7 @@ At least one of `allOf` or `anyOf` is required. When both are specified, both co
 | `deleteBranch`  | `boolean`  | `true`   | Delete branch after merge                    |
 | `bypassReason`  | `string`   | -        | Reason for bypass (Azure DevOps only)        |
 | `labels`        | `string[]` | -        | Labels to apply to created PRs (GitHub only) |
+| `branch`        | `string`   | -        | Branch name for sync PRs                     |
 
 ## Validation
 

--- a/plans/superpowers/plans/2026-05-18-pr-options-branch.md
+++ b/plans/superpowers/plans/2026-05-18-pr-options-branch.md
@@ -1,0 +1,886 @@
+# `prOptions.branch` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `prOptions.branch` in config YAML to set the PR branch name, with per-repo/group/global layering and CLI override.
+
+**Architecture:** Add `branch?: string` to `PRMergeOptions`. Move `validateBranchName` to `src/shared/branch-validation.ts` so both `src/config/` and `src/cli/` can import it. Validation added to config validator. Branch resolution in `repo-sync-runner.ts` picks per-repo config branch before falling back to the auto-generated name.
+
+**Tech Stack:** TypeScript, Node.js test runner (`node:test`), `node:assert/strict`
+
+______________________________________________________________________
+
+## Task 1: Move `validateBranchName` to shared
+
+**Files:**
+
+- Create: `src/shared/branch-validation.ts`
+
+- Modify: `src/cli/branch-utils.ts:16-37`
+
+- Modify: `src/cli/sync-command.ts:9`
+
+- Modify: `test/unit/cli/branch-utils.test.ts:5-6`
+
+- Create: `test/unit/shared/branch-validation.test.ts`
+
+- [ ] **Step 1: Create `src/shared/branch-validation.ts`**
+
+```typescript
+import { ValidationError } from "./errors.js";
+
+export function validateBranchName(branchName: string): void {
+  if (!branchName || branchName.trim() === "") {
+    throw new ValidationError("Branch name cannot be empty");
+  }
+
+  if (branchName.startsWith(".") || branchName.startsWith("-")) {
+    throw new ValidationError('Branch name cannot start with "." or "-"');
+  }
+
+  // Git disallows: space, ~, ^, :, ?, *, [, \, and consecutive dots (..)
+  if (/[\s~^:?*[\\]/.test(branchName) || branchName.includes("..")) {
+    throw new ValidationError("Branch name contains invalid characters");
+  }
+
+  if (
+    branchName.endsWith("/") ||
+    branchName.endsWith(".lock") ||
+    branchName.endsWith(".")
+  ) {
+    throw new ValidationError("Branch name has invalid ending");
+  }
+}
+```
+
+- [ ] **Step 2: Update `src/cli/branch-utils.ts` to re-export from shared**
+
+Replace `validateBranchName` in `src/cli/branch-utils.ts` with a re-export. The file should become:
+
+```typescript
+import { ValidationError } from "../shared/errors.js";
+
+export { validateBranchName } from "../shared/branch-validation.js";
+
+export function sanitizeBranchName(fileName: string): string {
+  return fileName
+    .toLowerCase()
+    .replace(/\.[^.]+$/, "")
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+```
+
+Note: The `ValidationError` import can also be removed since `sanitizeBranchName` doesn't use it. Check if anything else in this file uses it — if not, remove it.
+
+Actually, `sanitizeBranchName` doesn't throw `ValidationError`. Remove the unused import:
+
+```typescript
+export { validateBranchName } from "../shared/branch-validation.js";
+
+export function sanitizeBranchName(fileName: string): string {
+  return fileName
+    .toLowerCase()
+    .replace(/\.[^.]+$/, "")
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+```
+
+- [ ] **Step 3: Create `test/unit/shared/branch-validation.test.ts`**
+
+Test that the shared module exports work correctly:
+
+```typescript
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { validateBranchName } from "../../../src/shared/branch-validation.js";
+import { ValidationError } from "../../../src/shared/errors.js";
+
+describe("shared/branch-validation", () => {
+  test("accepts valid branch name", () => {
+    assert.doesNotThrow(() => validateBranchName("feature/my-branch"));
+  });
+
+  test("accepts branch with slashes and dashes", () => {
+    assert.doesNotThrow(() => validateBranchName("chore/sync-config"));
+  });
+
+  test("rejects empty string", () => {
+    assert.throws(
+      () => validateBranchName(""),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects whitespace-only", () => {
+    assert.throws(
+      () => validateBranchName("   "),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch starting with dot", () => {
+    assert.throws(
+      () => validateBranchName(".hidden"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch starting with dash", () => {
+    assert.throws(
+      () => validateBranchName("-invalid"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch with spaces", () => {
+    assert.throws(
+      () => validateBranchName("my branch"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch ending with .lock", () => {
+    assert.throws(
+      () => validateBranchName("branch.lock"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch ending with dot", () => {
+    assert.throws(
+      () => validateBranchName("branch."),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch with consecutive dots", () => {
+    assert.throws(
+      () => validateBranchName("feature..name"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch ending with slash", () => {
+    assert.throws(
+      () => validateBranchName("feature/"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+});
+```
+
+- [ ] **Step 4: Run tests to verify move didn't break anything**
+
+Run: `npm test` Expected: All existing tests pass. The `branch-utils.test.ts` tests still pass because `branch-utils.ts` re-exports `validateBranchName`. The new `branch-validation.test.ts` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/branch-validation.ts src/cli/branch-utils.ts test/unit/shared/branch-validation.test.ts
+git commit -m "refactor: move validateBranchName to src/shared/branch-validation.ts"
+```
+
+______________________________________________________________________
+
+## Task 2: Add `branch` to `PRMergeOptions`
+
+**Files:**
+
+- Modify: `src/config/types.ts:6-12`
+
+- [ ] **Step 1: Write failing type test**
+
+There's no separate type test needed — the config validator test (Task 3) will fail to compile if the type doesn't have `branch`. Proceed to implementation.
+
+- [ ] **Step 2: Add `branch` field to `PRMergeOptions`**
+
+In `src/config/types.ts`, change `PRMergeOptions`:
+
+```typescript
+export interface PRMergeOptions {
+  merge?: MergeMode;
+  mergeStrategy?: MergeStrategy;
+  deleteBranch?: boolean;
+  bypassReason?: string;
+  labels?: string[];
+  branch?: string;
+}
+```
+
+- [ ] **Step 3: Run type check**
+
+Run: `npx tsc --noEmit` Expected: PASS — `branch` is optional, no breaking changes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/config/types.ts
+git commit -m "feat: add branch field to PRMergeOptions interface"
+```
+
+______________________________________________________________________
+
+## Task 3: Config validation for `prOptions.branch`
+
+**Files:**
+
+- Modify: `src/config/validator.ts:1-9,125-138`
+
+- Test: `test/unit/config/validator.test.ts`
+
+- [ ] **Step 1: Write failing tests for branch validation**
+
+Add to `test/unit/config/validator.test.ts`, inside the existing `describe("prOptions labels validation", ...)` block (or create a sibling `describe`):
+
+```typescript
+describe("prOptions.branch validation", () => {
+  test("accepts valid branch name in global prOptions", () => {
+    const config = createValidConfig({
+      prOptions: { branch: "chore/custom-sync" },
+    });
+    assert.doesNotThrow(() => validateRawConfig(config));
+  });
+
+  test("rejects invalid branch name in global prOptions", () => {
+    const config = createValidConfig({
+      prOptions: { branch: ".invalid-branch" },
+    });
+    assert.throws(
+      () => validateRawConfig(config),
+      /Branch name cannot start with/
+    );
+  });
+
+  test("rejects empty branch name in global prOptions", () => {
+    const config = createValidConfig({
+      prOptions: { branch: "" },
+    });
+    assert.throws(
+      () => validateRawConfig(config),
+      /Branch name cannot be empty/
+    );
+  });
+
+  test("rejects invalid branch name in per-repo prOptions", () => {
+    const config = createValidConfig({
+      repos: [
+        {
+          git: "git@github.com:org/repo.git",
+          prOptions: { branch: "branch with spaces" },
+        },
+      ],
+    });
+    assert.throws(
+      () => validateRawConfig(config),
+      /Branch name contains invalid characters/
+    );
+  });
+
+  test("rejects invalid branch name in group prOptions", () => {
+    const config = createValidConfig({
+      files: { "f.json": { content: {} } },
+      groups: {
+        mygroup: {
+          prOptions: { branch: "branch.lock" },
+        },
+      },
+      repos: [{ git: "git@github.com:org/repo.git", groups: ["mygroup"] }],
+    });
+    assert.throws(
+      () => validateRawConfig(config),
+      /Branch name has invalid ending/
+    );
+  });
+
+  test("rejects invalid branch name in conditional group prOptions", () => {
+    const config = createValidConfig({
+      files: { "f.json": { content: {} } },
+      groups: {
+        "group-a": { files: { "f.json": { content: {} } } },
+      },
+      conditionalGroups: [
+        {
+          when: { allOf: ["group-a"] },
+          prOptions: { branch: "..bad" },
+        },
+      ],
+      repos: [{ git: "git@github.com:org/repo.git", groups: ["group-a"] }],
+    });
+    assert.throws(
+      () => validateRawConfig(config),
+      /Branch name cannot start with/
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `npm test -- --test-name-pattern "prOptions.branch"` Expected: FAIL — `validateRawConfig` does not yet validate `prOptions.branch`.
+
+Note: The "accepts valid branch name" test will pass (no validation = no rejection). The rejection tests will fail because no validation logic exists yet.
+
+- [ ] **Step 3: Add branch validation to `validatePrOptions`**
+
+In `src/config/validator.ts`, add import at the top:
+
+```typescript
+import { validateBranchName } from "../shared/branch-validation.js";
+```
+
+Then modify the `validatePrOptions` function (lines 125-138) to also validate `branch`:
+
+```typescript
+function validatePrOptions(config: RawConfig): void {
+  if (config.prOptions?.branch !== undefined) {
+    validateBranchName(config.prOptions.branch);
+  }
+
+  if (config.prOptions?.labels === undefined) return;
+
+  if (!Array.isArray(config.prOptions.labels)) {
+    throw new ValidationError("prOptions.labels must be an array of strings");
+  }
+  for (const label of config.prOptions.labels) {
+    if (typeof label !== "string" || label.length === 0) {
+      throw new ValidationError(
+        "prOptions.labels entries must be non-empty strings"
+      );
+    }
+  }
+}
+```
+
+Add per-repo validation inside `validateRepoEntry` in `src/config/validators/repo-entry-validator.ts`. Add import at the top:
+
+```typescript
+import { validateBranchName } from "../../shared/branch-validation.js";
+```
+
+Add a new function and call it from `validateRepoEntry`:
+
+```typescript
+function validateRepoPrOptions(repo: RawConfig["repos"][number]): void {
+  if (repo.prOptions?.branch !== undefined) {
+    validateBranchName(repo.prOptions.branch);
+  }
+}
+```
+
+Call it in `validateRepoEntry` after `validateRepoSettingsEntry`:
+
+```typescript
+export function validateRepoEntry(
+  config: RawConfig,
+  repo: RawConfig["repos"][number],
+  index: number
+): void {
+  const repoLabel = validateRepoGitField(repo, index);
+  validateRepoOrigins(config, repo, repoLabel);
+  validateRepoGroups(config, repo, index);
+  validateRepoFiles(config, repo, index, repoLabel);
+  validateRepoSettingsEntry(config, repo, repoLabel);
+  validateRepoPrOptions(repo);
+}
+```
+
+Add group validation inside `validateGroups` in `src/config/validators/group-validator.ts`. Add import at the top:
+
+```typescript
+import { validateBranchName } from "../../shared/branch-validation.js";
+```
+
+Add branch validation at the end of the group loop, after the settings validation block (around line 168):
+
+```typescript
+    if (group.prOptions?.branch !== undefined) {
+      validateBranchName(group.prOptions.branch);
+    }
+```
+
+Add conditional group validation inside `validateConditionalGroups`, after the settings validation block (around line 251):
+
+```typescript
+    if (entry.prOptions?.branch !== undefined) {
+      validateBranchName(entry.prOptions.branch);
+    }
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `npm test -- --test-name-pattern "prOptions.branch"` Expected: PASS — all branch validation tests pass.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm test` Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config/validator.ts src/config/validators/repo-entry-validator.ts src/config/validators/group-validator.ts test/unit/config/validator.test.ts
+git commit -m "feat: validate prOptions.branch in config at all layers"
+```
+
+______________________________________________________________________
+
+## Task 4: `mergePROptions` handles `branch` (normalizer)
+
+**Files:**
+
+- Test: `test/unit/config/normalizer.test.ts`
+
+No production code changes needed — `mergePROptions` already uses spread semantics (`{ ...global, ...perRepo }`), so `branch` merges automatically. This task adds tests to prove it.
+
+- [ ] **Step 1: Write tests for branch merging**
+
+Add to `test/unit/config/normalizer.test.ts`, near the existing prOptions merge tests (around line 3165):
+
+```typescript
+  test("global prOptions.branch propagates to repo", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      prOptions: { branch: "chore/global-sync" },
+      repos: [{ git: "git@github.com:org/repo.git" }],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/global-sync");
+  });
+
+  test("per-repo prOptions.branch overrides global", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      prOptions: { branch: "chore/global-sync" },
+      repos: [
+        {
+          git: "git@github.com:org/repo.git",
+          prOptions: { branch: "chore/repo-specific" },
+        },
+      ],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/repo-specific");
+  });
+
+  test("group prOptions.branch merges into chain", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      groups: {
+        mygroup: {
+          prOptions: { branch: "chore/group-sync" },
+        },
+      },
+      repos: [
+        { git: "git@github.com:org/repo.git", groups: ["mygroup"] },
+      ],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/group-sync");
+  });
+
+  test("per-repo prOptions.branch overrides group prOptions.branch", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      groups: {
+        mygroup: {
+          prOptions: { branch: "chore/group-sync" },
+        },
+      },
+      repos: [
+        {
+          git: "git@github.com:org/repo.git",
+          groups: ["mygroup"],
+          prOptions: { branch: "chore/repo-override" },
+        },
+      ],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/repo-override");
+  });
+
+  test("global prOptions.branch merges with per-repo other prOptions fields", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      prOptions: { branch: "chore/global-sync", merge: "auto" },
+      repos: [
+        {
+          git: "git@github.com:org/repo.git",
+          prOptions: { labels: ["config"] },
+        },
+      ],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/global-sync");
+    assert.equal(result.repos[0].prOptions?.merge, "auto");
+    assert.deepStrictEqual(result.repos[0].prOptions?.labels, ["config"]);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npm test -- --test-name-pattern "prOptions.branch"` Expected: PASS — all tests pass without production code changes (spread merge handles `branch` automatically).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/unit/config/normalizer.test.ts
+git commit -m "test: verify mergePROptions handles branch field correctly"
+```
+
+______________________________________________________________________
+
+## Task 5: Wire `effectivePrOptions` and branch resolution in `repo-sync-runner.ts`
+
+**Files:**
+
+- Modify: `src/cli/repo-sync-runner.ts:118-127,172-182`
+
+- Test: `test/unit/cli/sync-command.test.ts`
+
+- [ ] **Step 1: Write failing test for per-repo branch resolution**
+
+Add to `test/unit/cli/sync-command.test.ts`, inside the existing `describe("sync-command", ...)`:
+
+```typescript
+  test("prOptions.branch in config sets branch name per-repo", async () => {
+    writeFileSync(
+      testConfigPath,
+      `id: test-config
+${MINIMAL_FILES}
+prOptions:
+  branch: chore/custom-branch
+repos:
+  - git: https://github.com/test/repo
+`
+    );
+
+    const mockProcessor = createMockProcessor();
+
+    await runSync(
+      { config: testConfigPath, dryRun: true, workDir: testDir },
+      {
+        processorFactory: () => mockProcessor,
+        lifecycleManager: noopLifecycleManager,
+      }
+    );
+
+    const processMock = mockProcessor.process as MockFn;
+    const callArgs = processMock.mock.calls[0].arguments;
+    const options = callArgs[2] as { branchName: string };
+    assert.equal(options.branchName, "chore/custom-branch");
+  });
+
+  test("per-repo prOptions.branch overrides global", async () => {
+    writeFileSync(
+      testConfigPath,
+      `id: test-config
+${MINIMAL_FILES}
+prOptions:
+  branch: chore/global-branch
+repos:
+  - git: https://github.com/test/repo
+    prOptions:
+      branch: chore/repo-specific
+`
+    );
+
+    const mockProcessor = createMockProcessor();
+
+    await runSync(
+      { config: testConfigPath, dryRun: true, workDir: testDir },
+      {
+        processorFactory: () => mockProcessor,
+        lifecycleManager: noopLifecycleManager,
+      }
+    );
+
+    const processMock = mockProcessor.process as MockFn;
+    const callArgs = processMock.mock.calls[0].arguments;
+    const options = callArgs[2] as { branchName: string };
+    assert.equal(options.branchName, "chore/repo-specific");
+  });
+
+  test("CLI --branch overrides prOptions.branch in config", async () => {
+    writeFileSync(
+      testConfigPath,
+      `id: test-config
+${MINIMAL_FILES}
+prOptions:
+  branch: chore/config-branch
+repos:
+  - git: https://github.com/test/repo
+`
+    );
+
+    const mockProcessor = createMockProcessor();
+
+    await runSync(
+      {
+        config: testConfigPath,
+        dryRun: true,
+        workDir: testDir,
+        branch: "chore/cli-override",
+      },
+      {
+        processorFactory: () => mockProcessor,
+        lifecycleManager: noopLifecycleManager,
+      }
+    );
+
+    const processMock = mockProcessor.process as MockFn;
+    const callArgs = processMock.mock.calls[0].arguments;
+    const options = callArgs[2] as { branchName: string };
+    assert.equal(options.branchName, "chore/cli-override");
+  });
+
+  test("auto-generated branch used when no prOptions.branch set", async () => {
+    writeFileSync(
+      testConfigPath,
+      `id: test-config
+${MINIMAL_FILES}
+repos:
+  - git: https://github.com/test/repo
+`
+    );
+
+    const mockProcessor = createMockProcessor();
+
+    await runSync(
+      { config: testConfigPath, dryRun: true, workDir: testDir },
+      {
+        processorFactory: () => mockProcessor,
+        lifecycleManager: noopLifecycleManager,
+      }
+    );
+
+    const processMock = mockProcessor.process as MockFn;
+    const callArgs = processMock.mock.calls[0].arguments;
+    const options = callArgs[2] as { branchName: string };
+    assert.equal(options.branchName, "chore/sync-placeholder");
+  });
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `npm test -- --test-name-pattern "prOptions.branch in config"` Expected: FAIL — the processor currently receives `ctx.branchName` (auto-generated), not the per-repo config branch.
+
+- [ ] **Step 3: Add `branch` to `effectivePrOptions` merge**
+
+In `src/cli/repo-sync-runner.ts`, modify the `effectivePrOptions` block (lines 172-182):
+
+```typescript
+  const effectivePrOptions =
+    options.merge || options.mergeStrategy || options.deleteBranch || options.branch
+      ? {
+          ...repoConfig.prOptions,
+          merge: options.merge ?? repoConfig.prOptions?.merge,
+          mergeStrategy:
+            options.mergeStrategy ?? repoConfig.prOptions?.mergeStrategy,
+          deleteBranch:
+            options.deleteBranch ?? repoConfig.prOptions?.deleteBranch,
+          branch: options.branch ?? repoConfig.prOptions?.branch,
+        }
+      : repoConfig.prOptions;
+```
+
+- [ ] **Step 4: Add per-repo branch resolution in `runFileSyncPhase`**
+
+In `src/cli/repo-sync-runner.ts`, in `runFileSyncPhase` (around line 126), replace:
+
+```typescript
+    const result = await ctx.processor.process(repo.repoConfig, repo.repoInfo, {
+      branchName: ctx.branchName,
+```
+
+with:
+
+```typescript
+    const branchName = repo.repoConfig.prOptions?.branch ?? ctx.branchName;
+    const result = await ctx.processor.process(repo.repoConfig, repo.repoInfo, {
+      branchName,
+```
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+Run: `npm test -- --test-name-pattern "prOptions.branch"` Expected: PASS.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npm test` Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/repo-sync-runner.ts test/unit/cli/sync-command.test.ts
+git commit -m "feat: resolve prOptions.branch per-repo with CLI override"
+```
+
+______________________________________________________________________
+
+## Task 6: Lint and type check
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run type check**
+
+Run: `npm run test:typecheck` Expected: PASS.
+
+- [ ] **Step 2: Run linter**
+
+Run: `./lint.sh` Expected: PASS.
+
+- [ ] **Step 3: Run full test suite one more time**
+
+Run: `npm test` Expected: All tests pass.
+
+- [ ] **Step 4: Commit any lint fixes if needed**
+
+```bash
+git add -A
+git commit -m "chore: lint fixes"
+```
+
+______________________________________________________________________
+
+## Task 7: Integration tests
+
+**Files:**
+
+- Modify: `test/integration/github.test.ts`
+
+- [ ] **Step 1: Write integration test for `prOptions.branch` creating PR on correct branch**
+
+Add to `test/integration/github.test.ts`, near the existing prOptions.labels tests:
+
+```typescript
+  test("prOptions.branch creates PR on configured branch", async () => {
+    const customBranch = "chore/custom-pr-branch";
+
+    const configPath = writeConfig(
+      tmpDir,
+      `id: integration-test-pr-branch-github
+files:
+  pr-branch-test.json:
+    content:
+      prBranchTest: true
+prOptions:
+  branch: ${customBranch}
+repos:
+  - git: https://github.com/${testRepo}.git
+`
+    );
+
+    await exec(`node dist/cli.js sync --config ${configPath}`, {
+      cwd: projectRoot,
+    });
+
+    const pr = await waitForPrVisible(testRepo, customBranch, "number,headRefName");
+    assert.equal(pr.headRefName, customBranch);
+  });
+
+  test("per-repo prOptions.branch creates PR on repo-specific branch", async () => {
+    const repoBranch = "chore/repo-pr-branch";
+
+    const configPath = writeConfig(
+      tmpDir,
+      `id: integration-test-pr-branch-override-github
+files:
+  pr-branch-override-test.json:
+    content:
+      prBranchOverrideTest: true
+prOptions:
+  branch: chore/global-should-not-use
+repos:
+  - git: https://github.com/${testRepo}.git
+    prOptions:
+      branch: ${repoBranch}
+`
+    );
+
+    await exec(`node dist/cli.js sync --config ${configPath}`, {
+      cwd: projectRoot,
+    });
+
+    const pr = await waitForPrVisible(testRepo, repoBranch, "number,headRefName");
+    assert.equal(pr.headRefName, repoBranch);
+  });
+```
+
+- [ ] **Step 2: Build before running integration tests**
+
+Run: `npm run build` Expected: PASS.
+
+- [ ] **Step 3: Run GitHub integration tests**
+
+Run: `npm run test:integration:github` Expected: PASS — both new tests create PRs on the configured branch names.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/integration/github.test.ts
+git commit -m "test: add integration tests for prOptions.branch"
+```
+
+______________________________________________________________________
+
+## Task 8: Update documentation
+
+**Files:**
+
+- Modify: `docs/configuration.md` (or equivalent config reference page)
+
+- [ ] **Step 1: Find the config documentation file**
+
+Run: `grep -rn "prOptions" docs/ | head -20`
+
+Look for where `prOptions` is documented.
+
+- [ ] **Step 2: Add `branch` to the prOptions documentation**
+
+Add `branch` to the prOptions table/section wherever labels, merge, mergeStrategy, deleteBranch, and bypassReason are documented. Document:
+
+- Field name: `branch`
+
+- Type: `string`
+
+- Description: Branch name for sync PRs. Supports global, group, and per-repo levels. Per-repo overrides group, group overrides global. CLI `--branch` flag overrides all config values.
+
+- Example showing global and per-repo usage
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/
+git commit -m "docs: document prOptions.branch configuration"
+```
+
+______________________________________________________________________
+
+## Task 9: Final verification and push
+
+- [ ] **Step 1: Run full verification suite**
+
+```bash
+npm test && npm run test:typecheck && ./lint.sh
+```
+
+Expected: All pass.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin HEAD
+```

--- a/plans/superpowers/plans/2026-05-18-pr-options-branch.md
+++ b/plans/superpowers/plans/2026-05-18-pr-options-branch.md
@@ -211,14 +211,25 @@ export interface PRMergeOptions {
 }
 ```
 
-- [ ] **Step 3: Run type check**
+- [ ] **Step 3: Add `branch` to `config-schema.json`**
+
+In `config-schema.json`, add `branch` to the `prOptions` properties (near the existing `labels`, `bypassReason`, etc.):
+
+```json
+"branch": {
+  "type": "string",
+  "description": "Branch name for sync PRs. Per-repo overrides group, group overrides global. CLI --branch flag overrides all."
+}
+```
+
+- [ ] **Step 4: Run type check**
 
 Run: `npx tsc --noEmit` Expected: PASS — `branch` is optional, no breaking changes.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add src/config/types.ts
+git add src/config/types.ts config-schema.json
 git commit -m "feat: add branch field to PRMergeOptions interface"
 ```
 
@@ -650,7 +661,10 @@ repos:
     writeFileSync(
       testConfigPath,
       `id: test-config
-${MINIMAL_FILES}
+files:
+  test-file.json:
+    content:
+      key: value
 repos:
   - git: https://github.com/test/repo
 `
@@ -669,7 +683,7 @@ repos:
     const processMock = mockProcessor.process as MockFn;
     const callArgs = processMock.mock.calls[0].arguments;
     const options = callArgs[2] as { branchName: string };
-    assert.equal(options.branchName, "chore/sync-placeholder");
+    assert.equal(options.branchName, "chore/sync-test-file");
   });
 ```
 
@@ -840,25 +854,39 @@ ______________________________________________________________________
 
 **Files:**
 
-- Modify: `docs/configuration.md` (or equivalent config reference page)
+- Modify: `docs/configuration/pr-options.md`
 
-- [ ] **Step 1: Find the config documentation file**
+- Modify: `docs/reference/config-schema.md`
 
-Run: `grep -rn "prOptions" docs/ | head -20`
+- [ ] **Step 1: Update `docs/configuration/pr-options.md`**
 
-Look for where `prOptions` is documented.
+Add `branch` to the PR Options fields table (after the existing `labels` row):
 
-- [ ] **Step 2: Add `branch` to the prOptions documentation**
+| Field    | Type     | Description                                                                                                                  |
+| -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `branch` | `string` | Branch name for sync PRs. Per-repo overrides group, group overrides global. CLI `--branch` flag overrides all config values. |
 
-Add `branch` to the prOptions table/section wherever labels, merge, mergeStrategy, deleteBranch, and bypassReason are documented. Document:
+Add a usage example showing global and per-repo usage:
 
-- Field name: `branch`
+```yaml
+# Global branch name
+prOptions:
+  branch: chore/sync-config
 
-- Type: `string`
+# Per-repo override
+repos:
+  - git: https://github.com/org/repo.git
+    prOptions:
+      branch: chore/sync-repo-specific
+```
 
-- Description: Branch name for sync PRs. Supports global, group, and per-repo levels. Per-repo overrides group, group overrides global. CLI `--branch` flag overrides all config values.
+- [ ] **Step 2: Update `docs/reference/config-schema.md`**
 
-- Example showing global and per-repo usage
+Add `branch` to the PR Options schema table (after `labels`):
+
+| Field    | Type     | Description              |
+| -------- | -------- | ------------------------ |
+| `branch` | `string` | Branch name for sync PRs |
 
 - [ ] **Step 3: Commit**
 

--- a/plans/superpowers/specs/2026-05-18-pr-options-branch-design.md
+++ b/plans/superpowers/specs/2026-05-18-pr-options-branch-design.md
@@ -1,0 +1,99 @@
+# Design: `prOptions.branch` in Config YAML
+
+**Issue:** [#563](https://github.com/anthony-spruyt/xfg/issues/563) **Date:** 2026-05-18
+
+## Problem
+
+Branch name for sync PRs can only be controlled via CLI `--branch` flag. No declarative YAML equivalent exists. `prOptions.branch` in config is silently ignored.
+
+## Design
+
+Add `branch` field to `PRMergeOptions`. Resolve via the existing prOptions merge pipeline.
+
+### Priority Chain
+
+```text
+CLI --branch > per-repo prOptions.branch > global prOptions.branch > auto-generated from filenames
+```
+
+### Config Syntax
+
+```yaml
+prOptions:
+  branch: chore/my-custom-branch
+repos:
+  - git: https://github.com/org/repo.git
+    prOptions:
+      branch: chore/repo-specific-branch
+```
+
+## Changes
+
+### 1. `PRMergeOptions` interface (`src/config/types.ts`)
+
+Add `branch?: string` field.
+
+### 2. Config validator (`src/config/validator.ts`)
+
+Validate `prOptions.branch` using existing `validateBranchName()` from `src/cli/branch-utils.ts`. Apply to both global and per-repo prOptions.
+
+### 3. `effectivePrOptions` merge (`src/cli/repo-sync-runner.ts:172-182`)
+
+Add CLI `--branch` override to the effectivePrOptions conditional:
+
+```typescript
+const effectivePrOptions =
+  options.merge || options.mergeStrategy || options.deleteBranch || options.branch
+    ? {
+        ...repoConfig.prOptions,
+        merge: options.merge ?? repoConfig.prOptions?.merge,
+        mergeStrategy: options.mergeStrategy ?? repoConfig.prOptions?.mergeStrategy,
+        deleteBranch: options.deleteBranch ?? repoConfig.prOptions?.deleteBranch,
+        branch: options.branch ?? repoConfig.prOptions?.branch,
+      }
+    : repoConfig.prOptions;
+```
+
+### 4. Branch resolution (`src/cli/repo-sync-runner.ts` — `runFileSyncPhase`)
+
+Replace `ctx.branchName` with per-repo resolution:
+
+```typescript
+const branchName = repo.repoConfig.prOptions?.branch ?? ctx.branchName;
+```
+
+Where `ctx.branchName` remains the auto-generated fallback (set in `sync-command.ts` only when CLI `--branch` is absent).
+
+### 5. Validation in `sync-command.ts`
+
+Remove early CLI branch validation from sync-command — branch validation now happens in config validator for YAML values, and in the effectivePrOptions merge for CLI values. Or keep CLI validation where it is (fail-fast for obvious typos) and add YAML validation in config validator.
+
+**Decision:** Keep CLI validation in sync-command (fail-fast). Add YAML validation in config validator. Both use same `validateBranchName()`.
+
+### 6. Logging
+
+Update branch log line in `sync-command.ts:124` to indicate "per-repo" when global prOptions.branch is set but repos may override. Or keep as-is since per-repo resolution happens later.
+
+**Decision:** Keep existing log as-is. Per-repo branch shows in per-repo progress output already.
+
+## What Does NOT Change
+
+- `generateBranchName()` — still used as fallback
+- `ProcessorOptions.branchName` — still the interface to the processor
+- `mergePROptions()` — already handles spread override, `branch` field merges automatically
+- `RepoIterationContext.branchName` — remains as global fallback
+
+## Testing
+
+- Unit test: `mergePROptions` merges `branch` correctly (global, per-repo, override)
+- Unit test: config validator rejects invalid branch names in `prOptions.branch`
+- Unit test: `effectivePrOptions` resolves CLI > per-repo > global > auto-generated
+- Integration test: YAML with `prOptions.branch` creates PR on correct branch
+- Integration test: per-repo override creates different branches per repo
+
+## Edge Cases
+
+- `prOptions.branch` with `merge: direct` — branch still used for the push (no PR created, but branch name matters)
+- Empty string — validator rejects
+- Branch name with invalid chars — validator rejects (same rules as CLI `--branch`)
+- CLI `--branch` + per-repo `prOptions.branch` — CLI wins for all repos (explicit override)

--- a/plans/superpowers/specs/2026-05-18-pr-options-branch-design.md
+++ b/plans/superpowers/specs/2026-05-18-pr-options-branch-design.md
@@ -13,14 +13,20 @@ Add `branch` field to `PRMergeOptions`. Resolve via the existing prOptions merge
 ### Priority Chain
 
 ```text
-CLI --branch > per-repo prOptions.branch > global prOptions.branch > auto-generated from filenames
+CLI --branch > per-repo prOptions.branch > group prOptions.branch > global prOptions.branch > auto-generated from filenames
 ```
+
+The normalizer already resolves group layers via `mergePROptions()` spread semantics (per-repo overrides group, group overrides global). By the time `repoConfig.prOptions` reaches `runSingleRepo`, group merging is complete — no additional group handling needed at runtime.
 
 ### Config Syntax
 
 ```yaml
 prOptions:
   branch: chore/my-custom-branch
+groups:
+  team-a:
+    prOptions:
+      branch: chore/team-a-sync
 repos:
   - git: https://github.com/org/repo.git
     prOptions:
@@ -33,11 +39,21 @@ repos:
 
 Add `branch?: string` field.
 
-### 2. Config validator (`src/config/validator.ts`)
+### 2. Move `validateBranchName()` to shared (`src/shared/branch-validation.ts`)
 
-Validate `prOptions.branch` using existing `validateBranchName()` from `src/cli/branch-utils.ts`. Apply to both global and per-repo prOptions.
+`src/config/` must not depend on `src/cli/` (architecture rule). Move branch name validation logic to `src/shared/` so both config validator and CLI can import from the same shared location.
 
-### 3. `effectivePrOptions` merge (`src/cli/repo-sync-runner.ts:172-182`)
+### 3. Config validator (`src/config/validator.ts`)
+
+Validate `prOptions.branch` using `validateBranchName()` from `src/shared/branch-validation.ts`. Apply to:
+
+- Global `prOptions.branch`
+- Per-repo `prOptions.branch`
+- Group `prOptions.branch` (validated during group expansion in normalizer, or in a dedicated group validator if one exists)
+
+Note: Groups merge into per-repo config during normalization. Validation of the final merged `prOptions.branch` catches invalid values regardless of which layer introduced them.
+
+### 4. `effectivePrOptions` merge (`src/cli/repo-sync-runner.ts:172-182`)
 
 Add CLI `--branch` override to the effectivePrOptions conditional:
 
@@ -54,7 +70,7 @@ const effectivePrOptions =
     : repoConfig.prOptions;
 ```
 
-### 4. Branch resolution (`src/cli/repo-sync-runner.ts` — `runFileSyncPhase`)
+### 5. Branch resolution (`src/cli/repo-sync-runner.ts` — `runFileSyncPhase`)
 
 Replace `ctx.branchName` with per-repo resolution:
 
@@ -62,17 +78,13 @@ Replace `ctx.branchName` with per-repo resolution:
 const branchName = repo.repoConfig.prOptions?.branch ?? ctx.branchName;
 ```
 
-Where `ctx.branchName` remains the auto-generated fallback (set in `sync-command.ts` only when CLI `--branch` is absent).
+At this point `repo.repoConfig.prOptions` contains the fully-merged result: CLI override (from step 4) > per-repo > group > global. The `ctx.branchName` fallback is the auto-generated name from filenames.
 
-### 5. Validation in `sync-command.ts`
+### 6. Validation in `sync-command.ts`
 
-Remove early CLI branch validation from sync-command — branch validation now happens in config validator for YAML values, and in the effectivePrOptions merge for CLI values. Or keep CLI validation where it is (fail-fast for obvious typos) and add YAML validation in config validator.
+**Decision:** Keep CLI validation in sync-command (fail-fast). Add YAML validation in config validator. Both import `validateBranchName()` from `src/shared/branch-validation.ts`.
 
-**Decision:** Keep CLI validation in sync-command (fail-fast). Add YAML validation in config validator. Both use same `validateBranchName()`.
-
-### 6. Logging
-
-Update branch log line in `sync-command.ts:124` to indicate "per-repo" when global prOptions.branch is set but repos may override. Or keep as-is since per-repo resolution happens later.
+### 7. Logging
 
 **Decision:** Keep existing log as-is. Per-repo branch shows in per-repo progress output already.
 
@@ -83,11 +95,24 @@ Update branch log line in `sync-command.ts:124` to indicate "per-repo" when glob
 - `mergePROptions()` — already handles spread override, `branch` field merges automatically
 - `RepoIterationContext.branchName` — remains as global fallback
 
+## PR Reuse Behavior
+
+When two repos share the same `prOptions.branch` value, they will find and reuse each other's PRs (via `findExistingPRUrl(branchName)`). This is **existing behavior** — same thing happens today when CLI `--branch` is used with multiple repos. No change needed.
+
+Users wanting per-repo isolation must use distinct branch names per repo. The `${xfg:repo.name}` template can help:
+
+```yaml
+prOptions:
+  branch: chore/sync-${xfg:repo.name}
+```
+
 ## Testing
 
 - Unit test: `mergePROptions` merges `branch` correctly (global, per-repo, override)
 - Unit test: config validator rejects invalid branch names in `prOptions.branch`
 - Unit test: `effectivePrOptions` resolves CLI > per-repo > global > auto-generated
+- Unit test: group-layered `prOptions.branch` respects per-repo > group > global order
+- Unit test: `validateBranchName()` works from shared location (both CLI and validator import)
 - Integration test: YAML with `prOptions.branch` creates PR on correct branch
 - Integration test: per-repo override creates different branches per repo
 
@@ -97,3 +122,6 @@ Update branch log line in `sync-command.ts:124` to indicate "per-repo" when glob
 - Empty string — validator rejects
 - Branch name with invalid chars — validator rejects (same rules as CLI `--branch`)
 - CLI `--branch` + per-repo `prOptions.branch` — CLI wins for all repos (explicit override)
+- Two repos with same `prOptions.branch` — PR reuse (documented above, matches existing CLI behavior)
+- `${xfg:repo.name}` in branch name — interpolated during normalization (already supported in string fields)
+- Group sets branch, per-repo overrides — per-repo wins via `mergePROptions()` spread

--- a/plans/superpowers/specs/2026-05-18-pr-options-branch-design.md
+++ b/plans/superpowers/specs/2026-05-18-pr-options-branch-design.md
@@ -49,9 +49,9 @@ Validate `prOptions.branch` using `validateBranchName()` from `src/shared/branch
 
 - Global `prOptions.branch`
 - Per-repo `prOptions.branch`
-- Group `prOptions.branch` (validated during group expansion in normalizer, or in a dedicated group validator if one exists)
+- Group `prOptions.branch`
 
-Note: Groups merge into per-repo config during normalization. Validation of the final merged `prOptions.branch` catches invalid values regardless of which layer introduced them.
+Validation runs on raw config before normalization (same phase as existing `prOptions.labels` validation). Each layer is validated independently: global prOptions, each group's prOptions, and each repo's prOptions. This catches invalid branch names at the source layer rather than only after merge.
 
 ### 4. `effectivePrOptions` merge (`src/cli/repo-sync-runner.ts:172-182`)
 
@@ -99,12 +99,9 @@ At this point `repo.repoConfig.prOptions` contains the fully-merged result: CLI 
 
 When two repos share the same `prOptions.branch` value, they will find and reuse each other's PRs (via `findExistingPRUrl(branchName)`). This is **existing behavior** — same thing happens today when CLI `--branch` is used with multiple repos. No change needed.
 
-Users wanting per-repo isolation must use distinct branch names per repo. The `${xfg:repo.name}` template can help:
+Users wanting per-repo isolation must use distinct branch names per repo.
 
-```yaml
-prOptions:
-  branch: chore/sync-${xfg:repo.name}
-```
+Note: `${xfg:repo.name}` template interpolation is **not** currently applied to `prOptions` fields (only file content and PR body templates). Supporting xfg templates in `prOptions.branch` is a separate future enhancement, out of scope for this change.
 
 ## Testing
 
@@ -123,5 +120,8 @@ prOptions:
 - Branch name with invalid chars — validator rejects (same rules as CLI `--branch`)
 - CLI `--branch` + per-repo `prOptions.branch` — CLI wins for all repos (explicit override)
 - Two repos with same `prOptions.branch` — PR reuse (documented above, matches existing CLI behavior)
-- `${xfg:repo.name}` in branch name — interpolated during normalization (already supported in string fields)
 - Group sets branch, per-repo overrides — per-repo wins via `mergePROptions()` spread
+
+## Backward Compatibility
+
+Previously, `prOptions.branch` in config YAML was silently ignored (not a recognized field). Configs that had this field with an invalid branch name will now fail validation. This is correct behavior — the field was never functional, so no working configs will break. Invalid values should surface as errors rather than being silently accepted.

--- a/src/cli/branch-utils.ts
+++ b/src/cli/branch-utils.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from "../shared/errors.js";
+export { validateBranchName } from "../shared/branch-validation.js";
 
 export function sanitizeBranchName(fileName: string): string {
   return fileName
@@ -7,31 +7,4 @@ export function sanitizeBranchName(fileName: string): string {
     .replace(/[^a-z0-9-]/g, "-") // Replace non-alphanumeric with dashes
     .replace(/-+/g, "-") // Collapse multiple dashes
     .replace(/^-|-$/g, ""); // Remove leading/trailing dashes
-}
-
-/**
- * Validates a user-provided branch name against git's naming rules.
- * @throws ValidationError if the branch name is invalid
- */
-export function validateBranchName(branchName: string): void {
-  if (!branchName || branchName.trim() === "") {
-    throw new ValidationError("Branch name cannot be empty");
-  }
-
-  if (branchName.startsWith(".") || branchName.startsWith("-")) {
-    throw new ValidationError('Branch name cannot start with "." or "-"');
-  }
-
-  // Git disallows: space, ~, ^, :, ?, *, [, \, and consecutive dots (..)
-  if (/[\s~^:?*[\\]/.test(branchName) || branchName.includes("..")) {
-    throw new ValidationError("Branch name contains invalid characters");
-  }
-
-  if (
-    branchName.endsWith("/") ||
-    branchName.endsWith(".lock") ||
-    branchName.endsWith(".")
-  ) {
-    throw new ValidationError("Branch name has invalid ending");
-  }
 }

--- a/src/cli/repo-sync-runner.ts
+++ b/src/cli/repo-sync-runner.ts
@@ -123,8 +123,9 @@ async function runFileSyncPhase(
   try {
     ctx.logger.progress(repoNumber, repo.repoName, "Processing...");
 
+    const branchName = repo.repoConfig.prOptions?.branch ?? ctx.branchName;
     const result = await ctx.processor.process(repo.repoConfig, repo.repoInfo, {
-      branchName: ctx.branchName,
+      branchName,
       workDir: repo.workDir,
       configId: ctx.config.id,
       dryRun: ctx.options.dryRun,
@@ -170,7 +171,10 @@ export async function runSingleRepo(
   const repoNumber = index + 1;
 
   const effectivePrOptions =
-    options.merge || options.mergeStrategy || options.deleteBranch
+    options.merge ||
+    options.mergeStrategy ||
+    options.deleteBranch ||
+    options.branch
       ? {
           ...repoConfig.prOptions,
           merge: options.merge ?? repoConfig.prOptions?.merge,
@@ -178,6 +182,7 @@ export async function runSingleRepo(
             options.mergeStrategy ?? repoConfig.prOptions?.mergeStrategy,
           deleteBranch:
             options.deleteBranch ?? repoConfig.prOptions?.deleteBranch,
+          branch: options.branch ?? repoConfig.prOptions?.branch,
         }
       : repoConfig.prOptions;
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -9,6 +9,7 @@ export interface PRMergeOptions {
   deleteBranch?: boolean;
   bypassReason?: string;
   labels?: string[];
+  branch?: string;
 }
 
 export type RulesetTarget = "branch" | "tag";

--- a/src/config/validator.ts
+++ b/src/config/validator.ts
@@ -7,6 +7,7 @@ import type {
 import { validateFileName } from "./validators/file-validator.js";
 import { isPlainObject } from "../shared/type-guards.js";
 import { ValidationError } from "../shared/errors.js";
+import { validateBranchName } from "../shared/branch-validation.js";
 import {
   validateFileConfigFields,
   validateSettings,
@@ -123,6 +124,10 @@ function validateGithubHosts(config: RawConfig): void {
 }
 
 function validatePrOptions(config: RawConfig): void {
+  if (config.prOptions?.branch !== undefined) {
+    validateBranchName(config.prOptions.branch);
+  }
+
   if (config.prOptions?.labels === undefined) return;
 
   if (!Array.isArray(config.prOptions.labels)) {

--- a/src/config/validators/group-validator.ts
+++ b/src/config/validators/group-validator.ts
@@ -6,6 +6,7 @@ import type {
 import { resolveExtendsChain } from "../extends-resolver.js";
 import { isPlainObject } from "../../shared/type-guards.js";
 import { ValidationError } from "../../shared/errors.js";
+import { validateBranchName } from "../../shared/branch-validation.js";
 import {
   validateFileConfigFields,
   validateSettings,
@@ -166,6 +167,10 @@ export function validateGroups(config: RawConfig): void {
     if (group.settings !== undefined) {
       validateSettings(group.settings, `groups.${groupName}`, rootCtx);
     }
+
+    if (group.prOptions?.branch !== undefined) {
+      validateBranchName(group.prOptions.branch);
+    }
   }
 
   validateNoCircularExtends(config.groups);
@@ -248,6 +253,10 @@ export function validateConditionalGroups(config: RawConfig): void {
 
     if (entry.settings !== undefined) {
       validateSettings(entry.settings, ctx, rootCtx);
+    }
+
+    if (entry.prOptions?.branch !== undefined) {
+      validateBranchName(entry.prOptions.branch);
     }
   }
 }

--- a/src/config/validators/repo-entry-validator.ts
+++ b/src/config/validators/repo-entry-validator.ts
@@ -4,6 +4,7 @@ import { validateFileName } from "./file-validator.js";
 import { isPlainObject } from "../../shared/type-guards.js";
 import { escapeRegExp } from "../../shared/regex-utils.js";
 import { ValidationError } from "../../shared/errors.js";
+import { validateBranchName } from "../../shared/branch-validation.js";
 import {
   validateFileConfigFields,
   validateSettings,
@@ -237,6 +238,12 @@ function validateRepoSettingsEntry(
   validateSettings(repo.settings, `Repo ${repoLabel}`, rootCtx);
 }
 
+function validateRepoPrOptions(repo: RawConfig["repos"][number]): void {
+  if (repo.prOptions?.branch !== undefined) {
+    validateBranchName(repo.prOptions.branch);
+  }
+}
+
 export function validateRepoEntry(
   config: RawConfig,
   repo: RawConfig["repos"][number],
@@ -247,4 +254,5 @@ export function validateRepoEntry(
   validateRepoGroups(config, repo, index);
   validateRepoFiles(config, repo, index, repoLabel);
   validateRepoSettingsEntry(config, repo, repoLabel);
+  validateRepoPrOptions(repo);
 }

--- a/src/shared/branch-validation.ts
+++ b/src/shared/branch-validation.ts
@@ -1,0 +1,24 @@
+import { ValidationError } from "./errors.js";
+
+export function validateBranchName(branchName: string): void {
+  if (!branchName || branchName.trim() === "") {
+    throw new ValidationError("Branch name cannot be empty");
+  }
+
+  if (branchName.startsWith(".") || branchName.startsWith("-")) {
+    throw new ValidationError('Branch name cannot start with "." or "-"');
+  }
+
+  // Git disallows: space, ~, ^, :, ?, *, [, \, and consecutive dots (..)
+  if (/[\s~^:?*[\\]/.test(branchName) || branchName.includes("..")) {
+    throw new ValidationError("Branch name contains invalid characters");
+  }
+
+  if (
+    branchName.endsWith("/") ||
+    branchName.endsWith(".lock") ||
+    branchName.endsWith(".")
+  ) {
+    throw new ValidationError("Branch name has invalid ending");
+  }
+}

--- a/src/shared/branch-validation.ts
+++ b/src/shared/branch-validation.ts
@@ -1,5 +1,6 @@
 import { ValidationError } from "./errors.js";
 
+/** Validates a user-provided branch name against git's naming rules. @throws ValidationError if the branch name is invalid */
 export function validateBranchName(branchName: string): void {
   if (!branchName || branchName.trim() === "") {
     throw new ValidationError("Branch name cannot be empty");

--- a/test/integration/github.test.ts
+++ b/test/integration/github.test.ts
@@ -755,6 +755,66 @@ repos:
     assert.ok(!labelNames.includes("enhancement"));
   });
 
+  test("prOptions.branch creates PR on configured branch", async () => {
+    const customBranch = "chore/custom-pr-branch";
+
+    const configPath = writeConfig(
+      tmpDir,
+      `id: integration-test-pr-branch-github
+files:
+  pr-branch-test.json:
+    content:
+      prBranchTest: true
+prOptions:
+  branch: ${customBranch}
+repos:
+  - git: https://github.com/${testRepo}.git
+`
+    );
+
+    await exec(`node dist/cli.js sync --config ${configPath}`, {
+      cwd: projectRoot,
+    });
+
+    const pr = await waitForPrVisible(
+      testRepo,
+      customBranch,
+      "number,headRefName"
+    );
+    assert.equal(pr.headRefName, customBranch);
+  });
+
+  test("per-repo prOptions.branch creates PR on repo-specific branch", async () => {
+    const repoBranch = "chore/repo-pr-branch";
+
+    const configPath = writeConfig(
+      tmpDir,
+      `id: integration-test-pr-branch-override-github
+files:
+  pr-branch-override-test.json:
+    content:
+      prBranchOverrideTest: true
+prOptions:
+  branch: chore/global-should-not-use
+repos:
+  - git: https://github.com/${testRepo}.git
+    prOptions:
+      branch: ${repoBranch}
+`
+    );
+
+    await exec(`node dist/cli.js sync --config ${configPath}`, {
+      cwd: projectRoot,
+    });
+
+    const pr = await waitForPrVisible(
+      testRepo,
+      repoBranch,
+      "number,headRefName"
+    );
+    assert.equal(pr.headRefName, repoBranch);
+  });
+
   test("conditional group applies only when condition is met", async () => {
     const condGroupConfig = [
       `id: integration-test-github`,

--- a/test/unit/cli/sync-command.test.ts
+++ b/test/unit/cli/sync-command.test.ts
@@ -1350,6 +1350,41 @@ repos:
       assert.equal(options.branchName, "chore/cli-override");
     });
 
+    test("CLI --branch overrides per-repo prOptions.branch", async () => {
+      writeFileSync(
+        testConfigPath,
+        `id: test-config
+${MINIMAL_FILES}
+prOptions:
+  branch: chore/global-branch
+repos:
+  - git: https://github.com/test/repo
+    prOptions:
+      branch: feature/repo-specific
+`
+      );
+
+      const mockProcessor = createMockProcessor();
+
+      await runSync(
+        {
+          config: testConfigPath,
+          dryRun: true,
+          workDir: testDir,
+          branch: "chore/cli-override",
+        },
+        {
+          processorFactory: () => mockProcessor,
+          lifecycleManager: noopLifecycleManager,
+        }
+      );
+
+      const processMock = mockProcessor.process as MockFn;
+      const callArgs = processMock.mock.calls[0].arguments;
+      const options = callArgs[2] as { branchName: string };
+      assert.equal(options.branchName, "chore/cli-override");
+    });
+
     test("auto-generated branch used when no prOptions.branch set", async () => {
       writeFileSync(
         testConfigPath,
@@ -1377,6 +1412,45 @@ repos:
       const callArgs = processMock.mock.calls[0].arguments;
       const options = callArgs[2] as { branchName: string };
       assert.equal(options.branchName, "chore/sync-test-file");
+    });
+
+    test("resolves different prOptions.branch per repo independently", async () => {
+      writeFileSync(
+        testConfigPath,
+        `id: test-config
+${MINIMAL_FILES}
+repos:
+  - git: https://github.com/test/repo-one
+    prOptions:
+      branch: chore/repo-one-sync
+  - git: https://github.com/test/repo-two
+    prOptions:
+      branch: chore/repo-two-sync
+`
+      );
+
+      const mockProcessor = createMockProcessor();
+
+      await runSync(
+        { config: testConfigPath, dryRun: true, workDir: testDir },
+        {
+          processorFactory: () => mockProcessor,
+          lifecycleManager: noopLifecycleManager,
+        }
+      );
+
+      const processMock = mockProcessor.process as MockFn;
+      assert.equal(processMock.mock.calls.length, 2);
+
+      const optionsRepo1 = processMock.mock.calls[0].arguments[2] as {
+        branchName: string;
+      };
+      assert.equal(optionsRepo1.branchName, "chore/repo-one-sync");
+
+      const optionsRepo2 = processMock.mock.calls[1].arguments[2] as {
+        branchName: string;
+      };
+      assert.equal(optionsRepo2.branchName, "chore/repo-two-sync");
     });
   });
 

--- a/test/unit/cli/sync-command.test.ts
+++ b/test/unit/cli/sync-command.test.ts
@@ -1258,6 +1258,128 @@ repos:
     });
   });
 
+  describe("prOptions.branch resolution", () => {
+    test("prOptions.branch in config sets branch name per-repo", async () => {
+      writeFileSync(
+        testConfigPath,
+        `id: test-config
+${MINIMAL_FILES}
+prOptions:
+  branch: chore/custom-branch
+repos:
+  - git: https://github.com/test/repo
+`
+      );
+
+      const mockProcessor = createMockProcessor();
+
+      await runSync(
+        { config: testConfigPath, dryRun: true, workDir: testDir },
+        {
+          processorFactory: () => mockProcessor,
+          lifecycleManager: noopLifecycleManager,
+        }
+      );
+
+      const processMock = mockProcessor.process as MockFn;
+      const callArgs = processMock.mock.calls[0].arguments;
+      const options = callArgs[2] as { branchName: string };
+      assert.equal(options.branchName, "chore/custom-branch");
+    });
+
+    test("per-repo prOptions.branch overrides global", async () => {
+      writeFileSync(
+        testConfigPath,
+        `id: test-config
+${MINIMAL_FILES}
+prOptions:
+  branch: chore/global-branch
+repos:
+  - git: https://github.com/test/repo
+    prOptions:
+      branch: chore/repo-specific
+`
+      );
+
+      const mockProcessor = createMockProcessor();
+
+      await runSync(
+        { config: testConfigPath, dryRun: true, workDir: testDir },
+        {
+          processorFactory: () => mockProcessor,
+          lifecycleManager: noopLifecycleManager,
+        }
+      );
+
+      const processMock = mockProcessor.process as MockFn;
+      const callArgs = processMock.mock.calls[0].arguments;
+      const options = callArgs[2] as { branchName: string };
+      assert.equal(options.branchName, "chore/repo-specific");
+    });
+
+    test("CLI --branch overrides prOptions.branch in config", async () => {
+      writeFileSync(
+        testConfigPath,
+        `id: test-config
+${MINIMAL_FILES}
+prOptions:
+  branch: chore/config-branch
+repos:
+  - git: https://github.com/test/repo
+`
+      );
+
+      const mockProcessor = createMockProcessor();
+
+      await runSync(
+        {
+          config: testConfigPath,
+          dryRun: true,
+          workDir: testDir,
+          branch: "chore/cli-override",
+        },
+        {
+          processorFactory: () => mockProcessor,
+          lifecycleManager: noopLifecycleManager,
+        }
+      );
+
+      const processMock = mockProcessor.process as MockFn;
+      const callArgs = processMock.mock.calls[0].arguments;
+      const options = callArgs[2] as { branchName: string };
+      assert.equal(options.branchName, "chore/cli-override");
+    });
+
+    test("auto-generated branch used when no prOptions.branch set", async () => {
+      writeFileSync(
+        testConfigPath,
+        `id: test-config
+files:
+  test-file.json:
+    content:
+      key: value
+repos:
+  - git: https://github.com/test/repo
+`
+      );
+
+      const mockProcessor = createMockProcessor();
+
+      await runSync(
+        { config: testConfigPath, dryRun: true, workDir: testDir },
+        {
+          processorFactory: () => mockProcessor,
+          lifecycleManager: noopLifecycleManager,
+        }
+      );
+
+      const processMock = mockProcessor.process as MockFn;
+      const callArgs = processMock.mock.calls[0].arguments;
+      const options = callArgs[2] as { branchName: string };
+      assert.equal(options.branchName, "chore/sync-test-file");
+    });
+  });
+
   describe("merge mode warnings", () => {
     test("warns when mergeStrategy is set with direct merge mode", async () => {
       writeFileSync(

--- a/test/unit/cli/sync-command.test.ts
+++ b/test/unit/cli/sync-command.test.ts
@@ -8,7 +8,7 @@ import {
 } from "node:test";
 import { strict as assert } from "node:assert";
 type MockFn = Mock<(...args: unknown[]) => unknown>;
-import { writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, rmSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { runSync, type SyncOptions } from "../../../src/cli/sync-command.js";
@@ -33,8 +33,8 @@ import {
   creatingLifecycleManager,
 } from "../../mocks/index.js";
 
-const testDir = join(tmpdir(), "test-sync-cmd-tmp");
-const testConfigPath = join(testDir, "test-config.yaml");
+let testDir: string;
+let testConfigPath: string;
 
 // Minimal files section to satisfy validation
 const MINIMAL_FILES = `files:
@@ -66,10 +66,8 @@ describe("sync-command", () => {
   let consoleOutput: string[];
 
   beforeEach(() => {
-    if (existsSync(testDir)) {
-      rmSync(testDir, { recursive: true, force: true });
-    }
-    mkdirSync(testDir, { recursive: true });
+    testDir = mkdtempSync(join(tmpdir(), "test-sync-cmd-"));
+    testConfigPath = join(testDir, "test-config.yaml");
 
     originalExit = process.exit;
     exitCode = undefined;
@@ -94,9 +92,7 @@ describe("sync-command", () => {
     console.log = originalConsoleLog;
     console.error = originalConsoleError;
 
-    if (existsSync(testDir)) {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    rmSync(testDir, { recursive: true, force: true });
   });
 
   describe("lifecycle integration", () => {
@@ -1451,6 +1447,39 @@ repos:
         branchName: string;
       };
       assert.equal(optionsRepo2.branchName, "chore/repo-two-sync");
+    });
+
+    test("CLI --merge preserves config prOptions.branch when --branch not set", async () => {
+      writeFileSync(
+        testConfigPath,
+        `id: test-config
+${MINIMAL_FILES}
+prOptions:
+  branch: chore/config-branch
+repos:
+  - git: https://github.com/test/repo
+`
+      );
+
+      const mockProcessor = createMockProcessor();
+
+      await runSync(
+        {
+          config: testConfigPath,
+          dryRun: true,
+          workDir: testDir,
+          merge: "direct" as const,
+        },
+        {
+          processorFactory: () => mockProcessor,
+          lifecycleManager: noopLifecycleManager,
+        }
+      );
+
+      const processMock = mockProcessor.process as MockFn;
+      const callArgs = processMock.mock.calls[0].arguments;
+      const options = callArgs[2] as { branchName: string };
+      assert.equal(options.branchName, "chore/config-branch");
     });
   });
 

--- a/test/unit/config/normalizer.test.ts
+++ b/test/unit/config/normalizer.test.ts
@@ -3323,6 +3323,92 @@ describe("group configuration", () => {
     assert.deepStrictEqual(result.repos[0].prOptions?.labels, ["from-group"]);
   });
 
+  test("global prOptions.branch propagates to repo", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      prOptions: { branch: "chore/global-sync" },
+      repos: [{ git: "git@github.com:org/repo.git" }],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/global-sync");
+  });
+
+  test("per-repo prOptions.branch overrides global", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      prOptions: { branch: "chore/global-sync" },
+      repos: [
+        {
+          git: "git@github.com:org/repo.git",
+          prOptions: { branch: "chore/repo-specific" },
+        },
+      ],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/repo-specific");
+  });
+
+  test("group prOptions.branch merges into chain", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      groups: {
+        mygroup: {
+          prOptions: { branch: "chore/group-sync" },
+        },
+      },
+      repos: [{ git: "git@github.com:org/repo.git", groups: ["mygroup"] }],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/group-sync");
+  });
+
+  test("per-repo prOptions.branch overrides group prOptions.branch", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      groups: {
+        mygroup: {
+          prOptions: { branch: "chore/group-sync" },
+        },
+      },
+      repos: [
+        {
+          git: "git@github.com:org/repo.git",
+          groups: ["mygroup"],
+          prOptions: { branch: "chore/repo-override" },
+        },
+      ],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/repo-override");
+  });
+
+  test("global prOptions.branch merges with per-repo other prOptions fields", () => {
+    const raw: RawConfig = {
+      id: "test",
+      files: { "f.json": { content: {} } },
+      prOptions: { branch: "chore/global-sync", merge: "auto" },
+      repos: [
+        {
+          git: "git@github.com:org/repo.git",
+          prOptions: { labels: ["config"] },
+        },
+      ],
+    };
+
+    const result = normalizeConfig(raw, process.env);
+    assert.equal(result.repos[0].prOptions?.branch, "chore/global-sync");
+    assert.equal(result.repos[0].prOptions?.merge, "auto");
+    assert.deepStrictEqual(result.repos[0].prOptions?.labels, ["config"]);
+  });
+
   test("group with no files is skipped in mergeGroupFiles", () => {
     const raw: RawConfig = {
       id: "test-config",

--- a/test/unit/config/validator.test.ts
+++ b/test/unit/config/validator.test.ts
@@ -4508,6 +4508,93 @@ describe("labels validation", () => {
       );
     });
   });
+
+  describe("prOptions.branch validation", () => {
+    const createValidConfig = (overrides?: Partial<RawConfig>): RawConfig => ({
+      id: "test-config",
+      files: { "config.json": { content: { key: "value" } } },
+      repos: [{ git: "git@github.com:org/repo.git" }],
+      ...overrides,
+    });
+
+    test("accepts valid branch name in global prOptions", () => {
+      const config = createValidConfig({
+        prOptions: { branch: "chore/custom-sync" },
+      });
+      assert.doesNotThrow(() => validateRawConfig(config));
+    });
+
+    test("rejects invalid branch name in global prOptions", () => {
+      const config = createValidConfig({
+        prOptions: { branch: ".invalid-branch" },
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /Branch name cannot start with/
+      );
+    });
+
+    test("rejects empty branch name in global prOptions", () => {
+      const config = createValidConfig({
+        prOptions: { branch: "" },
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /Branch name cannot be empty/
+      );
+    });
+
+    test("rejects invalid branch name in per-repo prOptions", () => {
+      const config = createValidConfig({
+        repos: [
+          {
+            git: "git@github.com:org/repo.git",
+            prOptions: { branch: "branch with spaces" },
+          },
+        ],
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /Branch name contains invalid characters/
+      );
+    });
+
+    test("rejects invalid branch name in group prOptions", () => {
+      const config = createValidConfig({
+        files: { "f.json": { content: {} } },
+        groups: {
+          mygroup: {
+            prOptions: { branch: "branch.lock" },
+          },
+        },
+        repos: [{ git: "git@github.com:org/repo.git", groups: ["mygroup"] }],
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /Branch name has invalid ending/
+      );
+    });
+
+    test("rejects invalid branch name in conditional group prOptions", () => {
+      const config = createValidConfig({
+        files: { "f.json": { content: {} } },
+        groups: {
+          "group-a": { files: { "f.json": { content: {} } } },
+        },
+        conditionalGroups: [
+          {
+            when: { allOf: ["group-a"] },
+            prOptions: { branch: "..bad" },
+          },
+        ],
+        repos: [{ git: "git@github.com:org/repo.git", groups: ["group-a"] }],
+      });
+      assert.throws(
+        () => validateRawConfig(config),
+        /Branch name cannot start with/
+      );
+    });
+  });
 });
 
 describe("group validation - extended coverage", () => {

--- a/test/unit/shared/branch-validation.test.ts
+++ b/test/unit/shared/branch-validation.test.ts
@@ -47,6 +47,25 @@ describe("shared/branch-validation", () => {
     );
   });
 
+  test("rejects branch with forbidden characters", () => {
+    const forbidden = [
+      "feat~1",
+      "feat^2",
+      "feat:name",
+      "feat?name",
+      "feat*name",
+      "feat[0]",
+      "feat\\name",
+    ];
+    for (const name of forbidden) {
+      assert.throws(
+        () => validateBranchName(name),
+        (err: unknown) => err instanceof ValidationError,
+        `Expected "${name}" to be rejected`
+      );
+    }
+  });
+
   test("rejects branch ending with .lock", () => {
     assert.throws(
       () => validateBranchName("branch.lock"),

--- a/test/unit/shared/branch-validation.test.ts
+++ b/test/unit/shared/branch-validation.test.ts
@@ -1,0 +1,77 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { validateBranchName } from "../../../src/shared/branch-validation.js";
+import { ValidationError } from "../../../src/shared/errors.js";
+
+describe("shared/branch-validation", () => {
+  test("accepts valid branch name", () => {
+    assert.doesNotThrow(() => validateBranchName("feature/my-branch"));
+  });
+
+  test("accepts branch with slashes and dashes", () => {
+    assert.doesNotThrow(() => validateBranchName("chore/sync-config"));
+  });
+
+  test("rejects empty string", () => {
+    assert.throws(
+      () => validateBranchName(""),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects whitespace-only", () => {
+    assert.throws(
+      () => validateBranchName("   "),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch starting with dot", () => {
+    assert.throws(
+      () => validateBranchName(".hidden"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch starting with dash", () => {
+    assert.throws(
+      () => validateBranchName("-invalid"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch with spaces", () => {
+    assert.throws(
+      () => validateBranchName("my branch"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch ending with .lock", () => {
+    assert.throws(
+      () => validateBranchName("branch.lock"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch ending with dot", () => {
+    assert.throws(
+      () => validateBranchName("branch."),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch with consecutive dots", () => {
+    assert.throws(
+      () => validateBranchName("feature..name"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+
+  test("rejects branch ending with slash", () => {
+    assert.throws(
+      () => validateBranchName("feature/"),
+      (err: unknown) => err instanceof ValidationError
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `prOptions.branch` config field to set custom PR branch names at global, group, and per-repo levels
- Move `validateBranchName` to `src/shared/branch-validation.ts` so both CLI and config validation can use it
- Wire branch resolution in `repo-sync-runner.ts` with precedence: CLI `--branch` > per-repo config > group config > global config > auto-generated

## Changes

- **Type**: `branch?: string` added to `PRMergeOptions` interface and JSON schema
- **Validation**: Branch name validated at all config layers (global, repo, group, conditional group)
- **Resolution**: Per-repo `prOptions.branch` overrides the auto-generated branch name; CLI `--branch` overrides everything
- **Tests**: 15 new unit tests + 2 integration tests covering all merge/override scenarios
- **Docs**: Updated `docs/configuration/pr-options.md` and `docs/reference/config-schema.md`

## Test Plan

- [x] `npm test` — 2920 tests pass
- [x] `npm run test:typecheck` — clean
- [x] `./lint.sh` — clean (lychee 503 on external badge URL is pre-existing)
- [ ] `npm run test:integration:github` — 2 new integration tests (CI only)

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)